### PR TITLE
feat!: Replace --format with --output

### DIFF
--- a/create_instance.sh
+++ b/create_instance.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+unikraft instance create \
+	--set metro=ukp-stable \
+	--set autostart=true \
+	--set image=jedevc/www:latest \
+	--set resources.memory=512 \
+	--set resources.vcpus=1 \
+	--set "runtime.args=/usr/bin/caddy run --config /etc/caddy/Caddyfile" \
+	--set service.services=443:2015/tls+http \
+	--set service.domains=name=jedevcwww

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -99,9 +99,7 @@ type FormatOpts struct {
 	Field  []string `short:"f" help:"Specify which fields to include in the output."`
 	Filter []string `help:"Filter output based on a field value (e.g. --filter status==active)." sep:"none"`
 
-	Quiet  bool   `short:"q" help:"Only display resource keys."`
-	Format string `help:"Format the output using a Go template."`
-	Raw    bool   `help:"Output raw JSON API response."`
+	Output Printer `short:"o" help:"Output format. One of: kv, table, json, yaml, raw, quiet, template."`
 }
 
 type ResourceListCmd[R resource.GettableResource] struct {
@@ -136,22 +134,13 @@ func (cmd *ResourceListCmd[R]) Run(ctx context.Context, cfg *config.Config, sand
 		if err != nil {
 			return err
 		}
-
 		resources, err = filterResources(resources, filter)
 		if err != nil {
 			return err
 		}
-
-		switch {
-		case cmd.Quiet:
-			return printQuiet(out, resources...)
-		case cmd.Raw:
-			return printRaw(out, resources...)
-		case cmd.Format != "":
-			return printTemplate(out, cmd.Format, resources...)
-		default:
-			return printTable[R](out, cmd.Field, resources...)
-		}
+		return cmd.FormatOpts.Output.
+			WithDefault(PrinterTypeTable).
+			Print(out, cmd.Field, empty, resources...)
 	}
 
 	if cmd.Watch > 0 {
@@ -186,22 +175,13 @@ func (cmd *ResourceInspectCmd[R]) Run(ctx context.Context, cfg *config.Config, s
 		if err != nil {
 			return err
 		}
-
 		resources, err = filterResources(resources, filter)
 		if err != nil {
 			return err
 		}
-
-		switch {
-		case cmd.Quiet:
-			return printQuiet(out, resources...)
-		case cmd.Raw:
-			return printRaw(out, resources...)
-		case cmd.Format != "":
-			return printTemplate(out, cmd.Format, resources...)
-		default:
-			return printInspect(out, cmd.Field, resources...)
-		}
+		return cmd.FormatOpts.Output.
+			WithDefault(PrinterTypeKeyValue).
+			Print(out, cmd.Field, empty, resources...)
 	}
 
 	if cmd.Watch > 0 {
@@ -424,5 +404,5 @@ func (cmd *ResourceCreateCmd[R]) Run(ctx context.Context, cfg *config.Config, sa
 	if err != nil {
 		return err
 	}
-	return printInspect(cfg.Stdout, nil, res)
+	return printKVFormatted(cfg.Stdout, nil, res)
 }

--- a/internal/resource/cmd/cmd_test.go
+++ b/internal/resource/cmd/cmd_test.go
@@ -8,12 +8,15 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"testing"
 
+	"github.com/lunixbochs/vtclean"
 	"github.com/mitchellh/copystructure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
 
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/resource"
@@ -73,67 +76,6 @@ func TestList(t *testing.T) {
 	assert.Contains(t, output, "id-test1")
 	assert.Contains(t, output, "id-test2")
 
-	t.Run("quiet", func(t *testing.T) {
-		var out bytes.Buffer
-		cmd := &ResourceListCmd[resourcet.TestResource]{
-			FormatOpts: FormatOpts{
-				Quiet: true,
-			},
-		}
-		err := cmd.Run(ctx, testConfig(&out), sandbox)
-		require.NoError(t, err)
-		assert.Equal(t, "test1\ntest2\n", out.String())
-
-		out.Reset()
-		cmd.Name = []string{"test2"}
-		err = cmd.Run(ctx, testConfig(&out), sandbox)
-		require.NoError(t, err)
-		assert.Equal(t, "test2\n", out.String())
-	})
-
-	t.Run("raw", func(t *testing.T) {
-		var out bytes.Buffer
-		cmd := &ResourceListCmd[resourcet.TestResource]{
-			FormatOpts: FormatOpts{
-				Raw: true,
-			},
-		}
-		err := cmd.Run(ctx, testConfig(&out), sandbox)
-		require.NoError(t, err)
-
-		output := out.String()
-		assert.Contains(t, output, `"Name": "test1"`)
-		assert.Contains(t, output, `"ID": "id-test1"`)
-
-		out.Reset()
-		cmd.Name = []string{"test1"}
-		err = cmd.Run(ctx, testConfig(&out), sandbox)
-		require.NoError(t, err)
-
-		output = out.String()
-		assert.Contains(t, output, `"Name": "test1"`)
-		assert.Contains(t, output, `"ID": "id-test1"`)
-		assert.NotContains(t, output, `"Name": "test2"`)
-	})
-
-	t.Run("format", func(t *testing.T) {
-		var out bytes.Buffer
-		cmd := &ResourceListCmd[resourcet.TestResource]{
-			FormatOpts: FormatOpts{
-				Format: "{{range .}}{{.name}}\n{{end}}",
-			},
-		}
-		err := cmd.Run(ctx, testConfig(&out), sandbox)
-		require.NoError(t, err)
-		assert.Equal(t, "test1\ntest2\n", out.String())
-
-		out.Reset()
-		cmd.Name = []string{"test2", "test1"}
-		err = cmd.Run(ctx, testConfig(&out), sandbox)
-		require.NoError(t, err)
-		assert.Equal(t, "test2\ntest1\n", out.String())
-	})
-
 	t.Run("field", func(t *testing.T) {
 		var out bytes.Buffer
 		cmd := &ResourceListCmd[resourcet.TestResource]{
@@ -182,6 +124,104 @@ func TestList(t *testing.T) {
 		output = out.String()
 		assert.Contains(t, output, "test1")
 		assert.NotContains(t, output, "test2")
+	})
+}
+
+func TestListOutput(t *testing.T) {
+	ctx := context.Background()
+	sandbox := &resource.Sandbox{}
+
+	cloned, err := copystructure.Copy(baseTestStore)
+	require.NoError(t, err)
+	resourcet.TestStore = cloned.(map[string]resourcet.TestResource)
+
+	runList := func(t *testing.T, printer Printer) string {
+		t.Helper()
+		var out bytes.Buffer
+		cmd := &ResourceListCmd[resourcet.TestResource]{
+			FormatOpts: FormatOpts{
+				Output: printer,
+			},
+		}
+		err := cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+		return out.String()
+	}
+
+	t.Run("table", func(t *testing.T) {
+		output := runList(t, Printer{Type: PrinterTypeTable})
+		cleaned := vtclean.Clean(output, false)
+		assert.Contains(t, cleaned, "test1")
+		assert.Contains(t, cleaned, "test2")
+		assert.Contains(t, cleaned, "id-test1")
+	})
+
+	t.Run("kv", func(t *testing.T) {
+		output := runList(t, Printer{Type: PrinterTypeKeyValue})
+		assert.Contains(t, output, "name:")
+		assert.Contains(t, output, "id:")
+		assert.Contains(t, output, "test1")
+		assert.Contains(t, output, "id-test1")
+		assert.Contains(t, output, "test2")
+	})
+
+	t.Run("json", func(t *testing.T) {
+		output := runList(t, Printer{Type: PrinterTypeJSON})
+		var resources []map[string]any
+		err := json.Unmarshal([]byte(output), &resources)
+		require.NoError(t, err)
+		require.Len(t, resources, 2)
+
+		names := map[string]bool{}
+		for _, res := range resources {
+			if name, ok := res["name"].(string); ok {
+				names[name] = true
+			}
+		}
+		assert.True(t, names["test1"])
+		assert.True(t, names["test2"])
+	})
+
+	t.Run("yaml", func(t *testing.T) {
+		output := runList(t, Printer{Type: PrinterTypeYAML})
+		var resources []map[string]any
+		err := yaml.Unmarshal([]byte(output), &resources)
+		require.NoError(t, err)
+		require.Len(t, resources, 2)
+
+		names := map[string]bool{}
+		for _, res := range resources {
+			if name, ok := res["name"].(string); ok {
+				names[name] = true
+			}
+		}
+		assert.True(t, names["test1"])
+		assert.True(t, names["test2"])
+	})
+
+	t.Run("raw", func(t *testing.T) {
+		output := runList(t, Printer{Type: PrinterTypeRaw})
+		var resources []resourcet.TestResource
+		err := json.Unmarshal([]byte(output), &resources)
+		require.NoError(t, err)
+		require.Len(t, resources, 2)
+
+		names := map[string]bool{}
+		for _, res := range resources {
+			names[res.Name] = true
+		}
+		assert.True(t, names["test1"])
+		assert.True(t, names["test2"])
+	})
+
+	t.Run("quiet", func(t *testing.T) {
+		output := runList(t, Printer{Type: PrinterTypeQuiet})
+		assert.Equal(t, "test1\ntest2\n", output)
+	})
+
+	t.Run("template", func(t *testing.T) {
+		output := runList(t, Printer{Type: PrinterTypeTemplate, Value: "{{range .}}{{.name}}-{{.id}}\n{{end}}"})
+		assert.Equal(t, "test1-id-test1\ntest2-id-test2\n", output)
 	})
 }
 
@@ -242,71 +282,6 @@ func TestGet(t *testing.T) {
 		assert.Contains(t, output, "test2")
 		assert.Contains(t, output, "id-test1")
 		assert.Contains(t, output, "id-test2")
-	})
-
-	t.Run("quiet", func(t *testing.T) {
-		var out bytes.Buffer
-		cmd := &ResourceInspectCmd[resourcet.TestResource]{
-			Name: []string{"test1"},
-			FormatOpts: FormatOpts{
-				Quiet: true,
-			},
-		}
-		err := cmd.Run(ctx, testConfig(&out), sandbox)
-		require.NoError(t, err)
-		assert.Equal(t, "test1\n", out.String())
-
-		out.Reset()
-		cmd.Name = []string{"test2", "test1"}
-		err = cmd.Run(ctx, testConfig(&out), sandbox)
-		require.NoError(t, err)
-		assert.Equal(t, "test2\ntest1\n", out.String())
-	})
-
-	t.Run("raw", func(t *testing.T) {
-		var out bytes.Buffer
-		cmd := &ResourceInspectCmd[resourcet.TestResource]{
-			Name: []string{"test1"},
-			FormatOpts: FormatOpts{
-				Raw: true,
-			},
-		}
-		err := cmd.Run(ctx, testConfig(&out), sandbox)
-		require.NoError(t, err)
-
-		output := out.String()
-		assert.Contains(t, output, `"Name": "test1"`)
-		assert.Contains(t, output, `"ID": "id-test1"`)
-
-		out.Reset()
-		cmd.Name = []string{"test1", "test2"}
-		err = cmd.Run(ctx, testConfig(&out), sandbox)
-		require.NoError(t, err)
-
-		output = out.String()
-		assert.Contains(t, output, `"Name": "test1"`)
-		assert.Contains(t, output, `"ID": "id-test1"`)
-		assert.Contains(t, output, `"Name": "test2"`)
-		assert.Contains(t, output, `"ID": "id-test2"`)
-	})
-
-	t.Run("format", func(t *testing.T) {
-		var out bytes.Buffer
-		cmd := &ResourceInspectCmd[resourcet.TestResource]{
-			Name: []string{"test1"},
-			FormatOpts: FormatOpts{
-				Format: "{{range .}}{{.name}}: {{.url}}\n{{end}}",
-			},
-		}
-		err := cmd.Run(ctx, testConfig(&out), sandbox)
-		require.NoError(t, err)
-		assert.Equal(t, "test1: https://example.com\n", out.String())
-
-		out.Reset()
-		cmd.Name = []string{"test2", "test1"}
-		err = cmd.Run(ctx, testConfig(&out), sandbox)
-		require.NoError(t, err)
-		assert.Equal(t, "test2: https://example.org\ntest1: https://example.com\n", out.String())
 	})
 
 	t.Run("field", func(t *testing.T) {

--- a/internal/resource/cmd/printers.go
+++ b/internal/resource/cmd/printers.go
@@ -7,34 +7,118 @@ package cmd
 
 import (
 	"bytes"
+	"encoding"
 	"encoding/json"
 	"fmt"
+	"html/template"
 	"io"
 	"slices"
 	"strings"
-	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/juju/ansiterm"
 	"github.com/muesli/termenv"
+	"sigs.k8s.io/yaml"
 
 	"unikraft.com/cli/internal/kvwriter"
 	"unikraft.com/cli/internal/resource"
 	xslices "unikraft.com/cli/internal/x/slices"
 )
 
-func printTable[R resource.Resource](out io.Writer, fieldSpecs []string, resources ...resource.Resource) error {
+type PrinterType string
+
+const (
+	PrinterTypeTable    PrinterType = "table"
+	PrinterTypeKeyValue PrinterType = "kv"
+	PrinterTypeJSON     PrinterType = "json"
+	PrinterTypeYAML     PrinterType = "yaml"
+	PrinterTypeRaw      PrinterType = "raw"
+	PrinterTypeQuiet    PrinterType = "quiet"
+	PrinterTypeTemplate PrinterType = "template"
+)
+
+func (pt PrinterType) Validate() error {
+	switch pt {
+	case PrinterTypeTable, PrinterTypeKeyValue, PrinterTypeJSON, PrinterTypeYAML, PrinterTypeRaw, PrinterTypeQuiet, PrinterTypeTemplate:
+		return nil
+	default:
+		return fmt.Errorf("unknown printer type: %s", pt)
+	}
+}
+
+type Printer struct {
+	Type  PrinterType
+	Value string
+}
+
+var _ encoding.TextUnmarshaler = (*Printer)(nil)
+
+func (p *Printer) UnmarshalText(text []byte) error {
+	if len(text) == 0 {
+		return nil
+	}
+
+	k, v, _ := strings.Cut(string(text), "=")
+	pt := PrinterType(k)
+	if err := pt.Validate(); err != nil {
+		return err
+	}
+	p.Type = pt
+	p.Value = v
+	return nil
+}
+
+func ParsePrinter(s string) (Printer, error) {
+	pr := Printer{}
+	err := pr.UnmarshalText([]byte(s))
+	if err != nil {
+		return Printer{}, err
+	}
+	return pr, nil
+}
+
+func (p Printer) WithDefault(tp PrinterType) Printer {
+	if p.Type == "" {
+		p.Type = tp
+	}
+	return p
+}
+
+func (p Printer) Print(out io.Writer, fieldSpecs []string, base resource.Resource, resources ...resource.Resource) error {
+	switch p.Type {
+	case "":
+		return fmt.Errorf("printer type not specified")
+	case PrinterTypeTable:
+		return printTableFormatted(out, fieldSpecs, base, resources...)
+	case PrinterTypeKeyValue:
+		return printKVFormatted(out, fieldSpecs, resources...)
+	case PrinterTypeJSON:
+		return printJSON(out, resources...)
+	case PrinterTypeYAML:
+		return printYAML(out, resources...)
+	case PrinterTypeRaw:
+		return printRaw(out, resources...)
+	case PrinterTypeQuiet:
+		return printQuiet(out, resources...)
+	case PrinterTypeTemplate:
+		return printTemplate(out, p.Value, resources...)
+	default:
+		return fmt.Errorf("unknown printer type: %s", p.Type)
+	}
+}
+
+func printTableFormatted(out io.Writer, fieldSpecs []string, base resource.Resource, resources ...resource.Resource) error {
 	tw := ansiterm.NewTabWriter(out, 0, 8, 2, ' ', 0)
-	err := printTabSeparated[R](tw, fieldSpecs, resources...)
+	err := printTable(tw, fieldSpecs, base, resources...)
 	if err != nil {
 		return err
 	}
 	return tw.Flush()
 }
 
-func printInspect(out io.Writer, fieldSpecs []string, resources ...resource.Resource) error {
+func printKVFormatted(out io.Writer, fieldSpecs []string, resources ...resource.Resource) error {
 	bw := kvwriter.KeyValueWriter(out, "")
 	err := printKV(bw, fieldSpecs, resources...)
 	if err != nil {
@@ -107,9 +191,8 @@ func printKVFields(out io.Writer, parent *resource.Field, fields []resource.Fiel
 	return nil
 }
 
-func printTabSeparated[R resource.Resource](out io.Writer, fieldSpecs []string, resources ...resource.Resource) error {
-	var r R
-	headers, err := r.Fields()
+func printTable(out io.Writer, fieldSpecs []string, base resource.Resource, resources ...resource.Resource) error {
+	headers, err := base.Fields()
 	if err != nil {
 		return err
 	}
@@ -223,6 +306,40 @@ func printQuiet(out io.Writer, resources ...resource.Resource) error {
 		}
 	}
 	return nil
+}
+
+func printJSON(out io.Writer, resources ...resource.Resource) error {
+	input := make([]any, 0, len(resources))
+	for _, res := range resources {
+		fields, err := res.Fields()
+		if err != nil {
+			return err
+		}
+		input = append(input, resource.FieldsToMap(fields))
+	}
+	dt, err := json.MarshalIndent(input, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(out, string(dt))
+	return err
+}
+
+func printYAML(out io.Writer, resources ...resource.Resource) error {
+	input := make([]any, 0, len(resources))
+	for _, res := range resources {
+		fields, err := res.Fields()
+		if err != nil {
+			return err
+		}
+		input = append(input, resource.FieldsToMap(fields))
+	}
+	dt, err := yaml.Marshal(input)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprint(out, string(dt))
+	return err
 }
 
 func printRaw(out io.Writer, resources ...resource.Resource) error {


### PR DESCRIPTION
I added this to originally be similar to the docker command. But it's a bit weird, and I don't love it. `jq` is well loved for doing scripting anyways, so we should just support a `--json` output for fields instead (not to be confused with `--raw` which is the raw API data).