### PR TITLE
ci(tag): use `GH_PAT` over service account token

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -11,9 +11,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: write
-
 jobs:
   version:
     runs-on: ubuntu-latest
@@ -25,6 +22,10 @@ jobs:
     - name: Fetch all tags
       shell: bash
       run: git fetch --force --tags
+
+    - name: Login to GitHub
+      shell: bash
+      run: git remote set-url origin https://x-access-token:${{ secrets.GH_PAT }}@github.com/${{ github.repository }}
 
     - name: Generate next stable version
       shell: bash


### PR DESCRIPTION
It is not possible for the service account to trigger actions.
As a result, we use the `unikraft-bot` user account to make
triggering the release possible via the tag.

Signed-off-by: Alexander Jung <alex@unikraft.com>
