### PR TITLE
ci(release): Set `go-version-file`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,8 @@ jobs:
 
     - name: Set up Go
       uses: actions/setup-go@v6
+      with:
+        go-version-file: go.mod
 
     - name: Set Go variables
       id: goenv


### PR DESCRIPTION
The release has been silently failing because the setup-go step
has been using the host environment's pre-installed Go where
we need one compatible with this project.  This fix ensures that
the correct one is installed for the release.

Signed-off-by: Alexander Jung <alex@unikraft.com>
