### PR TITLE
ci: Handle releases via `workflow_run`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,11 @@
 name: release
 
 on:
+  workflow_run:
+    workflows:
+    - tag
+    types:
+    - completed
   push:
     tags:
     - 'v*'
@@ -17,6 +22,9 @@ concurrency:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     steps:
     - uses: actions/checkout@v4
       with:
@@ -28,7 +36,15 @@ jobs:
     - name: Generate GoReleaser config (staging)
       shell: bash
       run: |
-        if [[ "${GITHUB_REF#refs/tags/v}" == *"staging"* ]]; then
+        if [ "${{ github.event_name }}" == "push" ]; then
+          TAG="${GITHUB_REF##refs/tags/}"
+        else
+          # Fallback: extract latest semver tag from remote
+          git fetch --force --tags
+          TAG=$(make --no-print-directories last-version)
+        fi
+
+        if [[ "${TAG}" == *"staging"* ]]; then
           YTT_PRERELEASE=true
           YTT_DEB_EPOCH=1
           YTT_DEB_PRERELEASE=$(echo "${GITHUB_REF}" | awk -F'staging\\.' '{print $2}')

--- a/Makefile
+++ b/Makefile
@@ -134,8 +134,8 @@ next-staging: ## Show the next staging version of the CLI.
 	fi; \
 	echo $$NEXT
 
-.PHONY: last-version
-last-version: ## Show the last version of the CLI.
+.PHONY: last-stable
+last-stable: ## Show the last stable version of the CLI.
 	$(Q)$(GIT) describe --tags --match 'v[0-9]*.[0-9]*.[0-9]*' --exclude='*-*' --abbrev=0 | awk -F. -v OFS=. '{$NF += 1 ; print}'
 
 .PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -111,8 +111,8 @@ cicheck: ## Run CI checks.
 tidy: ## Tidy Go modules.
 	$(Q)$(GO) mod tidy
 
-.PHONY: curr-version
-curr-version: ## Show the current version of the CLI.
+.PHONY: hash-version
+hash-version: ## Show the version of the CLI based on repo state.
 	$(Q)echo "$(VERSION)"
 
 .PHONY: next-stable

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,10 @@ tidy: ## Tidy Go modules.
 hash-version: ## Show the version of the CLI based on repo state.
 	$(Q)echo "$(VERSION)"
 
+.PHONY: last-version
+last-version: ## Show the last version of the CLI.
+	$(Q)$(SVU) current
+
 .PHONY: next-stable
 next-stable: PRERELEASE ?=
 next-stable: ## Show the next stable version of the CLI.


### PR DESCRIPTION
- **build: Rename target from `curr-version` to `hash-version`**
- **build: Add a target which shows actual last tagged version**
- **build: Rename target from `last-version` to `last-stable`**
- **ci(release): Also trigger pipeline on workflow_run**
