### PR TITLE
feat: Add images command

### DIFF
--- a/cmd/unikraft/testdata/TestGolden/help
+++ b/cmd/unikraft/testdata/TestGolden/help
@@ -24,6 +24,8 @@ stdout:
 	          Manage Unikraft Cloud services.
 	  certificates, certificate
 	          Manage Unikraft Cloud certificates.
+	  images, image
+	          Manage Unikraft Cloud images.
 
 	Global flags:
 	  -h, --help

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/charmbracelet/x/ansi v0.11.3
 	github.com/containerd/containerd/v2 v2.2.1
 	github.com/cpuguy83/go-md2man/v2 v2.0.7
+	github.com/distribution/reference v0.6.0
 	github.com/docker/go-units v0.5.0
 	github.com/ettle/strcase v0.2.0
 	github.com/google/uuid v1.6.0
@@ -19,6 +20,7 @@ require (
 	github.com/lunixbochs/vtclean v1.0.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/muesli/termenv v0.16.0
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/sergi/go-diff v1.4.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dblohm7/wingoes v0.0.0-20240119213807-a09d6be7affa h1:h8TfIT1xc8FWbwwpmHn1J5i43Y0uZP97GqasGCzSRJk=
 github.com/dblohm7/wingoes v0.0.0-20240119213807-a09d6be7affa/go.mod h1:Nx87SkVqTKd8UtT+xu7sM/l+LgXs6c0aHrlKusR+2EQ=
+github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
+github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/ettle/strcase v0.2.0 h1:fGNiVF21fHXpX1niBgk0aROov1LagYsOwV/xqKDKR/Q=
@@ -110,6 +112,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/distribution/reference"
+	"github.com/opencontainers/go-digest"
+	"unikraft.com/cloud/sdk/platform"
+	"unikraft.com/x/log"
+
+	"unikraft.com/cli/internal/config"
+	"unikraft.com/cli/internal/mirror"
+	"unikraft.com/cli/internal/multimetro"
+	"unikraft.com/cli/internal/resource"
+	xslices "unikraft.com/cli/internal/x/slices"
+)
+
+type ImagesCmd struct {
+	resource.ResourceCmd[Image] `set:"name=image" set:"names=images"`
+}
+
+type Image struct {
+	MetroName string `mirror:"metro.name" field:"metro,short"`
+
+	Ref    ImageRef[reference.NamedTagged]   `field:",short"`
+	Refs   []ImageRef[reference.NamedTagged] `field:",long"`
+	Digest digest.Digest                     `field:",short"`
+
+	Namespace string
+	Dangling  bool `field:",long"`
+
+	Image platform.Image `field:"-" json:"image"`
+	Metro *config.Metro  `field:"-" json:"metro"`
+}
+
+func (Image) Type() resource.Type {
+	return resource.Type{
+		Name:  "image",
+		Names: "images",
+	}
+}
+
+func (i Image) key() multimetro.Key {
+	return multimetro.Key{
+		Metro: i.Metro.Name,
+		Name:  i.Ref.String(),
+	}
+}
+
+func (i Image) Key() string {
+	return i.key().String()
+}
+
+func (i Image) Raw() any {
+	return i.Image
+}
+
+func (i Image) Fields() ([]resource.Field, error) {
+	result, err := resource.FieldsFromStruct(i)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func (Image) List(ctx context.Context) ([]resource.Resource, error) {
+	cl, err := multimetro.NewClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resources, err := multimetro.DoAll(ctx, cl, func(ctx context.Context, mc *multimetro.MetroClient) ([]resource.Resource, error) {
+		log.G(ctx).Trace().Msg("listing images")
+		resp, err := mc.GetImages(ctx, platform.TagOrDigest{}, "")
+		if err != nil {
+			return nil, err
+		}
+		var results []resource.Resource
+		for _, image := range resp.Data.Images {
+			result, err := Image{}.load(image, &mc.Metro, false)
+			if err != nil {
+				return nil, err
+			}
+			for _, result := range result {
+				results = append(results, result)
+			}
+		}
+		return results, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return xslices.Flatten(resources), nil
+}
+
+func (Image) Get(ctx context.Context, keys []string) ([]resource.Resource, error) {
+	cl, err := multimetro.NewClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	resources, err := multimetro.DoKeys(ctx, cl, multimetro.ParseKeys(keys), func(ctx context.Context, mc *multimetro.MetroClient, keys multimetro.Keys) ([]resource.Resource, []multimetro.Key, error) {
+		log.G(ctx).Trace().Msg("getting images")
+		resp, err := mc.GetImages(ctx, platform.TagOrDigest{}, "")
+		if err != nil && !platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
+			return nil, nil, err
+		}
+		var found []multimetro.Key
+		var results []resource.Resource
+		for _, image := range resp.Data.Images {
+			result, err := Image{}.load(image, &mc.Metro, true)
+			if err != nil {
+				return nil, nil, err
+			}
+			for _, key := range keys {
+				for _, result := range result {
+					if result.matches(key.Name) {
+						found = append(found, key)
+						results = append(results, result)
+						break
+					}
+				}
+			}
+		}
+		return results, found, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resources, nil
+}
+
+func (i Image) matches(target string) bool {
+	named, err := reference.ParseNormalizedNamed(target)
+	if err != nil {
+		return false
+	}
+	named = reference.TagNameOnly(named)
+
+	ref := i.Ref.Reference
+	if named.Name() != ref.Name() {
+		return false
+	}
+	if i.Dangling {
+		if _, ok := named.(reference.Digested); !ok {
+			return false
+		}
+	}
+
+	if digestRef, ok := named.(reference.Digested); ok {
+		if i.Digest != digestRef.Digest() {
+			return false
+		}
+	} else if tagged, ok := named.(reference.Tagged); ok {
+		if ref.Tag() != tagged.Tag() {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (Image) load(image platform.Image, metro *config.Metro, allowDangling bool) ([]Image, error) {
+	if image.Digest == nil {
+		return nil, fmt.Errorf("image has no digest")
+	}
+	base, err := reference.ParseNormalizedNamed(*image.Digest)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse image ref %q: %w", *image.Digest, err)
+	}
+	baseDigested, ok := base.(reference.Digested)
+	if !ok {
+		return nil, fmt.Errorf("image ref %q is not digested", *image.Digest)
+	}
+	base = reference.TrimNamed(base)
+
+	if len(image.Tags) == 0 && allowDangling {
+		// Allow for dangling images (images with no tags)
+		ref, err := reference.WithTag(base, "latest")
+		if err != nil {
+			return nil, fmt.Errorf("could not create dangling image tag: %w", err)
+		}
+
+		result := Image{
+			Image: image,
+			Metro: metro,
+		}
+		err = mirror.Mirror(result, &result)
+		if err != nil {
+			return nil, fmt.Errorf("could not mirror image data: %w", err)
+		}
+
+		result.Dangling = true
+		result.Digest = baseDigested.Digest()
+		result.Ref.Reference = ref
+		if ns, _, ok := strings.Cut(reference.Path(ref), "/"); ok {
+			result.Namespace = ns
+		}
+		return []Image{result}, nil
+	}
+
+	tagged := make([]reference.NamedTagged, 0, len(image.Tags))
+	for _, tag := range image.Tags {
+		_, tag, ok := strings.Cut(tag, ":")
+		if !ok {
+			return nil, fmt.Errorf("could not parse image tag %q", tag)
+		}
+
+		ref, err := reference.WithTag(base, tag)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse image tag %q: %w", tag, err)
+		}
+		tagged = append(tagged, ref)
+	}
+
+	// move latest to front if present
+	idx := slices.IndexFunc(tagged, func(t reference.NamedTagged) bool {
+		return t.Tag() == "latest"
+	})
+	if idx > 0 {
+		latest := tagged[idx]
+		tagged = append(tagged[:idx], tagged[idx+1:]...)
+		tagged = append([]reference.NamedTagged{latest}, tagged...)
+	}
+
+	results := make([]Image, 0, len(image.Tags))
+	for _, tag := range tagged {
+		result := Image{
+			Image: image,
+			Metro: metro,
+		}
+		err := mirror.Mirror(result, &result)
+		if err != nil {
+			return nil, fmt.Errorf("could not mirror image data: %w", err)
+		}
+
+		result.Ref.Reference = tag
+		if ns, _, ok := strings.Cut(reference.Path(tag), "/"); ok {
+			result.Namespace = ns
+		}
+		for _, t := range tagged {
+			result.Refs = append(result.Refs, ImageRef[reference.NamedTagged]{
+				Reference: t,
+			})
+		}
+		result.Digest = baseDigested.Digest()
+
+		results = append(results, result)
+	}
+
+	return results, nil
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -39,6 +39,7 @@ type UnikraftCLI struct {
 	Volumes      VolumesCmd      `cmd:"" help:"Manage Unikraft Cloud volumes." aliases:"volume,volumes"`
 	Services     ServicesCmd     `cmd:"" help:"Manage Unikraft Cloud services." aliases:"service,services"`
 	Certificates CertificatesCmd `cmd:"" help:"Manage Unikraft Cloud certificates." aliases:"certificate,certificates"`
+	Images       ImagesCmd       `cmd:"" help:"Manage Unikraft Cloud images." aliases:"image,images"`
 }
 
 func NewRootCmd(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) (*kong.Context, *UnikraftCLI, func() error, error) {

--- a/internal/cmd/types.go
+++ b/internal/cmd/types.go
@@ -8,6 +8,7 @@ package cmd
 import (
 	"time"
 
+	"github.com/distribution/reference"
 	"github.com/docker/go-units"
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/x/colors"
@@ -32,6 +33,14 @@ type SizeMB int64
 
 func (s SizeMB) String() string {
 	return units.HumanSize(units.MB * float64(s))
+}
+
+type ImageRef[T reference.Reference] struct {
+	Reference T
+}
+
+func (ir ImageRef[T]) String() string {
+	return reference.FamiliarString(ir.Reference)
 }
 
 // InstanceState is a wrapper around platform.InstanceState to automatically

--- a/internal/mirror/mirror.go
+++ b/internal/mirror/mirror.go
@@ -112,7 +112,7 @@ func mirrorSlice(source gjson.Result, destVal reflect.Value) error {
 		return nil
 	}
 	if !source.IsArray() {
-		return fmt.Errorf("expected JSON array for slice, got: %s", source.Raw)
+		return nil
 	}
 	array := source.Array()
 

--- a/internal/multimetro/key.go
+++ b/internal/multimetro/key.go
@@ -20,7 +20,7 @@ type Key struct {
 }
 
 func ParseKey(s string) Key {
-	if metro, key, ok := strings.Cut(s, "/"); ok {
+	if metro, key, ok := strings.Cut(s, "#"); ok {
 		if uuid.Validate(key) == nil {
 			return Key{Metro: metro, UUID: key}
 		}
@@ -43,7 +43,7 @@ func (k Key) NameOrUUID() platform.NameOrUUID {
 func (k Key) String() string {
 	s := ""
 	if k.Metro != "" {
-		s += k.Metro + "/"
+		s += k.Metro + "#"
 	}
 	if k.UUID != "" {
 		s += k.UUID

--- a/internal/multimetro/key.go
+++ b/internal/multimetro/key.go
@@ -19,8 +19,10 @@ type Key struct {
 	UUID string
 }
 
+const MetroKeySeparator = "#"
+
 func ParseKey(s string) Key {
-	if metro, key, ok := strings.Cut(s, "#"); ok {
+	if metro, key, ok := strings.Cut(s, MetroKeySeparator); ok {
 		if uuid.Validate(key) == nil {
 			return Key{Metro: metro, UUID: key}
 		}
@@ -43,7 +45,7 @@ func (k Key) NameOrUUID() platform.NameOrUUID {
 func (k Key) String() string {
 	s := ""
 	if k.Metro != "" {
-		s += k.Metro + "#"
+		s += k.Metro + MetroKeySeparator
 	}
 	if k.UUID != "" {
 		s += k.UUID


### PR DESCRIPTION
Allow `unikraft images`.

This also includes a breaking change - to do metro-specific requets, instead of saying `<metro>/<name-or-uuid>`, you now have to say `<metro>#<name-or-uuid>`. This is because image names can be full docker images :shrug: This wasn't a super used feature, it's mostly only used so you can be super specific anyways, or do cool things like `unikraft instance delete $(unikraft instance ls --filter "<my-filter>")`, and have it get all the fully resolved keys.

At some point we should just print `index.<metro-endpoint>/<image>`, and have that operate as the full key. But this just doesn't work right now - there's still so much confusion over where an image will end up.