### PR TITLE
ci: Introduce more linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,8 +4,14 @@ run:
 linters:
   default: none
   enable:
-    - misspell
+    - staticcheck
+    - errcheck
+    - govet
     - unparam
+    - ineffassign
+    - unused
+    - misspell
+    - godox
   exclusions:
     generated: lax
     presets:
@@ -17,6 +23,22 @@ linters:
     - tmp/
     - dist/
     - examples$
+  settings:
+    staticcheck:
+      checks:
+      # default
+      - "all"
+      - "-ST1000"
+      - "-ST1003"
+      - "-ST1016"
+      - "-ST1020"
+      - "-ST1021"
+      - "-ST1022"
+      # kong uses duplicate struct tags
+      - "-SA5008" # invalid struct tag
+    godox:
+      keywords:
+        - XXX
 formatters:
   enable:
   - gofumpt

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -100,9 +100,8 @@ func NewRootCmd(ctx context.Context, args []string, stdin io.Reader, stdout, std
 	cli.Stdout = stdout
 	cli.Stderr = stderr
 
-	level := log.InfoLevel
-
-	switch cli.Config.LogLevel.String() {
+	var level log.Level
+	switch cli.LogLevel.String() {
 	case "trace":
 		level = log.TraceLevel
 	case "debug":
@@ -121,7 +120,7 @@ func NewRootCmd(ctx context.Context, args []string, stdin io.Reader, stdout, std
 		level = log.InfoLevel
 	}
 
-	cli.Context = log.WithLogger(cli.Context, log.New(stderr, cli.Config.LogType, level))
+	cli.Context = log.WithLogger(cli.Context, log.New(stderr, cli.LogType, level))
 	cli.Context = config.WithConfig(cli.Context, &cli.Config)
 	kctx.BindTo(cli.Context, (*context.Context)(nil))
 

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -21,7 +21,7 @@ var (
 	// ErrNoCurrentProfile is returned when there is no current profile set in the
 	// configuration. This can happen if the user has not logged in or if the
 	// current profile is not set in the configuration.
-	ErrNoCurrentProfile = jujuerrors.Errorf(heredoc.Docf(`
+	ErrNoCurrentProfile = jujuerrors.New(heredoc.Docf(`
 		profile not setup;
 
 		use %[1]sunikraft login%[1]s to get started,

--- a/internal/resource/cmd.go
+++ b/internal/resource/cmd.go
@@ -269,9 +269,11 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context) error {
 	dmp := diffmatchpatch.New()
 	diffs := dmp.DiffMain(start.String(), end.String(), false)
 	tw := kvwriter.KeyValueWriter(os.Stdout, "  ")
-	io.Copy(tw, strings.NewReader(prettydiff.Render(diffs)))
-	tw.Flush()
-	return nil
+	_, err = io.Copy(tw, strings.NewReader(prettydiff.Render(diffs)))
+	if err != nil {
+		return err
+	}
+	return tw.Flush()
 }
 
 type ResourceCreateCmd[R CreatableResource] struct {


### PR DESCRIPTION
And fix the issues they reveal. The new linters are:
- `staticcheck`, finds a whole bunch of issues
- `errcheck`, ensures we actually explicitly handle/discard errors
- `govet`, same as `go vet`
- `ineffassign`, finds assignments we don't actually use
- `unused`, prevents unused code
- `godox`, prevents `XXX` comments from passing (which is a personal little habit to highlight things that need doing before merging).