### PR TITLE
test: Add better golden tests and run them in CI

### DIFF
--- a/.github/workflows/check-static.yaml
+++ b/.github/workflows/check-static.yaml
@@ -1,6 +1,8 @@
 name: check/static
 
 on:
+  push:
+    branches: [prod-staging, prod-stable]
   pull_request:
     branches:
     - staging

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,69 @@
+name: test
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [prod-staging, prod-stable]
+  pull_request:
+    branches: [staging]
+    paths:
+      - '**'
+      - '!.github/**'
+      - .github/workflows/run-tests.yaml
+
+# Automatically cancel in-progress actions on the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  go:
+    runs-on: ubuntu-latest
+    env:
+      TASK_X_REMOTE_TASKFILES: 1
+    steps:
+      - uses: actions/checkout@v5
+      - uses: go-task/setup-task@v1
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Set Go variables
+        id: goenv
+        run: |
+          {
+            echo "cache=$(go env GOCACHE)"
+            echo "modcache=$(go env GOMODCACHE)"
+            echo "mod=$(go env GOMOD)"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Go caches
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.goenv.outputs.cache }}
+            ${{ steps.goenv.outputs.modcache }}
+          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles(steps.goenv.outputs.mod) }}
+          restore-keys: |
+            ${{ github.job }}-${{ runner.os }}-go-
+
+      - name: Run unit tests
+        shell: bash
+        run: |
+          task --yes go:test
+
+      - name: Run integration tests (without auth)
+        shell: bash
+        run: |
+          task --yes integration
+
+      # TODO: re-enable when we have access to internal metros
+      # - name: Run integration tests (with auth)
+      #   if: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
+      #   shell: bash
+      #   run: |
+      #     task --yes integration
+      #   env:
+      #     UKC_TOKEN: ${{ secrets.UKC_TOKEN }}
+      #     UKC_METRO: ${{ secrets.UKC_METRO }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,8 @@
 version: "2"
 run:
   issues-exit-code: 2
+  build-tags:
+    - integration
 linters:
   default: none
   enable:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,3 +19,18 @@ tasks:
     - task: go:build
       vars:
         package: ./cmd/unikraft
+
+  unit:
+    cmds:
+    - task: go:test
+
+  integration:
+    cmds:
+    - task: go:test
+      vars:
+        go_tags: "integration"
+        package: ./cmd/unikraft
+
+  integration-update:
+    cmd: >-
+      go test -v ./cmd/unikraft -tags integration --update

--- a/cmd/unikraft/main.go
+++ b/cmd/unikraft/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -89,7 +90,7 @@ func getMethod(value reflect.Value, name string) reflect.Value {
 }
 
 func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) (context.Context, error) {
-	cli, opts, err := cmd.NewRootCmd(ctx, args, stdin, stdout, stderr)
+	cli, opts, cleanup, err := cmd.NewRootCmd(ctx, args, stdin, stdout, stderr)
 	if err != nil {
 		return ctx, err
 	}
@@ -113,5 +114,9 @@ func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.
 		}
 	}
 
-	return opts.Context, cli.RunNode(node, &opts.Config)
+	err = cli.RunNode(node, &opts.Config)
+	if cleanup != nil {
+		err = errors.Join(err, cleanup())
+	}
+	return opts.Context, err
 }

--- a/cmd/unikraft/main_test.go
+++ b/cmd/unikraft/main_test.go
@@ -3,16 +3,22 @@
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
 
+//go:build integration
+
 package main
 
 import (
 	"bytes"
+	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -20,85 +26,185 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/v3/golden"
-	"mvdan.cc/sh/v3/syntax"
+	"mvdan.cc/sh/v3/shell"
+
+	"unikraft.com/x/log"
+
+	"unikraft.com/cli/internal/cmd"
+	"unikraft.com/cli/internal/config"
+	"unikraft.com/cli/internal/resource"
 )
 
 const unikraftCmd = "unikraft"
 
 type testCase struct {
 	name     string
-	commands [][]string
+	commands []command
+	online   bool
+}
+
+type command struct {
+	args     []string
+	allowErr bool
 	token    bool
 }
 
 var testCases = []testCase{
 	{
 		name:     "empty",
-		commands: [][]string{{unikraftCmd}},
+		commands: []command{{args: []string{unikraftCmd}, allowErr: true}},
 	},
 	{
 		name:     "help",
-		commands: [][]string{{unikraftCmd, "--help"}},
+		commands: []command{{args: []string{unikraftCmd, "--help"}}},
 	},
 	{
 		name:     "version",
-		commands: [][]string{{unikraftCmd, "--version"}},
+		commands: []command{{args: []string{unikraftCmd, "--version"}}},
 	},
+
 	{
-		name: "auth",
-		commands: [][]string{
-			{unikraftCmd, "login"},
-			{unikraftCmd, "logout"},
+		name:   "auth",
+		online: true,
+		commands: []command{
+			{args: []string{unikraftCmd, "login"}, token: true},
+			{args: []string{unikraftCmd, "profile", "list"}},
+			{args: []string{unikraftCmd, "metro", "list"}},
+			{args: []string{unikraftCmd, "logout"}},
 		},
-		token: true,
+	},
+
+	{
+		name:   "volumes",
+		online: true,
+		commands: []command{
+			{args: []string{unikraftCmd, "login"}, token: true},
+			{args: []string{unikraftCmd, "volume", "list"}},
+			{args: []string{unikraftCmd, "volume", "create", "--set", "name=test-$UNIQ_VOLUME", "--set", "size=10", "--set", "metro=" + defaultMetro}},
+			{args: []string{unikraftCmd, "volume", "list"}},
+			{args: []string{unikraftCmd, "volume", "inspect", "test-$UNIQ_VOLUME"}},
+			{args: []string{unikraftCmd, "volume", "edit", "test-$UNIQ_VOLUME", "--set", "size=20"}},
+			{args: []string{unikraftCmd, "volume", "list"}},
+			{args: []string{unikraftCmd, "volume", "inspect", "test-$UNIQ_VOLUME"}},
+			{args: []string{unikraftCmd, "volume", "delete", "test-$UNIQ_VOLUME"}},
+		},
 	},
 }
 
-func TestGolden(t *testing.T) {
-	ctx := t.Context()
+var (
+	token  string
+	metros []string
+)
 
+const (
+	defaultMetro = "test"
+)
+
+func init() {
+	if v, ok := os.LookupEnv("UKC_TOKEN"); ok {
+		token = v
+		os.Unsetenv("UKC_TOKEN")
+	}
+
+	if v, ok := os.LookupEnv("UKC_METROS"); ok {
+		metros = strings.Split(v, ",")
+		os.Unsetenv("UKC_METROS")
+	} else if v, ok := os.LookupEnv("UKC_METRO"); ok {
+		metros = []string{v}
+		os.Unsetenv("UKC_METRO")
+	}
+}
+
+func TestGolden(t *testing.T) {
+	t.Parallel()
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.NotEmpty(t, tc.commands, "no commands specified")
+			t.Parallel()
 
-			if tc.token && os.Getenv("UKC_TOKEN") == "" {
-				t.Skip("skipping test that requires UKC_TOKEN")
+			if tc.online && token == "" {
+				t.Skip("skipping online test that requires UKC_TOKEN")
+			}
+			if tc.online && len(metros) == 0 {
+				t.Skip("skipping online test that requires UKC_METRO/UKC_METROS")
 			}
 
+			ctx := t.Context()
+			ctx = log.WithLogger(ctx, log.New(t.Output(), log.TextType, log.TraceLevel))
+
+			assert.NotEmpty(t, tc.commands, "no commands specified")
+
+			configdir := filepath.Join(t.TempDir(), "unikraft.d")
+			cfg, profile := defaultCfg()
+			require.NoError(t, cfg.SaveTo(configdir))
+
+			sandboxPath := filepath.Join(t.TempDir(), "sandbox.json")
+			t.Cleanup(func() {
+				cfg, err := config.LoadFrom(configdir)
+				require.NoError(t, err)
+				ctx := config.WithConfig(ctx, cfg)
+
+				sandbox, err := resource.LoadSandbox(sandboxPath, cmd.SandboxedResources...)
+				require.NoError(t, err)
+				require.NotNil(t, sandbox)
+
+				require.NoError(t, sandbox.Teardown(context.WithoutCancel(ctx)))
+			})
+
+			expander := &expander{}
 			output := strings.Builder{}
 			for i, command := range tc.commands {
-				require.NotEmpty(t, command, "no command specified")
+				require.NotEmpty(t, command.args, "no command specified")
 				var args []string
-				if command[0] == unikraftCmd {
+				if command.args[0] == unikraftCmd {
 					args = append(args, "go", "run", ".")
-					args = append(args, command[1:]...)
+					args = append(args, command.args[1:]...)
 				} else {
 					assert.Fail(t, "first argument must be %q", unikraftCmd)
-					args = command
+					args = command.args
 				}
+				args = expander.expandArgs(args)
+
+				log.G(ctx).Debug().
+					Strs("args", args).
+					Msg("executing command")
 
 				cmd := exec.CommandContext(ctx, args[0], args[1:]...)
 				var stdout, stderr bytes.Buffer
 				cmd.Stdout = &stdout
 				cmd.Stderr = &stderr
 				cmd.Env = os.Environ()
+				cmd.Env = slices.DeleteFunc(cmd.Env, func(s string) bool {
+					return strings.HasPrefix(s, "UNIKRAFT_")
+				})
 				cmd.Env = append(cmd.Env, "NO_COLOR=1") // color makes golden files harder to read
+				cmd.Env = append(cmd.Env, resource.UnikraftSandboxEnv+"="+sandboxPath)
+				cmd.Env = append(cmd.Env, config.UnikraftConfigDirEnv+"="+configdir)
+				if command.token {
+					cmd.Env = append(cmd.Env, "UKC_TOKEN="+token)
+				}
 
 				err := cmd.Run()
 				var exitErr *exec.ExitError
 				var exitCode int
-				if errors.As(err, &exitErr) {
+				if errors.As(err, &exitErr) && command.allowErr {
 					exitCode = exitErr.ExitCode()
 					// ignore exit errors for help commands
 					err = nil
 				}
-				assert.NoError(t, err)
+				assert.NoError(t, err, "command %q failed", strings.Join(args, " "))
 
 				report := report{
-					args:     command,
+					args:     command.args,
 					stdout:   stdout.String(),
 					stderr:   stderr.String(),
 					exitCode: exitCode,
+				}
+				report.cleaners = append(report.cleaners, expander.cleaners()...)
+				for _, metro := range profile.Metros {
+					report.cleaners = append(report.cleaners, cleaner{
+						pattern: regexp.MustCompile(regexp.QuoteMeta(metro.Endpoint)),
+						repl:    "https://api." + metro.Name + ".unikraft.internal/",
+					})
 				}
 				if i != 0 {
 					output.WriteString("\n")
@@ -116,26 +222,18 @@ type report struct {
 	stdout   string
 	stderr   string
 	exitCode int
+	cleaners []cleaner
 }
 
 func (report *report) String() string {
 	out := strings.Builder{}
 
-	args := make([]string, 0, len(report.args))
-	for _, arg := range report.args {
-		arg, err := syntax.Quote(arg, syntax.LangPOSIX)
-		if err != nil {
-			panic(err)
-		}
-		args = append(args, arg)
-	}
-
-	out.WriteString("$ " + strings.Join(args, " ") + "\n\n")
-	stdout := cleanOutput(report.stdout)
+	out.WriteString("$ " + strings.Join(report.args, " ") + "\n\n")
+	stdout := report.cleanOutput(report.stdout)
 	if len(stdout) > 0 {
 		out.WriteString("stdout:\n" + indent(stdout, "\t") + "\n\n")
 	}
-	stderr := cleanOutput(report.stderr)
+	stderr := report.cleanOutput(report.stderr)
 	if len(stderr) > 0 {
 		out.WriteString("stderr:\n" + indent(stderr, "\t") + "\n\n")
 	}
@@ -144,6 +242,24 @@ func (report *report) String() string {
 	}
 
 	return strings.TrimSpace(out.String()) + "\n"
+}
+
+func (report *report) cleanOutput(s string) string {
+	// trim leading and trailing whitespace
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return s
+	}
+
+	// apply any necessary cleanup to the output here
+	for _, c := range cleaners {
+		s = c.pattern.ReplaceAllString(s, c.repl)
+	}
+	for _, c := range report.cleaners {
+		s = c.pattern.ReplaceAllString(s, c.repl)
+	}
+
+	return s
 }
 
 func indent(s string, indent string) string {
@@ -181,27 +297,80 @@ var cleaners = []cleaner{
 		pattern: wordCleanerf("%s/%s", runtime.GOOS, runtime.GOARCH),
 		repl:    "GOOS/GOARCH",
 	},
+	{
+		// uuids like "12345678-1234-1234-1234-123456789abc" change between runs
+		pattern: regexp.MustCompile(`\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b`),
+		repl:    "12345678-1234-1234-1234-123456789abc",
+	},
 }
 
 func wordCleaner(word string) *regexp.Regexp {
-	return regexp.MustCompile(`\b` + word + `\b`)
+	return regexp.MustCompile(`\b` + regexp.QuoteMeta(word) + `\b`)
 }
 
 func wordCleanerf(word string, args ...any) *regexp.Regexp {
-	return regexp.MustCompile(`\b` + fmt.Sprintf(word, args...) + `\b`)
+	return regexp.MustCompile(`\b` + regexp.QuoteMeta(fmt.Sprintf(word, args...)) + `\b`)
 }
 
-func cleanOutput(s string) string {
-	// trim leading and trailing whitespace
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return s
-	}
+type expander struct {
+	uniq map[string]string
+}
 
-	// apply any necessary cleanup to the output here
-	for _, c := range cleaners {
-		s = c.pattern.ReplaceAllString(s, c.repl)
+func (e *expander) expandArgs(args []string) []string {
+	if e.uniq == nil {
+		e.uniq = make(map[string]string)
 	}
+	expanded := make([]string, 0, len(args))
+	for _, arg := range args {
+		arg, err := shell.Expand(arg, func(varname string) string {
+			if varname, ok := strings.CutPrefix(varname, "UNIQ_"); ok {
+				if val, ok := e.uniq[varname]; ok {
+					return val
+				}
+				result := fmt.Sprintf("%x", rand.Text())[:12]
+				e.uniq[varname] = result
+				return result
+			}
+			return ""
+		})
+		if err != nil {
+			panic(err)
+		}
+		expanded = append(expanded, arg)
+	}
+	return expanded
+}
 
-	return s
+func (e *expander) cleaners() []cleaner {
+	cleaners := make([]cleaner, 0, len(e.uniq))
+	for varname, val := range e.uniq {
+		cleaners = append(cleaners, cleaner{
+			pattern: wordCleaner(val),
+			repl:    fmt.Sprintf("<%s>", varname),
+		})
+	}
+	return cleaners
+}
+
+func defaultCfg() (*config.Config, *config.Profile) {
+	profile := &config.Profile{
+		Type:  config.ProfileTypeCloud,
+		Name:  "default",
+		Token: "", // populated via login
+	}
+	for _, metro := range metros {
+		profile.Metros = append(profile.Metros, config.Metro{
+			Name:     defaultMetro,
+			Endpoint: metro,
+			Country:  "xx",
+		})
+		break
+	}
+	cfg := &config.Config{
+		Profile: "test",
+		Profiles: map[string]config.Profile{
+			"test": *profile,
+		},
+	}
+	return cfg, profile
 }

--- a/cmd/unikraft/testdata/TestGolden/auth
+++ b/cmd/unikraft/testdata/TestGolden/auth
@@ -1,11 +1,24 @@
 $ unikraft login
 
-stdout:
-	HH:MM INF existing authentication token found, re-authenticating
+stderr:
 	HH:MM INF using authentication token from UKC_TOKEN environment variable
+	HH:MM WRN no metros configured; please add them manually
 	HH:MM INF login successful
+
+$ unikraft profile list
+
+stdout:
+	NAME     ACTIVE  METROS
+	default  true    [test]
+	default  true    [test]
+
+$ unikraft metro list
+
+stdout:
+	NAME  COUNTRY  ENDPOINT
+	test  xx       https://api.test.unikraft.internal/
 
 $ unikraft logout
 
-stdout:
+stderr:
 	HH:MM INF logout successful

--- a/cmd/unikraft/testdata/TestGolden/empty
+++ b/cmd/unikraft/testdata/TestGolden/empty
@@ -1,12 +1,10 @@
 $ unikraft
 
-stdout:
+stderr:
 	HH:MM ERR  
 	HH:MM ERR error:
-	HH:MM ERR   parsing arguments: expected one of "instances", "login", "logout"
-	HH:MM ERR
-
-stderr:
+	HH:MM ERR   parsing arguments: expected one of "login", "logout", "profile", "metros", "instances", ...
+	HH:MM ERR  
 	exit status 1
 
 exit code: 1

--- a/cmd/unikraft/testdata/TestGolden/help
+++ b/cmd/unikraft/testdata/TestGolden/help
@@ -8,32 +8,40 @@ stdout:
 	  dev (GOOS/GOARCH)
 
 	Commands:
-	  instances
-	          View and manage applications.
 	  login
 	          Login to Unikraft Cloud.
 	  logout
 	          Logout from Unikraft Cloud.
+	  profile, profiles
+	          Manage Unikraft Cloud profiles.
+	  metros, metro
+	          Manage Unikraft Cloud metros.
+	  instances, instance
+	          Manage Unikraft Cloud instances.
+	  volumes, volume
+	          Manage Unikraft Cloud volumes.
+	  services, service
+	          Manage Unikraft Cloud services.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	  -c, --config
-	          Set the configuration file ($UNIKRAFT_CONFIG).
-	      --[no-]telemetry
-	          Enable or disable telemetry ($UNIKRAFT_TELEMETRY).
+	  -c, --config ($UNIKRAFT_CONFIG)
+	          Set the configuration file.
+	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis
-	          Enable or disable emojis in the CLI output ($UNIKRAFT_EMOJIS).
+	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	          Enable or disable emojis in the CLI output.
 	          [default: true]
-	      --log-level
-	          Set the logging level ($UNIKRAFT_LOG_LEVEL).
+	      --log-level ($UNIKRAFT_LOG_LEVEL)
+	          Set the logging level.
 	          [default: info, choice: trace,debug,info,warn,error,fatal]
-	      --log-type
-	          Set the log type ($UNIKRAFT_LOG_TYPE).
+	      --log-type ($UNIKRAFT_LOG_TYPE)
+	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile
-	          Set the current profile ($UNIKRAFT_PROFILE).
+	      --profile ($UNIKRAFT_PROFILE)
+	          Set the current profile.
 	          [default: default]
 	  -v, --version
 	          Print version information.

--- a/cmd/unikraft/testdata/TestGolden/volumes
+++ b/cmd/unikraft/testdata/TestGolden/volumes
@@ -1,0 +1,74 @@
+$ unikraft login
+
+stderr:
+	HH:MM INF using authentication token from UKC_TOKEN environment variable
+	HH:MM WRN no metros configured; please add them manually
+	HH:MM INF login successful
+
+$ unikraft volume list
+
+stdout:
+	METRO  NAME  STATE  SIZE
+
+$ unikraft volume create --set name=test-$UNIQ_VOLUME --set size=10 --set metro=test
+
+stdout:
+	metro:       test
+	name:        test-<VOLUME>
+	uuid:        12345678-1234-1234-1234-123456789abc
+	state:       available
+	size:        10MB
+	persistent:  true
+	attached-to:
+	mounted-by:
+
+$ unikraft volume list
+
+stdout:
+	METRO  NAME               STATE      SIZE
+	test   test-<VOLUME>  available  10MB
+
+$ unikraft volume inspect test-$UNIQ_VOLUME
+
+stdout:
+	metro:       test
+	name:        test-<VOLUME>
+	uuid:        12345678-1234-1234-1234-123456789abc
+	state:       available
+	size:        10MB
+	persistent:  true
+	attached-to:
+	mounted-by:
+
+$ unikraft volume edit test-$UNIQ_VOLUME --set size=20
+
+stdout:
+	metro:       test
+	  name:        test-<VOLUME>
+	  uuid:        12345678-1234-1234-1234-123456789abc
+	  state:       available
+	- size:        10MB
+	+ size:        20MB
+	  persistent:  true
+	  attached-to:
+	  mounted-by:
+
+$ unikraft volume list
+
+stdout:
+	METRO  NAME               STATE      SIZE
+	test   test-<VOLUME>  available  20MB
+
+$ unikraft volume inspect test-$UNIQ_VOLUME
+
+stdout:
+	metro:       test
+	name:        test-<VOLUME>
+	uuid:        12345678-1234-1234-1234-123456789abc
+	state:       available
+	size:        20MB
+	persistent:  true
+	attached-to:
+	mounted-by:
+
+$ unikraft volume delete test-$UNIQ_VOLUME

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -8,8 +8,10 @@ package cmd
 import (
 	"context"
 	"io"
+	"maps"
 	"path/filepath"
 	"runtime"
+	"slices"
 
 	"github.com/alecthomas/kong"
 	kongyaml "github.com/alecthomas/kong-yaml"
@@ -19,6 +21,7 @@ import (
 
 	"unikraft.com/cli/internal/cmd/login"
 	"unikraft.com/cli/internal/config"
+	"unikraft.com/cli/internal/resource"
 	"unikraft.com/cli/internal/version"
 )
 
@@ -37,7 +40,7 @@ type UnikraftCLI struct {
 	Services  ServicesCmd  `cmd:"" help:"Manage Unikraft Cloud services." aliases:"service,services"`
 }
 
-func NewRootCmd(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) (*kong.Context, *UnikraftCLI, error) {
+func NewRootCmd(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) (*kong.Context, *UnikraftCLI, func() error, error) {
 	cli := UnikraftCLI{}
 
 	helpOptions := kong.HelpOptions{
@@ -87,12 +90,12 @@ func NewRootCmd(ctx context.Context, args []string, stdin io.Reader, stdout, std
 		}),
 	)
 	if err != nil {
-		return nil, &cli, jujuerrors.Annotate(err, "initializing kong context")
+		return nil, nil, nil, jujuerrors.Annotate(err, "initializing kong context")
 	}
 
 	kctx, err := parser.Parse(args)
 	if err != nil {
-		return nil, &cli, jujuerrors.Annotate(err, "parsing arguments")
+		return nil, nil, nil, jujuerrors.Annotate(err, "parsing arguments")
 	}
 
 	cli.Context = ctx
@@ -124,6 +127,27 @@ func NewRootCmd(ctx context.Context, args []string, stdin io.Reader, stdout, std
 	cli.Context = config.WithConfig(cli.Context, &cli.Config)
 	kctx.BindTo(cli.Context, (*context.Context)(nil))
 
+	sandbox, err := resource.LoadSandboxFromEnv(SandboxedResources...)
+	if err != nil {
+		return nil, nil, nil, jujuerrors.Annotate(err, "loading sandbox from environment")
+	}
+	if sandbox != nil {
+		sandboxed := slices.Collect(maps.Keys(sandbox.Keys))
+		slices.Sort(sandboxed)
+		log.G(cli.Context).Debug().
+			Str("path", sandbox.Path).
+			Strs("resources", sandboxed).
+			Msg("loaded sandbox from environment")
+	}
+	kctx.Bind(sandbox)
+
+	cleanup := func() error {
+		if err := sandbox.Save(); err != nil {
+			return jujuerrors.Annotate(err, "saving sandbox")
+		}
+		return nil
+	}
+
 	log.G(cli.Context).
 		Debug().
 		Str("version", version.Version).
@@ -133,5 +157,11 @@ func NewRootCmd(ctx context.Context, args []string, stdin io.Reader, stdout, std
 		Str("built", version.BuildTime).
 		Msg("unikraft CLI")
 
-	return kctx, &cli, nil
+	return kctx, &cli, cleanup, nil
+}
+
+var SandboxedResources = []resource.Resource{
+	Instance{},
+	ServiceGroup{},
+	Volume{},
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -44,12 +45,16 @@ type Config struct {
 
 // Save the current configuration to the configuration file.
 func (c *Config) Save() error {
-	if err := os.MkdirAll(ConfigDir(), 0o755); err != nil {
+	return c.SaveTo(ConfigDir())
+}
+
+func (c *Config) SaveTo(dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return jujuerrors.Annotate(err, "creating config directory")
 	}
 
 	// Open the existing configuration file or create a new one.
-	configFile := filepath.Join(ConfigDir(), DefaultConfigFilename)
+	configFile := filepath.Join(dir, DefaultConfigFilename)
 	f, err := os.OpenFile(configFile, os.O_RDWR|os.O_CREATE, 0o644)
 	if err != nil {
 		return jujuerrors.Annotate(err, "opening config file")
@@ -81,4 +86,23 @@ func (c *Config) Save() error {
 	encoder.SetIndent(2)
 
 	return encoder.Encode(headNode)
+}
+
+func LoadFrom(dir string) (*Config, error) {
+	configFile := filepath.Join(dir, DefaultConfigFilename)
+	f, err := os.Open(configFile)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	} else if err != nil {
+		return nil, jujuerrors.Annotate(err, "opening config file")
+	}
+	defer f.Close()
+
+	c := Config{}
+	decoder := yaml.NewDecoder(f)
+	if err := decoder.Decode(&c); err != nil {
+		return nil, jujuerrors.Annotate(err, "decoding config file")
+	}
+
+	return &c, nil
 }

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -8,71 +8,18 @@ package config
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 )
 
 const (
-	UNIKRAFT_CONFIG_DIR = "UNIKRAFT_CONFIG_DIR"
-	XDG_CONFIG_HOME     = "XDG_CONFIG_HOME"
-	XDG_STATE_HOME      = "XDG_STATE_HOME"
-	XDG_DATA_HOME       = "XDG_DATA_HOME"
-	APP_DATA            = "AppData"
-	LOCAL_APP_DATA      = "LocalAppData"
+	UnikraftConfigDirEnv = "UNIKRAFT_CONFIG_DIR"
 )
 
-// Config path precedence
-// 1. UNIKRAFT_CONFIG_DIR
-// 2. XDG_CONFIG_HOME
-// 3. AppData (windows only)
-// 4. HOME
 func ConfigDir() string {
-	var path string
-	if a := os.Getenv(UNIKRAFT_CONFIG_DIR); a != "" {
-		path = a
-	} else if b := os.Getenv(XDG_CONFIG_HOME); b != "" {
-		path = filepath.Join(b, "unikraft")
-	} else if c := os.Getenv(APP_DATA); runtime.GOOS == "windows" && c != "" {
-		path = filepath.Join(c, "unikraft")
-	} else {
-		d, _ := os.UserHomeDir()
-		path = filepath.Join(d, ".config", "unikraft")
+	if path := os.Getenv(UnikraftConfigDirEnv); path != "" {
+		return path
 	}
-
-	return path
-}
-
-// State path precedence
-// 1. XDG_STATE_HOME
-// 2. LocalAppData (windows only)
-// 3. HOME
-func StateDir() string {
-	var path string
-	if a := os.Getenv(XDG_STATE_HOME); a != "" {
-		path = filepath.Join(a, "unikraft")
-	} else if b := os.Getenv(LOCAL_APP_DATA); runtime.GOOS == "windows" && b != "" {
-		path = filepath.Join(b, "unikraft")
-	} else {
-		c, _ := os.UserHomeDir()
-		path = filepath.Join(c, ".local", "state", "unikraft")
+	if path, err := os.UserConfigDir(); err == nil {
+		return filepath.Join(path, "unikraft")
 	}
-
-	return path
-}
-
-// Data path precedence
-// 1. XDG_DATA_HOME
-// 2. LocalAppData (windows only)
-// 3. HOME
-func DataDir() string {
-	var path string
-	if a := os.Getenv(XDG_DATA_HOME); a != "" {
-		path = filepath.Join(a, "unikraft")
-	} else if b := os.Getenv(LOCAL_APP_DATA); runtime.GOOS == "windows" && b != "" {
-		path = filepath.Join(b, "unikraft")
-	} else {
-		c, _ := os.UserHomeDir()
-		path = filepath.Join(c, ".local", "share", "unikraft")
-	}
-
-	return path
+	return ""
 }

--- a/internal/kvwriter/kvwriter.go
+++ b/internal/kvwriter/kvwriter.go
@@ -108,13 +108,19 @@ func (b *keyValueWriter) flush() error {
 
 			padding := maxKeyLen - len(cleankey)
 			line := []byte{}
-			line = append(line, []byte(styleSeq.String())...)
+			if styleSeq != nil {
+				line = append(line, []byte(styleSeq.String())...)
+			}
 			line = append(line, key...)
-			line = append(line, []byte(resetSeq.String())...)
+			if styleSeq != nil {
+				line = append(line, []byte(resetSeq.String())...)
+			}
 			line = append(line, ':')
-			line = append(line, bytes.Repeat([]byte(" "), padding)...)
-			line = append(line, ' ')
-			line = append(line, value...)
+			if len(value) > 0 {
+				line = append(line, bytes.Repeat([]byte(" "), padding)...)
+				line = append(line, ' ')
+				line = append(line, value...)
+			}
 			line = append(line, '\n')
 			if _, err := b.w.Write(line); err != nil {
 				return err

--- a/internal/mirror/mirror_test.go
+++ b/internal/mirror/mirror_test.go
@@ -46,7 +46,7 @@ func TestMirror_BasicExample(t *testing.T) {
 	assert.Equal(t, "value1", dest.Field1)
 	assert.Equal(t, 42, dest.Field2)
 	assert.Equal(t, "nested_value", dest.Nested.SubField)
-	assert.Equal(t, "nested_value", dest.Nested2.SubField)
+	assert.Empty(t, dest.Nested2.SubField)
 	assert.Equal(t, []string{"item1", "item2", "item3"}, dest.Lists)
 }
 

--- a/internal/resource/cmd.go
+++ b/internal/resource/cmd.go
@@ -10,13 +10,13 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/containerd/containerd/v2/pkg/filters"
 	"github.com/lunixbochs/vtclean"
 	"github.com/sergi/go-diff/diffmatchpatch"
 
+	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/kvwriter"
 	"unikraft.com/cli/internal/prettydiff"
 )
@@ -61,14 +61,15 @@ func (cmd *ResourceListCmd[R]) Help() string {
 	return "Lister"
 }
 
-func (cmd *ResourceListCmd[R]) Run(ctx context.Context) error {
+func (cmd *ResourceListCmd[R]) Run(ctx context.Context, cfg *config.Config, sandbox *Sandbox) error {
 	filter, err := filters.ParseAll(cmd.Filter...)
 	if err != nil {
 		return err
 	}
 	ctx = WithFilter(ctx, filter)
 
-	var r R
+	var empty R
+	r := sandbox.WrapGettable(empty)
 	var resources []Resource
 	if len(cmd.Name) > 0 {
 		resources, err = r.Get(ctx, cmd.Name)
@@ -86,13 +87,13 @@ func (cmd *ResourceListCmd[R]) Run(ctx context.Context) error {
 
 	switch {
 	case cmd.Quiet:
-		return printQuiet(os.Stdout, resources...)
+		return printQuiet(cfg.Stdout, resources...)
 	case cmd.Raw:
-		return printRaw(os.Stdout, resources...)
+		return printRaw(cfg.Stdout, resources...)
 	case cmd.Format != "":
-		return printTemplate(os.Stdout, cmd.Format, resources...)
+		return printTemplate(cfg.Stdout, cmd.Format, resources...)
 	default:
-		return printTable[R](os.Stdout, cmd.Field, resources...)
+		return printTable[R](cfg.Stdout, cmd.Field, resources...)
 	}
 }
 
@@ -102,14 +103,15 @@ type ResourceInspectCmd[R GettableResource] struct {
 	FormatOpts
 }
 
-func (cmd *ResourceInspectCmd[R]) Run(ctx context.Context) error {
+func (cmd *ResourceInspectCmd[R]) Run(ctx context.Context, cfg *config.Config, sandbox *Sandbox) error {
 	filter, err := filters.ParseAll(cmd.Filter...)
 	if err != nil {
 		return err
 	}
 	ctx = WithFilter(ctx, filter)
 
-	var r R
+	var empty R
+	r := sandbox.WrapGettable(empty)
 	resources, err := r.Get(ctx, cmd.Name)
 	if err != nil {
 		return err
@@ -122,13 +124,13 @@ func (cmd *ResourceInspectCmd[R]) Run(ctx context.Context) error {
 
 	switch {
 	case cmd.Quiet:
-		return printQuiet(os.Stdout, resources...)
+		return printQuiet(cfg.Stdout, resources...)
 	case cmd.Raw:
-		return printRaw(os.Stdout, resources...)
+		return printRaw(cfg.Stdout, resources...)
 	case cmd.Format != "":
-		return printTemplate(os.Stdout, cmd.Format, resources...)
+		return printTemplate(cfg.Stdout, cmd.Format, resources...)
 	default:
-		return printInspect(os.Stdout, cmd.Field, resources...)
+		return printInspect(cfg.Stdout, cmd.Field, resources...)
 	}
 }
 
@@ -164,8 +166,9 @@ type ResourceRemoveCmd[R DeletableResource] struct {
 	Name []string `arg:"" help:"Name of the resource to remove."`
 }
 
-func (cmd *ResourceRemoveCmd[R]) Run(ctx context.Context) error {
-	var r R
+func (cmd *ResourceRemoveCmd[R]) Run(ctx context.Context, sandbox *Sandbox) error {
+	var empty R
+	r := sandbox.WrapDeletable(empty)
 	resources, err := r.Get(ctx, cmd.Name)
 	if err != nil {
 		return err
@@ -182,8 +185,9 @@ type ResourceEditCmd[R EditableResource] struct {
 	Del    map[string]string `help:"Keys to delete from the resource."`
 }
 
-func (cmd *ResourceEditCmd[R]) Run(ctx context.Context) error {
-	var r R
+func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, cfg *config.Config, sandbox *Sandbox) error {
+	var empty R
+	r := sandbox.WrapEditable(empty)
 	resources, err := r.Get(ctx, []string{cmd.Name})
 	if err != nil {
 		return err
@@ -240,7 +244,7 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context) error {
 		return err
 	}
 	if cmd.Visual {
-		patched, err = VisualEdit(fields, patched)
+		patched, err = VisualEdit(cfg, fields, patched)
 		if err != nil {
 			return err
 		}
@@ -268,7 +272,7 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context) error {
 
 	dmp := diffmatchpatch.New()
 	diffs := dmp.DiffMain(start.String(), end.String(), false)
-	tw := kvwriter.KeyValueWriter(os.Stdout, "  ")
+	tw := kvwriter.KeyValueWriter(cfg.Stdout, "  ")
 	_, err = io.Copy(tw, strings.NewReader(prettydiff.Render(diffs)))
 	if err != nil {
 		return err
@@ -281,12 +285,13 @@ type ResourceCreateCmd[R CreatableResource] struct {
 	Set    map[string]string `help:"Key-value pairs for creating the resource."`
 }
 
-func (cmd *ResourceCreateCmd[R]) Run(ctx context.Context) error {
+func (cmd *ResourceCreateCmd[R]) Run(ctx context.Context, cfg *config.Config, sandbox *Sandbox) error {
 	if cmd.Set == nil {
 		cmd.Set = make(map[string]string)
 	}
 
-	var r R
+	var empty R
+	r := sandbox.WrapCreatable(empty)
 	fields, err := r.Fields()
 	if err != nil {
 		return fmt.Errorf("failed to get fields: %w", err)
@@ -301,7 +306,7 @@ func (cmd *ResourceCreateCmd[R]) Run(ctx context.Context) error {
 
 	if cmd.Visual {
 		// FIXME: should allow required fields
-		patched, err = VisualCreate(fields, patched)
+		patched, err = VisualCreate(cfg, fields, patched)
 		if err != nil {
 			return err
 		}
@@ -313,5 +318,5 @@ func (cmd *ResourceCreateCmd[R]) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return printInspect(os.Stdout, nil, resource)
+	return printInspect(cfg.Stdout, nil, resource)
 }

--- a/internal/resource/sandbox.go
+++ b/internal/resource/sandbox.go
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package resource
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"slices"
+
+	"unikraft.com/x/log"
+)
+
+// Sandbox represents a testing sandbox for resources. Resources created in the
+// sandbox are tracked and isolated from other resources (to provide our
+// testing framework a reliable clean environment).
+//
+// Sandboxes are persisted to disk as JSON files, which track resource types
+// and keys that belong to the sandbox.
+type Sandbox struct {
+	Path    string
+	Keys    map[string]map[string]struct{}
+	Cleanup []Resource
+}
+
+const UnikraftSandboxEnv = "UNIKRAFT_X_SANDBOX"
+
+func LoadSandboxFromEnv(resources ...Resource) (*Sandbox, error) {
+	path, ok := os.LookupEnv(UnikraftSandboxEnv)
+	if !ok {
+		return nil, nil
+	}
+	sandbox, err := LoadSandbox(path, resources...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load sandbox from %s: %w", path, err)
+	}
+	return sandbox, nil
+}
+
+func LoadSandbox(path string, resources ...Resource) (*Sandbox, error) {
+	s := Sandbox{Path: path, Cleanup: resources}
+	s.Keys = make(map[string]map[string]struct{})
+	for _, r := range resources {
+		if _, ok := s.Keys[r.Type().Name]; !ok {
+			s.Keys[r.Type().Name] = make(map[string]struct{})
+		}
+	}
+
+	f, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return &s, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to open sandbox file: %w", err)
+	}
+	defer f.Close()
+
+	var keys map[string][]string
+	err = json.NewDecoder(f).Decode(&keys)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode sandbox file: %w", err)
+	}
+	for rtype, rkeys := range keys {
+		if _, ok := s.Keys[rtype]; !ok {
+			continue
+		}
+		for _, rkey := range rkeys {
+			s.Keys[rtype][rkey] = struct{}{}
+		}
+	}
+
+	return &s, nil
+}
+
+func (s *Sandbox) Save() error {
+	if s == nil {
+		return nil
+	}
+	f, err := os.Create(s.Path)
+	if err != nil {
+		return fmt.Errorf("failed to create sandbox file: %w", err)
+	}
+	defer f.Close()
+
+	keys := make(map[string][]string, len(s.Keys))
+	for rtype, rkeys := range s.Keys {
+		keys[rtype] = slices.Collect(maps.Keys(rkeys))
+	}
+
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	err = enc.Encode(keys)
+	if err != nil {
+		return fmt.Errorf("failed to encode sandbox file: %w", err)
+	}
+
+	return nil
+}
+
+// Teardown attempts to delete all resources tracked by the sandbox. Some
+// resources may not be deletable, in which case they are skipped.
+func (s *Sandbox) Teardown(ctx context.Context) (rerr error) {
+	if s == nil {
+		return nil
+	}
+	log.G(ctx).Debug().
+		Str("path", s.Path).
+		Msg("tearing down sandbox")
+	for _, r := range s.Cleanup {
+		name := r.Type().Name
+		r, ok := r.(DeletableResource)
+		if !ok {
+			log.G(ctx).Debug().
+				Str("resource", name).
+				Msg("skipping resource cleanup as it is not deletable")
+			continue
+		}
+
+		targets := slices.Collect(maps.Keys(s.Keys[name]))
+		if len(targets) == 0 {
+			log.G(ctx).Debug().
+				Str("resource", name).
+				Msg("no resources to clean up in sandbox")
+			continue
+		}
+
+		log.G(ctx).Debug().
+			Str("resource", name).
+			Strs("targets", targets).
+			Msg("cleaning up resources in sandbox")
+
+		resources, err := r.Get(ctx, targets)
+		if err != nil {
+			rerr = errors.Join(rerr, fmt.Errorf("failed to get resources for cleanup: %w", err))
+			continue
+		}
+		err = r.Delete(ctx, resources)
+		if err != nil {
+			rerr = errors.Join(rerr, fmt.Errorf("failed to delete resources for cleanup: %w", err))
+			continue
+		}
+	}
+	return rerr
+}
+
+func (s *Sandbox) Add(r Resource) {
+	if s == nil {
+		return
+	}
+	if _, ok := s.Keys[r.Type().Name]; !ok {
+		return
+	}
+	s.Keys[r.Type().Name][r.Key()] = struct{}{}
+}
+
+func (s *Sandbox) Remove(r Resource) {
+	if s == nil {
+		return
+	}
+	if _, ok := s.Keys[r.Type().Name]; !ok {
+		return
+	}
+	delete(s.Keys[r.Type().Name], r.Key())
+}
+
+func (s *Sandbox) Has(r Resource) bool {
+	if s == nil {
+		return true
+	}
+	if _, ok := s.Keys[r.Type().Name]; !ok {
+		return true
+	}
+	_, ok := s.Keys[r.Type().Name][r.Key()]
+	return ok
+}
+
+func (s *Sandbox) Missing(r Resource) bool {
+	return !s.Has(r)
+}
+
+func (s *Sandbox) WrapGettable(r GettableResource) GettableResource {
+	if s == nil {
+		return r
+	}
+	return sandboxedGettableResource{
+		GettableResource: r,
+		sandbox:          s,
+	}
+}
+
+func (s *Sandbox) WrapEditable(r EditableResource) EditableResource {
+	if s == nil {
+		return r
+	}
+	return sandboxedEditableResource{
+		EditableResource: r,
+		sandbox:          s,
+	}
+}
+
+func (s *Sandbox) WrapCreatable(r CreatableResource) CreatableResource {
+	if s == nil {
+		return r
+	}
+	return sandboxedCreatableResource{
+		CreatableResource: r,
+		sandbox:           s,
+	}
+}
+
+func (s *Sandbox) WrapDeletable(r DeletableResource) DeletableResource {
+	if s == nil {
+		return r
+	}
+	return sandboxedDeletableResource{
+		DeletableResource: r,
+		sandbox:           s,
+	}
+}
+
+type sandboxedGettableResource struct {
+	GettableResource
+	sandbox *Sandbox
+}
+
+func (r sandboxedGettableResource) Get(ctx context.Context, keys []string) ([]Resource, error) {
+	resources, err := r.GettableResource.Get(ctx, keys)
+	if err != nil {
+		return nil, err
+	}
+	resources = slices.DeleteFunc(resources, r.sandbox.Missing)
+	if len(resources) == 0 {
+		return nil, fmt.Errorf("no resources found in the sandbox")
+	}
+	return resources, nil
+}
+
+func (r sandboxedGettableResource) List(ctx context.Context) ([]Resource, error) {
+	resources, err := r.GettableResource.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	resources = slices.DeleteFunc(resources, r.sandbox.Missing)
+	return resources, nil
+}
+
+type sandboxedEditableResource struct {
+	EditableResource
+	sandbox *Sandbox
+}
+
+func (r sandboxedEditableResource) Get(ctx context.Context, keys []string) ([]Resource, error) {
+	return sandboxedGettableResource{
+		GettableResource: r.EditableResource,
+		sandbox:          r.sandbox,
+	}.Get(ctx, keys)
+}
+
+func (r sandboxedEditableResource) List(ctx context.Context) ([]Resource, error) {
+	return sandboxedGettableResource{
+		GettableResource: r.EditableResource,
+		sandbox:          r.sandbox,
+	}.List(ctx)
+}
+
+func (r sandboxedEditableResource) Edit(ctx context.Context, target Resource, fields []Field) (Resource, error) {
+	if r.sandbox.Missing(target) {
+		return nil, fmt.Errorf("resource %s is not in the sandbox", target.Key())
+	}
+	return r.EditableResource.Edit(ctx, target, fields)
+}
+
+type sandboxedCreatableResource struct {
+	CreatableResource
+	sandbox *Sandbox
+}
+
+func (r sandboxedCreatableResource) Get(ctx context.Context, keys []string) ([]Resource, error) {
+	return sandboxedGettableResource{
+		GettableResource: r.CreatableResource,
+		sandbox:          r.sandbox,
+	}.Get(ctx, keys)
+}
+
+func (r sandboxedCreatableResource) List(ctx context.Context) ([]Resource, error) {
+	return sandboxedGettableResource{
+		GettableResource: r.CreatableResource,
+		sandbox:          r.sandbox,
+	}.List(ctx)
+}
+
+func (r sandboxedCreatableResource) Create(ctx context.Context, fields []Field) (Resource, error) {
+	res, err := r.CreatableResource.Create(ctx, fields)
+	if err != nil {
+		return nil, err
+	}
+	r.sandbox.Add(res)
+	return res, nil
+}
+
+type sandboxedDeletableResource struct {
+	DeletableResource
+	sandbox *Sandbox
+}
+
+func (r sandboxedDeletableResource) Get(ctx context.Context, keys []string) ([]Resource, error) {
+	return sandboxedGettableResource{
+		GettableResource: r.DeletableResource,
+		sandbox:          r.sandbox,
+	}.Get(ctx, keys)
+}
+
+func (r sandboxedDeletableResource) List(ctx context.Context) ([]Resource, error) {
+	return sandboxedGettableResource{
+		GettableResource: r.DeletableResource,
+		sandbox:          r.sandbox,
+	}.List(ctx)
+}
+
+func (r sandboxedDeletableResource) Delete(ctx context.Context, targets []Resource) error {
+	for _, res := range targets {
+		if r.sandbox.Missing(res) {
+			return fmt.Errorf("resource %s is not in the sandbox", res.Key())
+		}
+	}
+	err := r.DeletableResource.Delete(ctx, targets)
+	if err != nil {
+		return err
+	}
+	for _, res := range targets {
+		r.sandbox.Remove(res)
+	}
+	return nil
+}

--- a/internal/resource/visual.go
+++ b/internal/resource/visual.go
@@ -14,21 +14,22 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 	"sigs.k8s.io/yaml"
+	"unikraft.com/cli/internal/config"
 )
 
-func VisualEdit(fields []Field, patches []Field) ([]Field, error) {
-	return visualEdit(fields, patches, false)
+func VisualEdit(cfg *config.Config, fields []Field, patches []Field) ([]Field, error) {
+	return visualEdit(cfg, fields, patches, false)
 }
 
-func VisualCreate(fields []Field, creates []Field) ([]Field, error) {
-	return visualEdit(fields, creates, true)
+func VisualCreate(cfg *config.Config, fields []Field, creates []Field) ([]Field, error) {
+	return visualEdit(cfg, fields, creates, true)
 }
 
 // visualEdit opens an editor for the user to modify fields visually.
 //
 // It takes all the fields and already existing patched fields as input, and
 // returns all patched fields after editing.
-func visualEdit(fields []Field, patches []Field, create bool) ([]Field, error) {
+func visualEdit(cfg *config.Config, fields []Field, patches []Field, create bool) ([]Field, error) {
 	data, err := saveFields(fields, patches, create)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize fields: %w", err)
@@ -54,9 +55,9 @@ func visualEdit(fields []Field, patches []Field, create bool) ([]Field, error) {
 	}
 
 	cmd := exec.Command(editor, tmpfile.Name())
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdin = cfg.Stdin
+	cmd.Stdout = cfg.Stdout
+	cmd.Stderr = cfg.Stderr
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("editor exited with error: %w", err)
 	}


### PR DESCRIPTION
This PR adds support for *experimental* sandboxing. Resources created in the
sandbox are tracked and isolated from other resources (to provide our testing framework a reliable clean environment). Sandboxes are persisted to disk as JSON files, which track resource types and keys that belong to the sandbox.

Additionally, we allow easily cleaning up resources that belong to the sandbox. Tests *should* ideally be well behaved and clean up after themselves, but they might not (due to an error, or some other weird thing) - we shouldn't leave dangling resources in this case.

Finally, we start running tests in CI.