### PR TITLE
ci(release): Fix the path to the debian APT repository

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,7 +112,7 @@ jobs:
 
         for DISTRO in "${DISTROS[@]}"; do
           for DEB in dist/*.deb; do
-            wget "https://pkg.unikraft.com/debian/cli/upload/${DISTRO}/${COMPONENT}" \
+            wget "https://pkg.unikraft.com/debian/cli-apt/upload/${DISTRO}/${COMPONENT}" \
               --http-user "api" \
               --http-password "${{ secrets.PKG_TOKEN }}" \
               --method POST \


### PR DESCRIPTION
The feed was renamed from `cli` to `cli-apt`.  Adjust accordingly.

Signed-off-by: Alexander Jung <alex@unikraft.com>
