### PR TITLE
feat: Editing list fields

### DIFF
--- a/cmd/unikraft/main_test.go
+++ b/cmd/unikraft/main_test.go
@@ -48,6 +48,7 @@ type testCase struct {
 	name     string
 	commands []command
 	online   bool
+	cleaners []cleaner
 }
 
 type command struct {
@@ -97,42 +98,48 @@ var testCases = []testCase{
 		},
 	},
 
-	// NOTE: disabled since certificates get generated and are not cleaned up properly
-	// {
-	// 	name:   "services",
-	// 	online: true,
-	// 	commands: []command{
-	// 		{args: []string{unikraftCmd, "login"}, token: true},
-	// 		{args: []string{unikraftCmd, "service", "list"}},
-	// 		{args: []string{
-	// 			unikraftCmd, "service", "create",
-	// 			"--set", "name=test-$UNIQ_SVC_A",
-	// 			"--set", "metro=" + defaultMetro,
-	// 			"--set", "domains=fqdn=$UNIQ_DOMAIN_A.unikraft.example",
-	// 			"--set", "services=443:8080/tls+http",
-	// 			"--set", "services=80:443/http+redirect",
-	// 		}},
-	// 		{args: []string{
-	// 			unikraftCmd, "service", "create",
-	// 			"--set", "name=test-$UNIQ_SVC_B",
-	// 			"--set", "metro=" + defaultMetro,
-	// 			"--set", "domains=fqdn=$UNIQ_DOMAIN_B.unikraft.example",
-	// 			"--set", "services=443:8080/tls+http,80:443/http+redirect",
-	// 		}},
-	// 		{args: []string{unikraftCmd, "service", "list"}},
-	// 		{args: []string{unikraftCmd, "service", "inspect", "test-$UNIQ_SVC_A", "test-$UNIQ_SVC_B"}},
-	//
-	// 		{args: []string{unikraftCmd, "service", "edit", "test-$UNIQ_SVC_A", "--add", "services=1000:2000/tls"}},
-	// 		{args: []string{unikraftCmd, "service", "edit", "test-$UNIQ_SVC_B", "--set", "services=1000:2000/tls"}},
-	// 		{args: []string{unikraftCmd, "service", "inspect", "test-$UNIQ_SVC_A", "test-$UNIQ_SVC_B"}},
-	//
-	// 		{args: []string{unikraftCmd, "service", "edit", "test-$UNIQ_SVC_A", "--del", "services=1000:2000/tls"}},
-	// 		{args: []string{unikraftCmd, "service", "edit", "test-$UNIQ_SVC_B", "--del", "services=1000:2000/tls"}},
-	// 		{args: []string{unikraftCmd, "service", "inspect", "test-$UNIQ_SVC_A", "test-$UNIQ_SVC_B"}},
-	//
-	// 		{args: []string{unikraftCmd, "service", "delete", "test-$UNIQ_SVC_A", "test-$UNIQ_SVC_B"}},
-	// 	},
-	// },
+	{
+		name:   "services",
+		online: true,
+		commands: []command{
+			{args: []string{unikraftCmd, "login"}, token: true},
+			{args: []string{unikraftCmd, "service", "list"}},
+			{args: []string{
+				unikraftCmd, "service", "create",
+				"--set", "name=test-$UNIQ_SVC_A",
+				"--set", "metro=" + defaultMetro,
+				"--set", "domains=fqdn=$UNIQ_DOMAIN_A.unikraft.example",
+				"--set", "services=443:8080/tls+http",
+				"--set", "services=80:443/http+redirect",
+			}},
+			{args: []string{
+				unikraftCmd, "service", "create",
+				"--set", "name=test-$UNIQ_SVC_B",
+				"--set", "metro=" + defaultMetro,
+				"--set", "domains=fqdn=$UNIQ_DOMAIN_B.unikraft.example",
+				"--set", "services=443:8080/tls+http,80:443/http+redirect",
+			}},
+			{args: []string{unikraftCmd, "service", "list"}},
+			{args: []string{unikraftCmd, "service", "inspect", "test-$UNIQ_SVC_A", "test-$UNIQ_SVC_B"}},
+
+			{args: []string{unikraftCmd, "service", "edit", "test-$UNIQ_SVC_A", "--add", "services=1000:2000/tls"}},
+			{args: []string{unikraftCmd, "service", "edit", "test-$UNIQ_SVC_B", "--set", "services=1000:2000/tls"}},
+			{args: []string{unikraftCmd, "service", "inspect", "test-$UNIQ_SVC_A", "test-$UNIQ_SVC_B"}},
+
+			{args: []string{unikraftCmd, "service", "edit", "test-$UNIQ_SVC_A", "--del", "services=1000:2000/tls"}},
+			{args: []string{unikraftCmd, "service", "edit", "test-$UNIQ_SVC_B", "--del", "services=1000:2000/tls"}},
+			{args: []string{unikraftCmd, "service", "inspect", "test-$UNIQ_SVC_A", "test-$UNIQ_SVC_B"}},
+
+			{args: []string{unikraftCmd, "service", "delete", "test-$UNIQ_SVC_A", "test-$UNIQ_SVC_B"}},
+		},
+		cleaners: []cleaner{
+			{
+				// automatically generated certificate names
+				pattern: regexp.MustCompile(`\.unikraft\.example-[a-z0-9]{5,}`),
+				repl:    ".unikraft.example-xxxxx",
+			},
+		},
+	},
 
 	{
 		name:   "certificates",
@@ -258,6 +265,7 @@ func TestGolden(t *testing.T) {
 					stderr:   stderr.String(),
 					exitCode: exitCode,
 				}
+				report.cleaners = append(report.cleaners, tc.cleaners...)
 				report.cleaners = append(report.cleaners, expander.cleaners()...)
 				for _, metro := range profile.Metros {
 					report.cleaners = append(report.cleaners, cleaner{

--- a/cmd/unikraft/main_test.go
+++ b/cmd/unikraft/main_test.go
@@ -97,6 +97,43 @@ var testCases = []testCase{
 		},
 	},
 
+	// NOTE: disabled since certificates get generated and are not cleaned up properly
+	// {
+	// 	name:   "services",
+	// 	online: true,
+	// 	commands: []command{
+	// 		{args: []string{unikraftCmd, "login"}, token: true},
+	// 		{args: []string{unikraftCmd, "service", "list"}},
+	// 		{args: []string{
+	// 			unikraftCmd, "service", "create",
+	// 			"--set", "name=test-$UNIQ_SVC_A",
+	// 			"--set", "metro=" + defaultMetro,
+	// 			"--set", "domains=fqdn=$UNIQ_DOMAIN_A.unikraft.example",
+	// 			"--set", "services=443:8080/tls+http",
+	// 			"--set", "services=80:443/http+redirect",
+	// 		}},
+	// 		{args: []string{
+	// 			unikraftCmd, "service", "create",
+	// 			"--set", "name=test-$UNIQ_SVC_B",
+	// 			"--set", "metro=" + defaultMetro,
+	// 			"--set", "domains=fqdn=$UNIQ_DOMAIN_B.unikraft.example",
+	// 			"--set", "services=443:8080/tls+http,80:443/http+redirect",
+	// 		}},
+	// 		{args: []string{unikraftCmd, "service", "list"}},
+	// 		{args: []string{unikraftCmd, "service", "inspect", "test-$UNIQ_SVC_A", "test-$UNIQ_SVC_B"}},
+	//
+	// 		{args: []string{unikraftCmd, "service", "edit", "test-$UNIQ_SVC_A", "--add", "services=1000:2000/tls"}},
+	// 		{args: []string{unikraftCmd, "service", "edit", "test-$UNIQ_SVC_B", "--set", "services=1000:2000/tls"}},
+	// 		{args: []string{unikraftCmd, "service", "inspect", "test-$UNIQ_SVC_A", "test-$UNIQ_SVC_B"}},
+	//
+	// 		{args: []string{unikraftCmd, "service", "edit", "test-$UNIQ_SVC_A", "--del", "services=1000:2000/tls"}},
+	// 		{args: []string{unikraftCmd, "service", "edit", "test-$UNIQ_SVC_B", "--del", "services=1000:2000/tls"}},
+	// 		{args: []string{unikraftCmd, "service", "inspect", "test-$UNIQ_SVC_A", "test-$UNIQ_SVC_B"}},
+	//
+	// 		{args: []string{unikraftCmd, "service", "delete", "test-$UNIQ_SVC_A", "test-$UNIQ_SVC_B"}},
+	// 	},
+	// },
+
 	{
 		name:   "certificates",
 		online: true,

--- a/cmd/unikraft/testdata/TestGolden/services
+++ b/cmd/unikraft/testdata/TestGolden/services
@@ -1,0 +1,239 @@
+$ unikraft login
+
+stderr:
+	HH:MM INF using authentication token from UKC_TOKEN environment variable
+	HH:MM WRN no metros configured; please add them manually
+	HH:MM INF login successful
+
+$ unikraft service list
+
+stdout:
+	METRO  NAME  AUTOSCALE  FQDN  SERVICES
+
+$ unikraft service create --set name=test-$UNIQ_SVC_A --set metro=test --set domains=fqdn=$UNIQ_DOMAIN_A.unikraft.example --set services=443:8080/tls+http --set services=80:443/http+redirect
+
+stdout:
+	metro:         test
+	name:          test-<SVC_A>
+	uuid:          12345678-1234-1234-1234-123456789abc
+	persistent:    true
+	limits:
+	  soft:        1
+	  hard:        65535
+	domains:
+	- fqdn:        <DOMAIN_A>.unikraft.example
+	  certificate:
+	    name:      <DOMAIN_A>.unikraft.example-xxxxx
+	    uuid:      12345678-1234-1234-1234-123456789abc
+	services:
+	- 443:8080/tls+http
+	- 80:443/http+redirect
+
+$ unikraft service create --set name=test-$UNIQ_SVC_B --set metro=test --set domains=fqdn=$UNIQ_DOMAIN_B.unikraft.example --set services=443:8080/tls+http,80:443/http+redirect
+
+stdout:
+	metro:         test
+	name:          test-<SVC_B>
+	uuid:          12345678-1234-1234-1234-123456789abc
+	persistent:    true
+	limits:
+	  soft:        1
+	  hard:        65535
+	domains:
+	- fqdn:        <DOMAIN_B>.unikraft.example
+	  certificate:
+	    name:      <DOMAIN_B>.unikraft.example-xxxxx
+	    uuid:      12345678-1234-1234-1234-123456789abc
+	services:
+	- 443:8080/tls+http
+	- 80:443/http+redirect
+
+$ unikraft service list
+
+stdout:
+	METRO  NAME               AUTOSCALE  FQDN                           SERVICES
+	test   test-<SVC_B>  false      <DOMAIN_B>.unikraft.example  443:8080/tls+http, 80:443/http+redirect
+	test   test-<SVC_A>  false      <DOMAIN_A>.unikraft.example  443:8080/tls+http, 80:443/http+redirect
+
+$ unikraft service inspect test-$UNIQ_SVC_A test-$UNIQ_SVC_B
+
+stdout:
+	metro:         test
+	name:          test-<SVC_A>
+	uuid:          12345678-1234-1234-1234-123456789abc
+	persistent:    true
+	limits:
+	  soft:        1
+	  hard:        65535
+	domains:
+	- fqdn:        <DOMAIN_A>.unikraft.example
+	  certificate:
+	    name:      <DOMAIN_A>.unikraft.example-xxxxx
+	    uuid:      12345678-1234-1234-1234-123456789abc
+	services:
+	- 443:8080/tls+http
+	- 80:443/http+redirect
+
+	metro:         test
+	name:          test-<SVC_B>
+	uuid:          12345678-1234-1234-1234-123456789abc
+	persistent:    true
+	limits:
+	  soft:        1
+	  hard:        65535
+	domains:
+	- fqdn:        <DOMAIN_B>.unikraft.example
+	  certificate:
+	    name:      <DOMAIN_B>.unikraft.example-xxxxx
+	    uuid:      12345678-1234-1234-1234-123456789abc
+	services:
+	- 443:8080/tls+http
+	- 80:443/http+redirect
+
+$ unikraft service edit test-$UNIQ_SVC_A --add services=1000:2000/tls
+
+stdout:
+	metro:         test
+	  name:          test-<SVC_A>
+	  uuid:          12345678-1234-1234-1234-123456789abc
+	  persistent:    true
+	  limits:
+	    soft:        1
+	    hard:        65535
+	  domains:
+	  - fqdn:        <DOMAIN_A>.unikraft.example
+	    certificate:
+	      name:      <DOMAIN_A>.unikraft.example-xxxxx
+	      uuid:      12345678-1234-1234-1234-123456789abc
+	  services:
+	  - 443:8080/tls+http
+	  - 80:443/http+redirect
+	+ - 1000:2000/tls
+
+$ unikraft service edit test-$UNIQ_SVC_B --set services=1000:2000/tls
+
+stdout:
+	metro:         test
+	  name:          test-<SVC_B>
+	  uuid:          12345678-1234-1234-1234-123456789abc
+	  persistent:    true
+	  limits:
+	    soft:        1
+	    hard:        65535
+	  domains:
+	  - fqdn:        <DOMAIN_B>.unikraft.example
+	    certificate:
+	      name:      <DOMAIN_B>.unikraft.example-xxxxx
+	      uuid:      12345678-1234-1234-1234-123456789abc
+	  services:
+	- - 443:8080/tls+http
+	- - 80:443/http+redirect
+	+ - 1000:2000/tls
+	+
+
+$ unikraft service inspect test-$UNIQ_SVC_A test-$UNIQ_SVC_B
+
+stdout:
+	metro:         test
+	name:          test-<SVC_A>
+	uuid:          12345678-1234-1234-1234-123456789abc
+	persistent:    true
+	limits:
+	  soft:        1
+	  hard:        65535
+	domains:
+	- fqdn:        <DOMAIN_A>.unikraft.example
+	  certificate:
+	    name:      <DOMAIN_A>.unikraft.example-xxxxx
+	    uuid:      12345678-1234-1234-1234-123456789abc
+	services:
+	- 443:8080/tls+http
+	- 80:443/http+redirect
+	- 1000:2000/tls
+
+	metro:         test
+	name:          test-<SVC_B>
+	uuid:          12345678-1234-1234-1234-123456789abc
+	persistent:    true
+	limits:
+	  soft:        1
+	  hard:        65535
+	domains:
+	- fqdn:        <DOMAIN_B>.unikraft.example
+	  certificate:
+	    name:      <DOMAIN_B>.unikraft.example-xxxxx
+	    uuid:      12345678-1234-1234-1234-123456789abc
+	services:
+	- 1000:2000/tls
+
+$ unikraft service edit test-$UNIQ_SVC_A --del services=1000:2000/tls
+
+stdout:
+	metro:         test
+	  name:          test-<SVC_A>
+	  uuid:          12345678-1234-1234-1234-123456789abc
+	  persistent:    true
+	  limits:
+	    soft:        1
+	    hard:        65535
+	  domains:
+	  - fqdn:        <DOMAIN_A>.unikraft.example
+	    certificate:
+	      name:      <DOMAIN_A>.unikraft.example-xxxxx
+	      uuid:      12345678-1234-1234-1234-123456789abc
+	  services:
+	  - 443:8080/tls+http
+	  - 80:443/http+redirect
+	- - 1000:2000/tls
+
+$ unikraft service edit test-$UNIQ_SVC_B --del services=1000:2000/tls
+
+stdout:
+	metro:         test
+	  name:          test-<SVC_B>
+	  uuid:          12345678-1234-1234-1234-123456789abc
+	  persistent:    true
+	  limits:
+	    soft:        1
+	    hard:        65535
+	  domains:
+	  - fqdn:        <DOMAIN_B>.unikraft.example
+	    certificate:
+	      name:      <DOMAIN_B>.unikraft.example-xxxxx
+	      uuid:      12345678-1234-1234-1234-123456789abc
+	- services:
+	- - 1000:2000/tls
+
+$ unikraft service inspect test-$UNIQ_SVC_A test-$UNIQ_SVC_B
+
+stdout:
+	metro:         test
+	name:          test-<SVC_A>
+	uuid:          12345678-1234-1234-1234-123456789abc
+	persistent:    true
+	limits:
+	  soft:        1
+	  hard:        65535
+	domains:
+	- fqdn:        <DOMAIN_A>.unikraft.example
+	  certificate:
+	    name:      <DOMAIN_A>.unikraft.example-xxxxx
+	    uuid:      12345678-1234-1234-1234-123456789abc
+	services:
+	- 443:8080/tls+http
+	- 80:443/http+redirect
+
+	metro:         test
+	name:          test-<SVC_B>
+	uuid:          12345678-1234-1234-1234-123456789abc
+	persistent:    true
+	limits:
+	  soft:        1
+	  hard:        65535
+	domains:
+	- fqdn:        <DOMAIN_B>.unikraft.example
+	  certificate:
+	    name:      <DOMAIN_B>.unikraft.example-xxxxx
+	    uuid:      12345678-1234-1234-1234-123456789abc
+
+$ unikraft service delete test-$UNIQ_SVC_A test-$UNIQ_SVC_B

--- a/cmd/unikraft/testdata/TestGolden/volumes
+++ b/cmd/unikraft/testdata/TestGolden/volumes
@@ -13,14 +13,12 @@ stdout:
 $ unikraft volume create --set name=test-$UNIQ_VOLUME --set size=10 --set metro=test
 
 stdout:
-	metro:       test
-	name:        test-<VOLUME>
-	uuid:        12345678-1234-1234-1234-123456789abc
-	state:       available
-	size:        10MB
-	persistent:  true
-	attached-to:
-	mounted-by:
+	metro:      test
+	name:       test-<VOLUME>
+	uuid:       12345678-1234-1234-1234-123456789abc
+	state:      available
+	size:       10MB
+	persistent: true
 
 $ unikraft volume list
 
@@ -31,27 +29,23 @@ stdout:
 $ unikraft volume inspect test-$UNIQ_VOLUME
 
 stdout:
-	metro:       test
-	name:        test-<VOLUME>
-	uuid:        12345678-1234-1234-1234-123456789abc
-	state:       available
-	size:        10MB
-	persistent:  true
-	attached-to:
-	mounted-by:
+	metro:      test
+	name:       test-<VOLUME>
+	uuid:       12345678-1234-1234-1234-123456789abc
+	state:      available
+	size:       10MB
+	persistent: true
 
 $ unikraft volume edit test-$UNIQ_VOLUME --set size=20
 
 stdout:
-	metro:       test
-	  name:        test-<VOLUME>
-	  uuid:        12345678-1234-1234-1234-123456789abc
-	  state:       available
-	- size:        10MB
-	+ size:        20MB
-	  persistent:  true
-	  attached-to:
-	  mounted-by:
+	metro:      test
+	  name:       test-<VOLUME>
+	  uuid:       12345678-1234-1234-1234-123456789abc
+	  state:      available
+	- size:       10MB
+	+ size:       20MB
+	  persistent: true
 
 $ unikraft volume list
 
@@ -62,13 +56,11 @@ stdout:
 $ unikraft volume inspect test-$UNIQ_VOLUME
 
 stdout:
-	metro:       test
-	name:        test-<VOLUME>
-	uuid:        12345678-1234-1234-1234-123456789abc
-	state:       available
-	size:        20MB
-	persistent:  true
-	attached-to:
-	mounted-by:
+	metro:      test
+	name:       test-<VOLUME>
+	uuid:       12345678-1234-1234-1234-123456789abc
+	state:      available
+	size:       20MB
+	persistent: true
 
 $ unikraft volume delete test-$UNIQ_VOLUME

--- a/internal/cmd/services.go
+++ b/internal/cmd/services.go
@@ -60,9 +60,9 @@ type ServiceGroup struct {
 }
 
 type Service struct {
-	Source      uint32                     `mirror:"port" json:"source" field:",long"`
-	Destination uint32                     `mirror:"destination_port" json:"destination" field:",long"`
-	Handlers    []platform.ServiceHandlers `mirror:"handlers" json:"handlers" field:",long"`
+	Source      uint32                     `mirror:"port" json:"source" field:",short"`
+	Destination uint32                     `mirror:"destination_port" json:"destination" field:",short"`
+	Handlers    []platform.ServiceHandlers `mirror:"handlers" json:"handlers" field:",short"`
 }
 
 func (s *Service) String() string {

--- a/internal/cmd/services.go
+++ b/internal/cmd/services.go
@@ -23,8 +23,10 @@ import (
 )
 
 type ServicesCmd struct {
-	resource.ResourceCmd[ServiceGroup]         `set:"name=service" set:"names=services"`
-	resource.EditableResourceCmd[ServiceGroup] `set:"name=service" set:"names=services"`
+	resource.ResourceCmd[ServiceGroup]          `set:"name=service" set:"names=services"`
+	resource.DeletableResourceCmd[ServiceGroup] `set:"name=service" set:"names=services"`
+	resource.EditableResourceCmd[ServiceGroup]  `set:"name=service" set:"names=services"`
+	resource.CreatableResourceCmd[ServiceGroup] `set:"name=service" set:"names=services"`
 }
 
 type ServiceGroup struct {
@@ -138,15 +140,23 @@ func (s ServiceGroup) Fields() ([]resource.Field, error) {
 
 	for key, field := range resource.IterFields(result) {
 		switch key.String() {
+		case "metro":
+			field.Create = &resource.Patch{Set: "", Required: true}
+		case "name":
+			field.Create = &resource.Patch{Set: ""}
 		case "services":
 			// FIXME: del should support deleting by *just* port
 			field.Patch = &resource.Patch{Set: []*Service{}, Add: []*Service{}, Del: []*Service{}}
+			field.Create = &resource.Patch{Set: []*Service{}, Required: true}
 		case "domains":
 			field.Patch = &resource.Patch{Set: []Domain{}, Add: []Domain{}, Del: []Domain{}}
+			field.Create = &resource.Patch{Set: []Domain{}}
 		case "limits.soft":
 			field.Patch = &resource.Patch{Set: uint64(0)}
+			field.Create = &resource.Patch{Set: uint64(0)}
 		case "limits.hard":
 			field.Patch = &resource.Patch{Set: uint64(0)}
+			field.Create = &resource.Patch{Set: uint64(0)}
 		}
 	}
 
@@ -227,6 +237,91 @@ func (ServiceGroup) load(serviceGroup platform.ServiceGroup, metro *config.Metro
 		return ServiceGroup{}, fmt.Errorf("could not mirror service group data: %w", err)
 	}
 	return result, nil
+}
+
+func (ServiceGroup) Delete(ctx context.Context, targets []resource.Resource) error {
+	keys := make([]multimetro.Key, len(targets))
+	for i, target := range targets {
+		sg := target.(ServiceGroup)
+		keys[i] = sg.key()
+	}
+
+	cl, err := multimetro.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = multimetro.DoKeys(ctx, cl, keys, func(ctx context.Context, mc *multimetro.MetroClient, keys multimetro.Keys) ([]struct{}, []multimetro.Key, error) {
+		log.G(ctx).Trace().Msg("deleting service groups")
+		_, err := mc.DeleteServiceGroups(ctx, keys.NamesOrUUIDs())
+		return nil, keys, err
+	})
+	return err
+}
+
+func (ServiceGroup) Create(ctx context.Context, fields []resource.Field) (resource.Resource, error) {
+	var req platform.CreateServiceGroupRequest
+	var metro string
+	for key, field := range resource.IterFields(fields) {
+		if field.Create != nil && field.Create.Set != nil {
+			switch key.String() {
+			case "metro":
+				metro = field.Create.Set.(string)
+			case "name":
+				name := field.Create.Set.(string)
+				req.Name = &name
+			case "limits.soft":
+				limit := field.Create.Set.(uint64)
+				req.SoftLimit = &limit
+			case "limits.hard":
+				limit := field.Create.Set.(uint64)
+				req.HardLimit = &limit
+			case "domains":
+				for _, domain := range field.Create.Set.([]Domain) {
+					name := domain.Name
+					if name == "" {
+						name = domain.FQDN + "."
+					}
+					req.Domains = append(req.Domains, platform.CreateServiceGroupRequestDomain{
+						Name: name,
+					})
+				}
+			case "services":
+				for _, svc := range field.Create.Set.([]*Service) {
+					req.Services = append(req.Services, platform.Service{
+						Port:            svc.Source,
+						DestinationPort: &svc.Destination,
+						Handlers:        svc.Handlers,
+					})
+				}
+			}
+		}
+	}
+
+	cl, err := multimetro.NewClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	uuid, err := multimetro.DoMetro(ctx, cl, metro, func(ctx context.Context, mc *multimetro.MetroClient) (string, error) {
+		log.G(ctx).Trace().Msg("creating service group")
+		resp, err := mc.CreateServiceGroup(ctx, req)
+		if err != nil {
+			return "", err
+		}
+		return *resp.Data.ServiceGroups[0].Uuid, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	key := multimetro.Key{
+		Metro: metro,
+		UUID:  uuid,
+	}
+	results, err := ServiceGroup{}.Get(ctx, []string{key.String()})
+	if err != nil {
+		return nil, err
+	}
+	return results[0], nil
 }
 
 func (ServiceGroup) Edit(ctx context.Context, target resource.Resource, fields []resource.Field) (resource.Resource, error) {

--- a/internal/cmd/services.go
+++ b/internal/cmd/services.go
@@ -8,6 +8,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"unikraft.com/cloud/sdk/platform"
@@ -21,7 +23,8 @@ import (
 )
 
 type ServicesCmd struct {
-	resource.ResourceCmd[ServiceGroup] `set:"name=service" set:"names=services"`
+	resource.ResourceCmd[ServiceGroup]         `set:"name=service" set:"names=services"`
+	resource.EditableResourceCmd[ServiceGroup] `set:"name=service" set:"names=services"`
 }
 
 type ServiceGroup struct {
@@ -41,25 +44,67 @@ type ServiceGroup struct {
 		CreatedAt time.Time `mirror:"service_group.created_at"`
 	}
 
-	Domains []struct {
-		FQDN string `mirror:"fqdn" field:",short"`
-		// TODO: certificate
-	} `mirror:"service_group.domains"`
+	Domains []Domain `mirror:"service_group.domains"`
 
 	Instances []struct {
 		Name string `mirror:"name" field:",long"`
 		UUID string `mirror:"uuid" field:",long"`
 	} `mirror:"service_group.instances"`
 
-	// TODO: support shorthand
-	Services []struct {
-		Source      uint32                     `mirror:"port" field:",long"`
-		Destination uint32                     `mirror:"destination_port" field:",long"`
-		Handlers    []platform.ServiceHandlers `mirror:"handlers" field:",long"`
-	} `mirror:"service_group.services"`
+	Services []*Service `mirror:"service_group.services"`
 
 	ServiceGroup platform.ServiceGroup `field:"-" json:"service_group"`
 	Metro        *config.Metro         `field:"-" json:"metro"`
+}
+
+type Service struct {
+	Source      uint32                     `mirror:"port" json:"source" field:",long"`
+	Destination uint32                     `mirror:"destination_port" json:"destination" field:",long"`
+	Handlers    []platform.ServiceHandlers `mirror:"handlers" json:"handlers" field:",long"`
+}
+
+func (s *Service) String() string {
+	handlers := make([]string, len(s.Handlers))
+	for i, handler := range s.Handlers {
+		handlers[i] = string(handler)
+	}
+	return fmt.Sprintf("%d:%d/%s", s.Source, s.Destination, strings.Join(handlers, "+"))
+}
+
+func (s *Service) Parse(str string) error {
+	ports, handlers, _ := strings.Cut(str, "/")
+	src, dest, ok := strings.Cut(ports, ":")
+	if !ok {
+		return fmt.Errorf("invalid service format, expected SOURCE:DESTINATION/HANDLERS")
+	}
+
+	srcPort, err := strconv.Atoi(src)
+	if err != nil {
+		return fmt.Errorf("invalid source port: %w", err)
+	}
+	s.Source = uint32(srcPort)
+
+	destPort, err := strconv.Atoi(dest)
+	if err != nil {
+		return fmt.Errorf("invalid destination port: %w", err)
+	}
+	s.Destination = uint32(destPort)
+
+	if handlers != "" {
+		for handler := range strings.SplitSeq(handlers, "+") {
+			s.Handlers = append(s.Handlers, platform.ServiceHandlers(handler))
+		}
+	}
+
+	return nil
+}
+
+type Domain struct {
+	FQDN string `mirror:"fqdn" field:",short"`
+
+	Name string `field:",invisible"` // edit-only field
+
+	// TODO: certificates
 }
 
 func (ServiceGroup) Type() resource.Type {
@@ -89,6 +134,20 @@ func (s ServiceGroup) Fields() ([]resource.Field, error) {
 	result, err := resource.FieldsFromStruct(s)
 	if err != nil {
 		return nil, err
+	}
+
+	for key, field := range resource.IterFields(result) {
+		switch key.String() {
+		case "services":
+			// FIXME: del should support deleting by *just* port
+			field.Patch = &resource.Patch{Set: []*Service{}, Add: []*Service{}, Del: []*Service{}}
+		case "domains":
+			field.Patch = &resource.Patch{Set: []Domain{}, Add: []Domain{}, Del: []Domain{}}
+		case "limits.soft":
+			field.Patch = &resource.Patch{Set: uint64(0)}
+		case "limits.hard":
+			field.Patch = &resource.Patch{Set: uint64(0)}
+		}
 	}
 
 	return result, nil
@@ -168,4 +227,88 @@ func (ServiceGroup) load(serviceGroup platform.ServiceGroup, metro *config.Metro
 		return ServiceGroup{}, fmt.Errorf("could not mirror service group data: %w", err)
 	}
 	return result, nil
+}
+
+func (ServiceGroup) Edit(ctx context.Context, target resource.Resource, fields []resource.Field) (resource.Resource, error) {
+	sg := target.(ServiceGroup)
+	var reqs []platform.UpdateServiceGroupsRequestItem
+	for key, field := range resource.IterFields(fields) {
+		reqs = append(reqs, ServiceGroup{}.getFieldRequests(sg.UUID, key, *field)...)
+	}
+
+	cl, err := multimetro.NewClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	_, err = multimetro.DoKeyExact(ctx, cl, sg.key(), func(ctx context.Context, metroClient *multimetro.MetroClient) (struct{}, error) {
+		log.G(ctx).Trace().Msg("updating service group")
+		_, err := metroClient.UpdateServiceGroups(ctx, reqs)
+		return struct{}{}, err
+	})
+	if err != nil {
+		return nil, err
+	}
+	results, err := ServiceGroup{}.Get(ctx, []string{sg.Key()})
+	if err != nil {
+		return nil, err
+	}
+	return results[0], nil
+}
+
+func (ServiceGroup) getFieldRequests(uuid string, key resource.FieldPath, field resource.Field) (reqs []platform.UpdateServiceGroupsRequestItem) {
+	if field.Patch == nil {
+		return reqs
+	}
+	if field.Patch.Set != nil {
+		reqs = append(reqs, ServiceGroup{}.getPatchRequest(uuid, key, field.Patch.Set, platform.UpdateServiceGroupsRequestItemOpSet))
+	}
+	if field.Patch.Add != nil {
+		reqs = append(reqs, ServiceGroup{}.getPatchRequest(uuid, key, field.Patch.Add, platform.UpdateServiceGroupsRequestItemOpAdd))
+	}
+	if field.Patch.Del != nil {
+		reqs = append(reqs, ServiceGroup{}.getPatchRequest(uuid, key, field.Patch.Del, platform.UpdateServiceGroupsRequestItemOpDel))
+	}
+	return reqs
+}
+
+func (ServiceGroup) getPatchRequest(uuid string, key resource.FieldPath, value any, op platform.UpdateServiceGroupsRequestItemOp) platform.UpdateServiceGroupsRequestItem {
+	var prop platform.UpdateServiceGroupsRequestItemProp
+	switch key.String() {
+	case "limits.soft":
+		prop = platform.UpdateServiceGroupsRequestItemPropSoft_limit
+	case "limits.hard":
+		prop = platform.UpdateServiceGroupsRequestItemPropHard_limit
+	case "domains":
+		prop = platform.UpdateServiceGroupsRequestItemPropDomains
+		nvalue := []platform.CreateServiceGroupRequestDomain{}
+		for _, domain := range value.([]Domain) {
+			name := domain.Name
+			if name == "" {
+				name = domain.FQDN + "."
+			}
+			nvalue = append(nvalue, platform.CreateServiceGroupRequestDomain{
+				Name: name,
+			})
+		}
+		value = nvalue
+	case "services":
+		prop = platform.UpdateServiceGroupsRequestItemPropServices
+		nvalue := []platform.Service{}
+		for _, svc := range value.([]*Service) {
+			nvalue = append(nvalue, platform.Service{
+				Port:            svc.Source,
+				DestinationPort: &svc.Destination,
+				Handlers:        svc.Handlers,
+			})
+		}
+		value = nvalue
+	default:
+		return platform.UpdateServiceGroupsRequestItem{}
+	}
+	return platform.UpdateServiceGroupsRequestItem{
+		Uuid:  &uuid,
+		Op:    op,
+		Prop:  prop,
+		Value: platform.Ptr(value),
+	}
 }

--- a/internal/cmd/services.go
+++ b/internal/cmd/services.go
@@ -103,10 +103,12 @@ func (s *Service) Parse(str string) error {
 
 type Domain struct {
 	FQDN string `mirror:"fqdn" field:",short"`
-
 	Name string `field:",invisible"` // edit-only field
 
-	// TODO: certificates
+	Certificate struct {
+		Name string `mirror:"name" field:",long"`
+		UUID string `mirror:"uuid" field:",long"`
+	} `mirror:"certificate"`
 }
 
 func (ServiceGroup) Type() resource.Type {
@@ -157,6 +159,18 @@ func (s ServiceGroup) Fields() ([]resource.Field, error) {
 		case "limits.hard":
 			field.Patch = &resource.Patch{Set: uint64(0)}
 			field.Create = &resource.Patch{Set: uint64(0)}
+		}
+		if key.MatchesString("domains.*.certificate") {
+			name, _ := field.Get("name")
+			uuid, _ := field.Get("uuid")
+			field.Links = append(field.Links, resource.Link{
+				Type: "certificate",
+				Key: multimetro.Key{
+					Metro: s.Metro.Name,
+					Name:  name.Value.(string),
+					UUID:  uuid.Value.(string),
+				}.String(),
+			})
 		}
 	}
 

--- a/internal/kvwriter/kvwriter.go
+++ b/internal/kvwriter/kvwriter.go
@@ -51,6 +51,11 @@ func (b *keyValueWriter) Write(p []byte) (n int, err error) {
 
 	for line := range lines {
 		key, value, ok := bytes.Cut(line, []byte(":"))
+		if ok && len(value) > 0 {
+			if value[0] != ' ' && value[0] != '\t' && value[0] != '\n' {
+				ok = false
+			}
+		}
 		if ok {
 			b.keys = append(b.keys, key)
 			b.cleankeys = append(b.cleankeys, []byte(vtclean.Clean(string(key), false)))

--- a/internal/mirror/mirror.go
+++ b/internal/mirror/mirror.go
@@ -40,10 +40,11 @@ func Mirror(source any, dest any) error {
 		destVal = destVal.Elem()
 	}
 
-	return mirrorValue(gjson.Parse(sourceStr), destVal, true)
+	pkgPath := destVal.Type().PkgPath()
+	return mirrorStruct(gjson.Parse(sourceStr), destVal, pkgPath)
 }
 
-func mirrorValue(source gjson.Result, dest reflect.Value, topLevel bool) error {
+func mirrorValue(source gjson.Result, dest reflect.Value, pkgPath string) error {
 	if !dest.IsValid() || !dest.CanSet() {
 		return nil
 	}
@@ -51,24 +52,24 @@ func mirrorValue(source gjson.Result, dest reflect.Value, topLevel bool) error {
 	destType := dest.Type()
 	switch dest.Kind() {
 	case reflect.Struct:
-		return mirrorStruct(source, dest, topLevel)
+		return mirrorStruct(source, dest, pkgPath)
 	case reflect.Slice, reflect.Array:
-		return mirrorSlice(source, dest)
+		return mirrorSlice(source, dest, pkgPath)
 	case reflect.Map:
-		return mirrorMap(source, dest)
+		return mirrorMap(source, dest, pkgPath)
 	case reflect.Pointer:
 		if dest.IsNil() {
 			dest.Set(reflect.New(destType.Elem()))
 		}
-		return mirrorValue(source, dest.Elem(), topLevel)
+		return mirrorValue(source, dest.Elem(), pkgPath)
 	}
 
 	return nil
 }
 
-func mirrorStruct(source gjson.Result, dest reflect.Value, topLevel bool) error {
+func mirrorStruct(source gjson.Result, dest reflect.Value, pkgPath string) error {
 	destType := dest.Type()
-	if !topLevel && destType.Name() != "" {
+	if destType.PkgPath() != "" && destType.PkgPath() != pkgPath {
 		return nil
 	}
 	for i := range destType.NumField() {
@@ -89,7 +90,7 @@ func mirrorStruct(source gjson.Result, dest reflect.Value, topLevel bool) error 
 				source = source.Get(path)
 			}
 
-			if canSetFieldValue(field.Type) {
+			if canSetFieldValue(field.Type, pkgPath) {
 				ok, err := setFieldValue(source, fieldVal)
 				if err != nil {
 					return fmt.Errorf("field %s: %w", field.Name, err)
@@ -100,14 +101,14 @@ func mirrorStruct(source gjson.Result, dest reflect.Value, topLevel bool) error 
 			}
 		}
 
-		if err := mirrorValue(source, fieldVal, false); err != nil {
+		if err := mirrorValue(source, fieldVal, pkgPath); err != nil {
 			return fmt.Errorf("field %s: %w", field.Name, err)
 		}
 	}
 	return nil
 }
 
-func mirrorSlice(source gjson.Result, destVal reflect.Value) error {
+func mirrorSlice(source gjson.Result, destVal reflect.Value, pkgPath string) error {
 	if !source.Exists() {
 		return nil
 	}
@@ -124,32 +125,32 @@ func mirrorSlice(source gjson.Result, destVal reflect.Value) error {
 	}
 	for i := range destVal.Len() {
 		source := array[i]
-		if err := mirrorValue(source, destVal.Index(i), false); err != nil {
+		if err := mirrorValue(source, destVal.Index(i), pkgPath); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func mirrorMap(source gjson.Result, destVal reflect.Value) error {
+func mirrorMap(source gjson.Result, destVal reflect.Value, pkgPath string) error {
 	for _, key := range destVal.MapKeys() {
 		itemVal := destVal.MapIndex(key)
-		if err := mirrorValue(source, itemVal, false); err != nil {
+		if err := mirrorValue(source, itemVal, pkgPath); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func canSetFieldValue(destType reflect.Type) bool {
+func canSetFieldValue(destType reflect.Type, pkgPath string) bool {
 	for destType.Kind() == reflect.Pointer {
 		destType = destType.Elem()
 	}
 	switch destType.Kind() {
 	case reflect.Struct:
-		return destType.Name() != ""
+		return destType.PkgPath() != "" && destType.PkgPath() != pkgPath
 	case reflect.Slice, reflect.Map:
-		return canSetFieldValue(destType.Elem())
+		return canSetFieldValue(destType.Elem(), pkgPath)
 	default:
 		return true
 	}

--- a/internal/mirror/mirror_test.go
+++ b/internal/mirror/mirror_test.go
@@ -47,7 +47,7 @@ func TestMirror_BasicExample(t *testing.T) {
 	assert.Equal(t, "value1", dest.Field1)
 	assert.Equal(t, 42, dest.Field2)
 	assert.Equal(t, "nested_value", dest.Nested.SubField)
-	assert.Empty(t, dest.Nested2.SubField)
+	assert.Equal(t, "nested_value", dest.Nested2.SubField)
 	assert.Equal(t, []string{"item1", "item2", "item3"}, dest.Lists)
 }
 

--- a/internal/resource/cmd.go
+++ b/internal/resource/cmd.go
@@ -179,11 +179,35 @@ func (cmd *ResourceRemoveCmd[R]) Run(ctx context.Context, sandbox *Sandbox) erro
 type ResourceEditCmd[R EditableResource] struct {
 	Name string `arg:"" help:"Name of the ${name} to edit."`
 
-	Set map[string]string `help:"Key-value pairs to update the ${name} with."`
-	Add map[string]string `help:"Key-value pairs to add to the ${name}."`
-	Del map[string]string `help:"Keys to delete from the ${name}."`
+	Set []map[string]string `help:"Key-value pairs to update the ${name} with." mapsep:"none"`
+	Add []map[string]string `help:"Key-value pairs to add to the ${name}." mapsep:"none"`
+	Del []map[string]string `help:"Keys to delete from the ${name}." mapsep:"none"`
 
 	Visual bool `short:"e" help:"Open an editor to modify fields visually."`
+}
+
+func (cmd *ResourceEditCmd[R]) toPatchSpec() PatchSpec {
+	spec := PatchSpec{
+		Set: make(map[string][]string),
+		Add: make(map[string][]string),
+		Del: make(map[string][]string),
+	}
+	for _, m := range cmd.Set {
+		for k, v := range m {
+			spec.Set[k] = append(spec.Set[k], v)
+		}
+	}
+	for _, m := range cmd.Add {
+		for k, v := range m {
+			spec.Add[k] = append(spec.Add[k], v)
+		}
+	}
+	for _, m := range cmd.Del {
+		for k, v := range m {
+			spec.Del[k] = append(spec.Del[k], v)
+		}
+	}
+	return spec
 }
 
 func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, cfg *config.Config, sandbox *Sandbox) error {
@@ -205,25 +229,17 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, cfg *config.Config, sand
 	}
 	resource := resources[0]
 
-	if cmd.Set == nil {
-		cmd.Set = make(map[string]string)
-	}
-	if cmd.Add == nil {
-		cmd.Add = make(map[string]string)
-	}
-	if cmd.Del == nil {
-		cmd.Del = make(map[string]string)
-	}
+	spec := cmd.toPatchSpec()
 
 	// Check for duplicate field paths across Set/Add/Del
 	allFields := make(map[string]int)
-	for k := range cmd.Set {
+	for k := range spec.Set {
 		allFields[k]++
 	}
-	for k := range cmd.Add {
+	for k := range spec.Add {
 		allFields[k]++
 	}
-	for k := range cmd.Del {
+	for k := range spec.Del {
 		allFields[k]++
 	}
 	for k, count := range allFields {
@@ -236,11 +252,7 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, cfg *config.Config, sand
 	if err != nil {
 		return fmt.Errorf("failed to get fields: %w", err)
 	}
-	patched, err := PatchedFields(fields, PatchSpec{
-		Set: cmd.Set,
-		Add: cmd.Add,
-		Del: cmd.Del,
-	})
+	patched, err := PatchedFields(fields, spec)
 	if err != nil {
 		return err
 	}
@@ -280,26 +292,32 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, cfg *config.Config, sand
 }
 
 type ResourceCreateCmd[R CreatableResource] struct {
-	Set map[string]string `help:"Key-value pairs for creating the ${name}."`
+	Set []map[string]string `help:"Key-value pairs for creating the ${name}." mapsep:"none"`
 
 	Visual bool `short:"e" help:"Open an editor to set fields visually."`
 }
 
-func (cmd *ResourceCreateCmd[R]) Run(ctx context.Context, cfg *config.Config, sandbox *Sandbox) error {
-	if cmd.Set == nil {
-		cmd.Set = make(map[string]string)
+func (cmd *ResourceCreateCmd[R]) toPatchSpec() PatchSpec {
+	spec := PatchSpec{
+		Create: true,
+		Set:    make(map[string][]string),
 	}
+	for _, m := range cmd.Set {
+		for k, v := range m {
+			spec.Set[k] = append(spec.Set[k], v)
+		}
+	}
+	return spec
+}
 
+func (cmd *ResourceCreateCmd[R]) Run(ctx context.Context, cfg *config.Config, sandbox *Sandbox) error {
 	var empty R
 	r := sandbox.WrapCreatable(empty)
 	fields, err := r.Fields()
 	if err != nil {
 		return fmt.Errorf("failed to get fields: %w", err)
 	}
-	patched, err := PatchedFields(fields, PatchSpec{
-		Create: true,
-		Set:    cmd.Set,
-	})
+	patched, err := PatchedFields(fields, cmd.toPatchSpec())
 	if err != nil {
 		return err
 	}

--- a/internal/resource/cmd.go
+++ b/internal/resource/cmd.go
@@ -179,9 +179,9 @@ func (cmd *ResourceRemoveCmd[R]) Run(ctx context.Context, sandbox *Sandbox) erro
 type ResourceEditCmd[R EditableResource] struct {
 	Name string `arg:"" help:"Name of the ${name} to edit."`
 
-	Set []map[string]string `help:"Key-value pairs to update the ${name} with." mapsep:"none"`
-	Add []map[string]string `help:"Key-value pairs to add to the ${name}." mapsep:"none"`
-	Del []map[string]string `help:"Keys to delete from the ${name}." mapsep:"none"`
+	Set []map[string]string `help:"Key-value pairs to update the ${name} with." sep:"none" mapsep:"none"`
+	Add []map[string]string `help:"Key-value pairs to add to the ${name}." sep:"none" mapsep:"none"`
+	Del []map[string]string `help:"Keys to delete from the ${name}." sep:"none" mapsep:"none"`
 
 	Visual bool `short:"e" help:"Open an editor to modify fields visually."`
 }
@@ -292,7 +292,7 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, cfg *config.Config, sand
 }
 
 type ResourceCreateCmd[R CreatableResource] struct {
-	Set []map[string]string `help:"Key-value pairs for creating the ${name}." mapsep:"none"`
+	Set []map[string]string `help:"Key-value pairs for creating the ${name}." sep:"none" mapsep:"none"`
 
 	Visual bool `short:"e" help:"Open an editor to set fields visually."`
 }

--- a/internal/resource/cmd.go
+++ b/internal/resource/cmd.go
@@ -245,7 +245,7 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, cfg *config.Config, sand
 		return err
 	}
 	if cmd.Visual {
-		patched, err = VisualEdit(cfg, fields, patched)
+		patched, err = VisualEdit(ctx, cfg, fields, patched)
 		if err != nil {
 			return err
 		}
@@ -306,7 +306,7 @@ func (cmd *ResourceCreateCmd[R]) Run(ctx context.Context, cfg *config.Config, sa
 
 	if cmd.Visual {
 		// FIXME: should allow required fields
-		patched, err = VisualCreate(cfg, fields, patched)
+		patched, err = VisualCreate(ctx, cfg, fields, patched)
 		if err != nil {
 			return err
 		}

--- a/internal/resource/cmd.go
+++ b/internal/resource/cmd.go
@@ -250,20 +250,18 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, cfg *config.Config, sand
 			return err
 		}
 	}
-
-	fields = filterPatchableFields(patched)
-	if len(fields) == 0 {
-		return fmt.Errorf("no editable fields provided")
-	}
+	patched = filterPatchableFields(patched)
 
 	start := &bytes.Buffer{}
 	err = printKV(start, nil, resource)
 	if err != nil {
 		return err
 	}
-	resource, err = r.Edit(ctx, resource, fields)
-	if err != nil {
-		return err
+	if len(patched) > 0 {
+		resource, err = r.Edit(ctx, resource, patched)
+		if err != nil {
+			return err
+		}
 	}
 	end := &bytes.Buffer{}
 	err = printKV(end, nil, resource)

--- a/internal/resource/collect.go
+++ b/internal/resource/collect.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package resource
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// collectValue collects a value of the given type from the Field.
+//
+// In the simplest case, this is just returning field.Value, but for nested
+// structures, like lists of fields, then we need to assemble a value from
+// the subfields. e.g. [Field{Value: 1}, Field{Value: 2}] -> []int{1, 2}
+func collectValue(field Field, into reflect.Type) (any, error) {
+	v, err := collectValueRaw(field)
+	if err != nil {
+		return nil, err
+	}
+	target := reflect.New(into).Elem().Interface()
+
+	if err := decodeStruct(v, &target); err != nil {
+		return nil, fmt.Errorf("failed to decode value into type %s: %w", into.String(), err)
+	}
+	return target, nil
+}
+
+func collectValueRaw(field Field) (any, error) {
+	if field.Value != nil {
+		return field.Value, nil
+	}
+	if field.Elem != nil {
+		sl := make([]any, 0, len(field.Subfields))
+		for _, subfield := range field.Subfields {
+			elemValue, err := collectValueRaw(subfield)
+			if err != nil {
+				return nil, err
+			}
+			sl = append(sl, elemValue)
+		}
+		return sl, nil
+	}
+	if len(field.Subfields) > 0 {
+		m := make(map[string]any, len(field.Subfields))
+		for _, subfield := range field.Subfields {
+			subfieldValue, err := collectValueRaw(subfield)
+			if err != nil {
+				return nil, err
+			}
+			m[subfield.Name] = subfieldValue
+		}
+		return m, nil
+	}
+	return nil, fmt.Errorf("field has no value")
+}
+
+// storeValue stores a value into the given Field, as the reverse of collectValue.
+//
+// In the simplest case, this is just setting field.Value, but for nested structures,
+// like lists of fields, then we need to decompose the value into the subfields.
+// e.g. []int{1, 2} -> [Field{Value: 1}, Field{Value: 2}].
+func storeValue(field *Field, base reflect.Value) error {
+	value := base
+	for value.Kind() == reflect.Interface || value.Kind() == reflect.Pointer {
+		value = value.Elem()
+	}
+
+	if field.Value != nil {
+		if !base.Type().AssignableTo(reflect.TypeOf(field.Value)) {
+			return fmt.Errorf("cannot assign value of type %s to field %s of type %T", value.Type().String(), field.Name, field.Value)
+		}
+		field.Value = base.Interface()
+	}
+
+	if field.Elem != nil {
+		if value.Kind() != reflect.Slice && value.Kind() != reflect.Array {
+			return fmt.Errorf("expected slice for field %s, got %s", field.Name, value.Kind().String())
+		}
+		if field.Subfields == nil {
+			field.Subfields = make([]Field, value.Len())
+			for i := range field.Subfields {
+				field.Subfields[i] = CloneField(*field.Elem)
+				field.Subfields[i].Name = fmt.Sprintf("%d", i)
+			}
+		}
+		if value.Len() != len(field.Subfields) {
+			return fmt.Errorf("expected %d elements for field %s, got %d", len(field.Subfields), field.Name, value.Len())
+		}
+		for i := range value.Len() {
+			err := storeValue(&field.Subfields[i], value.Index(i))
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if len(field.Subfields) > 0 {
+		if value.Kind() != reflect.Struct {
+			// NOTE: theoretically possible to support more types here
+			// but in reality, we don't seem to have Patches for other types
+			return fmt.Errorf("expected struct for field %s, got %s", field.Name, value.Kind().String())
+		}
+		for i := range value.NumField() {
+			parsedField := parseField(value.Type().Field(i))
+			if parsedField == nil {
+				continue
+			}
+
+			var subfield *Field
+			for j := range field.Subfields {
+				if field.Subfields[j].Name == parsedField.name {
+					subfield = &field.Subfields[j]
+					break
+				}
+			}
+			if subfield == nil {
+				return fmt.Errorf("no subfield named %s in field %s", parsedField.name, field.Name)
+			}
+			err := storeValue(subfield, value.Field(i))
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if field.Value != nil {
+		return nil
+	}
+	return fmt.Errorf("field has no value")
+}

--- a/internal/resource/patch.go
+++ b/internal/resource/patch.go
@@ -14,6 +14,8 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+
+	"github.com/mitchellh/mapstructure"
 )
 
 type PatchSpec struct {
@@ -166,7 +168,15 @@ func parseNewReflect(input string, output reflect.Value) (reflect.Value, error) 
 	return newVal.Elem(), nil
 }
 
-func parseReflect(input string, output reflect.Value) error {
+func parseReflect(input string, value reflect.Value) error {
+	output := value
+	for output.Kind() == reflect.Pointer {
+		if output.IsNil() {
+			output.Set(reflect.New(output.Type().Elem()))
+		}
+		output = output.Elem()
+	}
+
 	switch output.Kind() {
 	case reflect.Pointer:
 		if output.IsNil() {
@@ -237,7 +247,30 @@ func parseReflect(input string, output reflect.Value) error {
 		}
 		output.Set(mapp)
 		return nil
+	case reflect.Struct:
+		valueField, ok := value.Interface().(valueField)
+		if ok {
+			return valueField.Parse(input)
+		}
+
+		kv := map[string]string{}
+		fields := strings.Split(input, ",")
+		for _, field := range fields {
+			field = strings.TrimSpace(field)
+			k, v, _ := strings.Cut(field, "=")
+			kv[k] = v
+		}
+
+		decoderConfig := mapstructure.DecoderConfig{
+			ErrorUnused: true,
+			Result:      value.Addr().Interface(),
+		}
+		decoder, err := mapstructure.NewDecoder(&decoderConfig)
+		if err != nil {
+			return fmt.Errorf("failed to create decoder: %w", err)
+		}
+		return decoder.Decode(kv)
 	default:
-		return fmt.Errorf("unsupported kind: %s", output.Kind())
+		return fmt.Errorf("unsupported type: %T", value.Interface())
 	}
 }

--- a/internal/resource/patch.go
+++ b/internal/resource/patch.go
@@ -14,8 +14,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-
-	"github.com/mitchellh/mapstructure"
 )
 
 type PatchSpec struct {
@@ -268,16 +266,7 @@ func parseReflect(input []string, value reflect.Value) error {
 			k, v, _ := strings.Cut(field, "=")
 			kv[k] = v
 		}
-
-		decoderConfig := mapstructure.DecoderConfig{
-			ErrorUnused: true,
-			Result:      value.Addr().Interface(),
-		}
-		decoder, err := mapstructure.NewDecoder(&decoderConfig)
-		if err != nil {
-			return fmt.Errorf("failed to create decoder: %w", err)
-		}
-		return decoder.Decode(kv)
+		return decodeStruct(kv, value.Addr().Interface())
 	default:
 		return fmt.Errorf("unsupported type: %T", value.Interface())
 	}

--- a/internal/resource/patch.go
+++ b/internal/resource/patch.go
@@ -21,9 +21,9 @@ import (
 type PatchSpec struct {
 	Create bool
 
-	Set map[string]string
-	Add map[string]string
-	Del map[string]string
+	Set map[string][]string
+	Add map[string][]string
+	Del map[string][]string
 }
 
 func (spec *PatchSpec) Keys() iter.Seq[string] {
@@ -151,7 +151,7 @@ func PatchedFields(fields []Field, spec PatchSpec) ([]Field, error) {
 	return filterPatchableFields(fields), nil
 }
 
-func parseNewValue(input string, output any) (any, error) {
+func parseNewValue(input []string, output any) (any, error) {
 	parsedVal, err := parseNewReflect(input, reflect.ValueOf(output))
 	if err != nil {
 		return nil, err
@@ -159,7 +159,7 @@ func parseNewValue(input string, output any) (any, error) {
 	return parsedVal.Interface(), nil
 }
 
-func parseNewReflect(input string, output reflect.Value) (reflect.Value, error) {
+func parseNewReflect(input []string, output reflect.Value) (reflect.Value, error) {
 	newVal := reflect.New(output.Type())
 	err := parseReflect(input, newVal.Elem())
 	if err != nil {
@@ -168,7 +168,11 @@ func parseNewReflect(input string, output reflect.Value) (reflect.Value, error) 
 	return newVal.Elem(), nil
 }
 
-func parseReflect(input string, value reflect.Value) error {
+func parseReflect(input []string, value reflect.Value) error {
+	if len(input) == 0 {
+		return nil
+	}
+
 	output := value
 	for output.Kind() == reflect.Pointer {
 		if output.IsNil() {
@@ -184,77 +188,81 @@ func parseReflect(input string, value reflect.Value) error {
 		}
 		return parseReflect(input, output.Elem())
 	case reflect.String:
-		output.SetString(input)
+		output.SetString(input[0])
 		return nil
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		v, err := strconv.ParseInt(input, 10, output.Type().Bits())
+		v, err := strconv.ParseInt(input[0], 10, output.Type().Bits())
 		if err != nil {
 			return err
 		}
 		output.SetInt(v)
 		return nil
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		v, err := strconv.ParseUint(input, 10, output.Type().Bits())
+		v, err := strconv.ParseUint(input[0], 10, output.Type().Bits())
 		if err != nil {
 			return err
 		}
 		output.SetUint(v)
 		return nil
 	case reflect.Float32, reflect.Float64:
-		v, err := strconv.ParseFloat(input, output.Type().Bits())
+		v, err := strconv.ParseFloat(input[0], output.Type().Bits())
 		if err != nil {
 			return err
 		}
 		output.SetFloat(v)
 		return nil
 	case reflect.Bool:
-		v, err := strconv.ParseBool(input)
+		v, err := strconv.ParseBool(input[0])
 		if err != nil {
 			return err
 		}
 		output.SetBool(v)
 		return nil
 	case reflect.Slice:
-		inputs := strings.Split(input, ",")
-		slice := reflect.MakeSlice(output.Type(), len(inputs), len(inputs))
-		for i, item := range inputs {
-			err := parseReflect(item, slice.Index(i))
-			if err != nil {
-				return err
+		slice := reflect.MakeSlice(output.Type(), 0, 0)
+		for _, input := range input {
+			for item := range strings.SplitSeq(input, ",") {
+				val := reflect.New(output.Type().Elem()).Elem()
+				err := parseReflect([]string{item}, val)
+				if err != nil {
+					return err
+				}
+				slice = reflect.Append(slice, val)
 			}
 		}
 		output.Set(slice)
 		return nil
 	case reflect.Map:
-		inputs := strings.Split(input, ",")
 		mapp := reflect.MakeMap(output.Type())
-		for _, item := range inputs {
-			if item == "" {
-				continue
+		for _, input := range input {
+			for item := range strings.SplitSeq(input, ",") {
+				if item == "" {
+					continue
+				}
+				k, v, _ := strings.Cut(item, "=")
+				key := reflect.New(output.Type().Key()).Elem()
+				err := parseReflect([]string{k}, key)
+				if err != nil {
+					return err
+				}
+				val := reflect.New(output.Type().Elem()).Elem()
+				err = parseReflect([]string{v}, val)
+				if err != nil {
+					return err
+				}
+				mapp.SetMapIndex(key, val)
 			}
-			k, v, _ := strings.Cut(item, "=")
-			key := reflect.New(output.Type().Key()).Elem()
-			err := parseReflect(k, key)
-			if err != nil {
-				return err
-			}
-			val := reflect.New(output.Type().Elem()).Elem()
-			err = parseReflect(v, val)
-			if err != nil {
-				return err
-			}
-			mapp.SetMapIndex(key, val)
 		}
 		output.Set(mapp)
 		return nil
 	case reflect.Struct:
 		valueField, ok := value.Interface().(valueField)
 		if ok {
-			return valueField.Parse(input)
+			return valueField.Parse(input[0])
 		}
 
 		kv := map[string]string{}
-		fields := strings.Split(input, ",")
+		fields := strings.Split(input[0], ",")
 		for _, field := range fields {
 			field = strings.TrimSpace(field)
 			k, v, _ := strings.Cut(field, "=")

--- a/internal/resource/printers.go
+++ b/internal/resource/printers.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -18,7 +19,9 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/juju/ansiterm"
 	"github.com/muesli/termenv"
+
 	"unikraft.com/cli/internal/kvwriter"
+	xslices "unikraft.com/cli/internal/x/slices"
 )
 
 func printTable[R Resource](out io.Writer, fieldSpecs []string, resources ...Resource) error {
@@ -49,6 +52,7 @@ func printKV(out io.Writer, specs []string, resources ...Resource) error {
 		if err != nil {
 			return err
 		}
+		fields = DedupeFields(fields)
 
 		if i > 0 {
 			if _, err := fmt.Fprintln(out); err != nil {
@@ -72,6 +76,10 @@ func printKVFields(out io.Writer, parent *Field, fields []Field, current int, in
 			line.WriteString("- ")
 			nextCurrent = indent
 			nextIndent = indent
+			if field.Value != nil {
+				line.WriteString(field.ValueString())
+				line.WriteString("\n")
+			}
 		} else {
 			if i == 0 {
 				line.WriteString(strings.Repeat("  ", max(0, indent-current)))
@@ -89,8 +97,10 @@ func printKVFields(out io.Writer, parent *Field, fields []Field, current int, in
 			return err
 		}
 
-		if err := printKVFields(out, &field, field.Subfields, nextCurrent, nextIndent); err != nil {
-			return err
+		if field.Value == nil {
+			if err := printKVFields(out, &field, field.Subfields, nextCurrent, nextIndent); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -108,20 +118,21 @@ func printTabSeparated[R Resource](out io.Writer, fieldSpecs []string, resources
 		return err
 	}
 
-	headerIdx := -1
-	for _, header := range IterFields(headers) {
-		if header.HasChildren() {
+	headerPaths, headerFields := xslices.Collect2(IterFields(headers))
+
+	for i, header := range headerFields {
+		if header.HasChildren() && header.Value == nil {
 			continue
 		}
-		headerIdx++
+		path := headerPaths[i]
 
-		if headerIdx > 0 {
+		if i > 0 {
 			_, err := fmt.Fprint(out, "\t")
 			if err != nil {
 				return err
 			}
 		}
-		name := strings.ToUpper(header.Name)
+		name := strings.ToUpper(headerName(path))
 		_, err := fmt.Fprintf(out, "%s", lipgloss.NewStyle().SetString(name).Bold(true).String())
 		if err != nil {
 			return err
@@ -138,14 +149,13 @@ func printTabSeparated[R Resource](out io.Writer, fieldSpecs []string, resources
 			return err
 		}
 
-		headerIdx := -1
-		for path, header := range IterFields(headers) {
-			if header.HasChildren() {
+		for i, header := range headerFields {
+			if header.HasChildren() && header.Value == nil {
 				continue
 			}
-			headerIdx++
+			path := headerPaths[i]
 
-			if headerIdx > 0 {
+			if i > 0 {
 				_, err = fmt.Fprint(out, "\t")
 				if err != nil {
 					return err
@@ -155,7 +165,7 @@ func printTabSeparated[R Resource](out io.Writer, fieldSpecs []string, resources
 			fields := GetFieldByPath(fields, path)
 			fieldIdx := -1
 			for _, field := range IterFields(fields) {
-				if field.HasChildren() {
+				if field.Value == nil {
 					continue
 				}
 				fieldIdx++
@@ -194,6 +204,16 @@ func printTabSeparated[R Resource](out io.Writer, fieldSpecs []string, resources
 	return nil
 }
 
+func headerName(path FieldPath) string {
+	for _, part := range slices.Backward(path) {
+		if part == "*" {
+			continue
+		}
+		return part
+	}
+	return ""
+}
+
 func printQuiet(out io.Writer, resources ...Resource) error {
 	for _, resource := range resources {
 		_, err := fmt.Fprintln(out, resource.Key())
@@ -224,7 +244,7 @@ func printTemplate(out io.Writer, tmplStr string, resources ...Resource) error {
 		if err != nil {
 			return err
 		}
-		input = append(input, fieldsToMap(fields))
+		input = append(input, FieldsToMap(fields))
 	}
 
 	tmpl, err := template.New("out").Funcs(sprig.TxtFuncMap()).Parse(tmplStr)
@@ -262,8 +282,11 @@ func resourceFields(fields []Field, header bool, verbosity FieldVerbosity, field
 
 	result, missing := FilterFieldsByPath(fields, base, !header)
 	if len(base) == 0 {
-		result = filterFields(result, func(field Field) bool {
-			return field.Verbosity >= verbosity
+		result = filterFields(result, func(field Field) filterResult {
+			if field.Verbosity >= verbosity {
+				return filterRecurse
+			}
+			return filterExclude
 		})
 	}
 
@@ -281,12 +304,6 @@ func resourceFields(fields []Field, header bool, verbosity FieldVerbosity, field
 
 	if len(missing) > 0 {
 		return nil, fmt.Errorf("unknown fields: %v", missing)
-	}
-
-	if header {
-		for i := range result {
-			result[i] = mergeFieldElems(result[i])
-		}
 	}
 
 	return result, nil

--- a/internal/resource/printers.go
+++ b/internal/resource/printers.go
@@ -283,10 +283,13 @@ func resourceFields(fields []Field, header bool, verbosity FieldVerbosity, field
 	result, missing := FilterFieldsByPath(fields, base, !header)
 	if len(base) == 0 {
 		result = filterFields(result, func(field Field) filterResult {
-			if field.Verbosity >= verbosity {
-				return filterRecurse
+			if field.Verbosity < verbosity {
+				return filterExclude
 			}
-			return filterExclude
+			if field.Empty && !header {
+				return filterExclude
+			}
+			return filterRecurse
 		})
 	}
 

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -8,6 +8,8 @@ package resource
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strings"
 )
 
 type Type struct {
@@ -80,10 +82,10 @@ type Patch struct {
 }
 
 func (f Field) ValueString() string {
-	value := f.Value
-	if value == nil {
-		return ""
-	}
+	return valueString(f.Value)
+}
+
+func valueString(value any) string {
 	for {
 		unwrapped, ok := value.(interface{ Unwrap() any })
 		if !ok {
@@ -91,10 +93,34 @@ func (f Field) ValueString() string {
 		}
 		value = unwrapped.Unwrap()
 	}
-	if str, ok := value.(fmt.Stringer); ok {
-		return str.String()
+	if value, ok := value.(fmt.Stringer); ok {
+		return value.String()
 	}
-	return fmt.Sprintf("%v", value)
+
+	if value == nil {
+		return "<nil>"
+	}
+
+	v := reflect.ValueOf(value)
+	switch v.Kind() {
+	case reflect.String:
+		return v.String()
+	case reflect.Slice, reflect.Array:
+		var result []string
+		for i := range v.Len() {
+			result = append(result, valueString(v.Index(i).Interface()))
+		}
+		return "[" + strings.Join(result, " ") + "]"
+	case reflect.Map:
+		var result []string
+		for _, key := range v.MapKeys() {
+			val := v.MapIndex(key)
+			result = append(result, fmt.Sprintf("%s:%s", valueString(key.Interface()), valueString(val.Interface())))
+		}
+		return "{" + strings.Join(result, " ") + "}"
+	default:
+		return fmt.Sprintf("%v", value)
+	}
 }
 
 type FieldVerbosity int

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -60,6 +60,7 @@ type Field struct {
 	Elem *Field `json:"elem,omitempty"`
 
 	// display settings
+	Empty     bool           `json:"empty,omitempty"`
 	Verbosity FieldVerbosity `json:"verbosity"`
 	Hyperlink string         `json:"hyperlink,omitempty"`
 

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -126,7 +126,8 @@ func valueString(value any) string {
 type FieldVerbosity int
 
 const (
-	FieldVerbosityHidden FieldVerbosity = iota
+	FieldVerbosityInvisible FieldVerbosity = iota
+	FieldVerbosityHidden
 	FieldVerbosityLong
 	FieldVerbosityShort
 )
@@ -136,6 +137,8 @@ func (v FieldVerbosity) String() string {
 		v = FieldVerbosityHidden
 	}
 	switch v {
+	case FieldVerbosityInvisible:
+		return "invisible"
 	case FieldVerbosityHidden:
 		return "hidden"
 	case FieldVerbosityLong:

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -22,8 +22,6 @@ type Resource interface {
 	Key() string
 	Fields() ([]Field, error)
 	Raw() any
-
-	// TODO: link to other resources, e.g. instance -> image
 }
 
 type GettableResource interface {
@@ -47,6 +45,11 @@ type DeletableResource interface {
 	Delete(ctx context.Context, targets []Resource) error
 }
 
+type Link struct {
+	Type string
+	Key  string
+}
+
 type Field struct {
 	// Name is the name of the field
 	Name string `json:"name"`
@@ -58,6 +61,8 @@ type Field struct {
 	// Elem is used to indicate that all subfields have the same substructure
 	// (e.g. for arrays)
 	Elem *Field `json:"elem,omitempty"`
+
+	Links []Link `json:"links,omitempty"`
 
 	// display settings
 	Empty     bool           `json:"empty,omitempty"`
@@ -71,6 +76,15 @@ type Field struct {
 
 func (f Field) HasChildren() bool {
 	return len(f.Subfields) > 0 || f.Elem != nil
+}
+
+func (f Field) Get(name string) (Field, bool) {
+	for _, subfield := range f.Subfields {
+		if subfield.Name == name {
+			return subfield, true
+		}
+	}
+	return Field{}, false
 }
 
 type Patch struct {

--- a/internal/resource/resource_helpers.go
+++ b/internal/resource/resource_helpers.go
@@ -5,8 +5,20 @@
 
 package resource
 
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+)
+
 // CloneFields creates a deep copy of the given slice of Fields.
 func CloneFields(fields []Field) []Field {
+	if fields == nil {
+		return nil
+	}
 	result := make([]Field, 0, len(fields))
 	for _, field := range fields {
 		newField := field
@@ -16,25 +28,23 @@ func CloneFields(fields []Field) []Field {
 	return result
 }
 
-// MergeFields merges the src slice of Fields into the dest slice of Fields.
-// If a field with the same Name exists in both slices, their Subfields are
-// merged recursively.
-func MergeFields(dest []Field, src []Field) []Field {
-	destMap := make(map[string]*Field)
-	for i := range dest {
-		field := &dest[i]
-		destMap[field.Name] = field
-	}
-
-	for _, srcField := range src {
-		if destField, ok := destMap[srcField.Name]; ok {
-			destField.Subfields = MergeFields(destField.Subfields, srcField.Subfields)
+func DedupeFields(fields []Field) []Field {
+	seen := make(map[string]int)
+	result := make([]Field, 0, len(fields))
+	for _, field := range fields {
+		if idx, ok := seen[field.Name]; ok {
+			result[idx].Subfields = DedupeFields(append(result[idx].Subfields, field.Subfields...))
 		} else {
-			dest = append(dest, srcField)
+			seen[field.Name] = len(result)
+			result = append(result, field)
 		}
 	}
+	return result
+}
 
-	return dest
+// MergeFields merges the src slice of Fields into the dest slice of Fields.
+func MergeFields(dest []Field, src []Field) []Field {
+	return append(slices.Clone(dest), src...)
 }
 
 // RemoveFields removes fields from the dest slice of Fields based on the
@@ -50,10 +60,12 @@ func RemoveFields(dest []Field, remove []Field) []Field {
 	for _, destField := range dest {
 		if removeField, ok := removeMap[destField.Name]; ok {
 			if len(removeField.Subfields) == 0 {
+				// this field matches exactly, to remove it
 				continue
 			}
 			destField.Subfields = RemoveFields(destField.Subfields, removeField.Subfields)
-			if len(destField.Subfields) == 0 {
+			if len(destField.Subfields) == 0 && destField.Value == nil {
+				// this field has no remaining children or value, to remove it
 				continue
 			}
 		}
@@ -63,45 +75,197 @@ func RemoveFields(dest []Field, remove []Field) []Field {
 	return result
 }
 
-// fieldsToMap converts a slice of Fields into a map[string]any suitable for
+// FieldsToMap converts a slice of Fields into a map[string]any suitable for
 // marshaling into YAML or JSON.
+func FieldsToMap(fields []Field) map[string]any {
+	return fieldsToMap(fields)
+}
+
+func fieldToValue(field Field) any {
+	if field.Elem != nil {
+		return fieldsToSlice(field.Subfields)
+	}
+	if len(field.Subfields) > 0 {
+		return fieldsToMap(field.Subfields)
+	}
+	return field.Value
+}
+
 func fieldsToMap(fields []Field) map[string]any {
 	result := make(map[string]any, len(fields))
 	for _, field := range fields {
-		if len(field.Subfields) > 0 {
-			result[field.Name] = fieldsToMap(field.Subfields)
-		} else {
-			result[field.Name] = field.Value
-		}
+		result[field.Name] = fieldToValue(field)
 	}
 	return result
 }
 
+func fieldsToSlice(fields []Field) []any {
+	result := make([]any, 0, len(fields))
+	for _, field := range fields {
+		result = append(result, fieldToValue(field))
+	}
+	return result
+}
+
+// MapToFields converts a map[string]any into a slice of Fields, it loads into
+// the field Value.
+func MapToFields(fields []Field, m map[string]any) ([]Field, []FieldPath, error) {
+	return mapToFields(fields, m)
+}
+
+func valueToField(field *Field, val any) (*Field, []FieldPath, error) {
+	fieldClone := *field
+	field = &fieldClone
+
+	var unknown []FieldPath
+
+	if field.Value != nil {
+		field.Value = reflect.New(reflect.TypeOf(field.Value)).Elem().Interface()
+		decoderConfig := mapstructure.DecoderConfig{
+			DecodeHook: mapstructure.StringToTimeHookFunc(time.RFC3339),
+			Result:     &field.Value,
+		}
+		decoder, err := mapstructure.NewDecoder(&decoderConfig)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create decoder for field %q: %w", field.Name, err)
+		}
+		err = decoder.Decode(val)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to decode value %v for field %q: %w", val, field.Name, err)
+		}
+	}
+
+	if field.Elem != nil {
+		var valSlice []any
+		if val != nil {
+			var ok bool
+			valSlice, ok = val.([]any)
+			if !ok {
+				return nil, nil, fmt.Errorf("expected slice for field %s, got %T", field.Name, val)
+			}
+		}
+		subfields, fieldUnknown, err := slicesToFields(field.Elem, valSlice)
+		if err != nil {
+			return nil, nil, err
+		}
+		field.Subfields = subfields
+		unknown = fieldUnknown
+	} else if len(field.Subfields) > 0 {
+		var valMap map[string]any
+		if val != nil {
+			var ok bool
+			valMap, ok = val.(map[string]any)
+			if !ok {
+				return nil, nil, fmt.Errorf("expected map for field %s, got %T", field.Name, val)
+			}
+		}
+		subfields, fieldUnknown, err := MapToFields(field.Subfields, valMap)
+		if err != nil {
+			return nil, nil, err
+		}
+		field.Subfields = subfields
+		unknown = fieldUnknown
+	}
+
+	for i := range unknown {
+		unknown[i] = append(FieldPath{field.Name}, unknown[i]...)
+	}
+	return field, unknown, nil
+}
+
+func mapToFields(fields []Field, m map[string]any) ([]Field, []FieldPath, error) {
+	fields = slices.Clone(fields)
+	used := map[string]struct{}{}
+	var unknown []FieldPath
+	for i, field := range fields {
+		val, ok := m[field.Name]
+		if !ok {
+			continue
+		}
+		field, fieldUnknown, err := valueToField(&field, val)
+		if err != nil {
+			return nil, nil, err
+		}
+		fields[i] = *field
+		unknown = append(unknown, fieldUnknown...)
+		used[field.Name] = struct{}{}
+	}
+	for key := range m {
+		if _, ok := used[key]; !ok {
+			unknown = append(unknown, FieldPath{key})
+		}
+	}
+	return fields, unknown, nil
+}
+
+func slicesToFields(elem *Field, vals []any) ([]Field, []FieldPath, error) {
+	if len(vals) == 0 {
+		return nil, nil, nil
+	}
+	fields := make([]Field, 0, len(vals))
+	var unknown []FieldPath
+	for i, val := range vals {
+		elem := *elem
+		elem.Name = fmt.Sprintf("%d", i)
+		field, fieldUnknown, err := valueToField(&elem, val)
+		if err != nil {
+			return nil, nil, err
+		}
+		fields = append(fields, *field)
+		unknown = append(unknown, fieldUnknown...)
+	}
+	return fields, unknown, nil
+}
+
+type filterResult int
+
+const (
+	filterExclude filterResult = iota
+	filterInclude
+	filterRecurse
+	filterPrune
+)
+
 // filterFields filters the given fields based on the provided predicate
 // function f. It recursively filters subfields as well.
-func filterFields(fields []Field, f func(Field) bool) []Field {
+func filterFields(fields []Field, f func(Field) filterResult) []Field {
 	if fields == nil {
 		return nil
 	}
 
 	result := make([]Field, 0, len(fields))
 	for _, field := range fields {
-		field.Subfields = filterFields(field.Subfields, f)
-		if len(field.Subfields) > 0 || f(field) {
-			result = append(result, field)
+		ff := f(field)
+		if ff == filterExclude {
+			continue
 		}
+		if ff == filterInclude {
+			result = append(result, field)
+			continue
+		}
+		field.Subfields = filterFields(field.Subfields, f)
+		if ff == filterPrune && len(field.Subfields) == 0 {
+			continue
+		}
+		result = append(result, field)
 	}
 	return result
 }
 
 func filterPatchableFields(fields []Field) []Field {
-	return filterFields(fields, func(field Field) bool {
-		return field.Patch != nil
+	return filterFields(fields, func(field Field) filterResult {
+		if field.Patch != nil {
+			return filterInclude
+		}
+		return filterPrune
 	})
 }
 
 func filterCreatableFields(fields []Field) []Field {
-	return filterFields(fields, func(field Field) bool {
-		return field.Create != nil
+	return filterFields(fields, func(field Field) filterResult {
+		if field.Create != nil {
+			return filterInclude
+		}
+		return filterPrune
 	})
 }

--- a/internal/resource/resource_helpers.go
+++ b/internal/resource/resource_helpers.go
@@ -9,10 +9,13 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
-	"time"
-
-	"github.com/mitchellh/mapstructure"
 )
+
+func CloneField(field Field) Field {
+	newField := field
+	newField.Subfields = CloneFields(field.Subfields)
+	return newField
+}
 
 // CloneFields creates a deep copy of the given slice of Fields.
 func CloneFields(fields []Field) []Field {
@@ -121,16 +124,7 @@ func valueToField(field *Field, val any) (*Field, []FieldPath, error) {
 
 	if field.Value != nil {
 		field.Value = reflect.New(reflect.TypeOf(field.Value)).Elem().Interface()
-		decoderConfig := mapstructure.DecoderConfig{
-			DecodeHook: mapstructure.StringToTimeHookFunc(time.RFC3339),
-			Result:     &field.Value,
-		}
-		decoder, err := mapstructure.NewDecoder(&decoderConfig)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create decoder for field %q: %w", field.Name, err)
-		}
-		err = decoder.Decode(val)
-		if err != nil {
+		if err := decodeStruct(val, &field.Value); err != nil {
 			return nil, nil, fmt.Errorf("failed to decode value %v for field %q: %w", val, field.Name, err)
 		}
 	}

--- a/internal/resource/resource_path.go
+++ b/internal/resource/resource_path.go
@@ -25,6 +25,22 @@ func ParseFieldPath(s string) FieldPath {
 	return FieldPath(parts)
 }
 
+func (fp FieldPath) Matches(spec FieldPath) bool {
+	if len(fp) != len(spec) {
+		return false
+	}
+	for i := range fp {
+		if spec[i] != "*" && fp[i] != spec[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (fp FieldPath) MatchesString(s string) bool {
+	return fp.Matches(ParseFieldPath(s))
+}
+
 func (fp FieldPath) String() string {
 	return strings.Join(fp, ".")
 }

--- a/internal/resource/resource_path.go
+++ b/internal/resource/resource_path.go
@@ -92,13 +92,17 @@ func FilterFieldsByPath(fields []Field, specs []FieldPath, strict bool) ([]Field
 }
 
 func filterFieldsByPath(field Field, specs []FieldPath, strict bool) (result Field, missing []FieldPath) {
+	if len(specs) == 0 {
+		if !strict {
+			field = mergeElem(field)
+		}
+		field = pruneFields(field)
+		return field, nil
+	}
+
 	result = field
 	result.Value = nil
 	result.Subfields = nil
-
-	if len(specs) == 0 {
-		return pruneFields(field), nil
-	}
 
 	for len(specs) > 0 {
 		// find the first "group" of specs with the same root
@@ -115,11 +119,14 @@ func filterFieldsByPath(field Field, specs []FieldPath, strict bool) (result Fie
 				// if we don't, then recursively include all subfields
 				if !strict && field.Elem != nil {
 					elem := *field.Elem
-					elem.Name = "*"
+					elem = mergeElem(elem)
 					elem = pruneFields(elem)
 					result.Subfields = append(result.Subfields, elem)
 				}
 				for _, subfield := range field.Subfields {
+					if !strict {
+						subfield = mergeElem(subfield)
+					}
 					subfield = pruneFields(subfield)
 					result.Subfields = append(result.Subfields, subfield)
 				}
@@ -180,6 +187,20 @@ func pruneFields(field Field) Field {
 	field.Subfields = slices.Clone(field.Subfields)
 	for i := range field.Subfields {
 		field.Subfields[i] = pruneFields(field.Subfields[i])
+	}
+	return field
+}
+
+func mergeElem(field Field) Field {
+	if field.Elem != nil {
+		elem := mergeElem(*field.Elem)
+		elem.Name = "*"
+		field.Elem = nil
+		field.Subfields = append(field.Subfields, elem)
+	}
+	field.Subfields = slices.Clone(field.Subfields)
+	for i := range field.Subfields {
+		field.Subfields[i] = mergeElem(field.Subfields[i])
 	}
 	return field
 }

--- a/internal/resource/resource_path.go
+++ b/internal/resource/resource_path.go
@@ -9,6 +9,8 @@ import (
 	"iter"
 	"slices"
 	"strings"
+
+	xslices "unikraft.com/cli/internal/x/slices"
 )
 
 // FieldPath represents a dot-separated path to a field in a resource.
@@ -35,18 +37,24 @@ func IterFields(fields []Field) iter.Seq2[FieldPath, *Field] {
 	}
 }
 
-func iterFields(path FieldPath, fields []Field, yield func(FieldPath, *Field) bool) {
+func iterFields(path FieldPath, fields []Field, yield func(FieldPath, *Field) bool) bool {
 	for i := range fields {
 		field := &fields[i]
 		path := append(slices.Clone(path), field.Name)
 		if !yield(path, field) {
-			return
+			return false
 		}
-		iterFields(path, field.Subfields, yield)
+		if !iterFields(path, field.Subfields, yield) {
+			return false
+		}
 	}
+	return true
 }
 
 // GetFieldByPath retrieves all fields matching the given FieldPath.
+//
+// It can be used similarly to FilterFieldsByPath, but instead of retaining the
+// structure, it flattens the result to contain only the matching fields.
 func GetFieldByPath(fields []Field, spec FieldPath) []Field {
 	return getFieldByPath(nil, fields, spec)
 }
@@ -60,7 +68,7 @@ func getFieldByPath(parent *Field, fields []Field, spec FieldPath) []Field {
 	for _, field := range fields {
 		if spec[0] == field.Name || spec[0] == "*" && parent != nil && parent.Elem != nil {
 			if len(spec) == 1 {
-				result = append(result, field)
+				result = append(result, pruneFields(field))
 			} else {
 				subfields := getFieldByPath(&field, field.Subfields, spec[1:])
 				result = append(result, subfields...)
@@ -80,130 +88,98 @@ func FilterFieldsByPath(fields []Field, specs []FieldPath, strict bool) ([]Field
 	field, missing := filterFieldsByPath(Field{
 		Subfields: fields,
 	}, specs, strict)
-	return field.Subfields, missing
+	return field.Subfields, xslices.DedupeStringer(missing)
 }
 
 func filterFieldsByPath(field Field, specs []FieldPath, strict bool) (result Field, missing []FieldPath) {
+	result = field
+	result.Value = nil
+	result.Subfields = nil
+
 	if len(specs) == 0 {
-		return field, nil
-	}
-
-	// make a map to track found keys (to avoid duplicates)
-	foundKeys := make(map[string]int)
-
-	// remove all the fully matched specs
-	originalLen := len(specs)
-	specs = slices.Clone(specs)
-	specs = slices.DeleteFunc(specs, func(fp FieldPath) bool {
-		return len(fp) == 0
-	})
-	if len(specs) == 0 {
-		return field, nil
-	}
-	if len(specs) < originalLen {
-		for _, field := range field.Subfields {
-			if _, ok := foundKeys[field.Name]; ok {
-				continue
-			}
-			foundKeys[field.Name] = len(result.Subfields)
-			result.Subfields = append(result.Subfields, field)
-		}
-
-		// keep going - we want to find missing keys
+		return pruneFields(field), nil
 	}
 
 	for len(specs) > 0 {
 		// find the first "group" of specs with the same root
-		target, rest := specs[:1], specs[1:]
-		for i := 0; i < len(rest); {
-			if len(rest[i]) > 0 && len(target[0]) > 0 && rest[i][0] == target[0][0] {
-				target = append(target, rest[i])
-				rest = append(rest[:i], rest[i+1:]...)
+		target, rest := slices.Clone(specs[:1]), slices.Clone(specs[1:])
+		specs = rest
+
+		// check for an exact match
+		if len(target[0]) == 0 {
+			if field.Value != nil {
+				// if we have a value, then include only that, don't include subfields
+				// (we'll go grab those later)
+				result.Value = field.Value
 			} else {
-				i++
+				// if we don't, then recursively include all subfields
+				if !strict && field.Elem != nil {
+					elem := *field.Elem
+					elem.Name = "*"
+					elem = pruneFields(elem)
+					result.Subfields = append(result.Subfields, elem)
+				}
+				for _, subfield := range field.Subfields {
+					subfield = pruneFields(subfield)
+					result.Subfields = append(result.Subfields, subfield)
+				}
 			}
+			continue
 		}
 
 		spec := target[0][0]
 		for i := range target {
 			target[i] = target[i][1:]
 		}
-		specs = rest
 
-		// then find all fields matching the root of that group
+		// find all fields matching the root
 		matched := false
 		for _, subfield := range field.Subfields {
 			if spec == subfield.Name || spec == "*" && field.Elem != nil {
 				matched = true
-				filtered, missed := filterFieldsByPath(subfield, target, strict)
-
-				if idx, ok := foundKeys[subfield.Name]; ok {
-					field := &result.Subfields[idx]
-					mergeTopLevelField(field, &filtered)
-				} else {
-					subfield.Subfields = filtered.Subfields
-					foundKeys[subfield.Name] = len(result.Subfields)
-					result.Subfields = append(result.Subfields, subfield)
-				}
+				subfield, missed := filterFieldsByPath(subfield, target, strict)
+				result.Subfields = append(result.Subfields, subfield)
 
 				for _, miss := range missed {
 					missing = append(missing, append(FieldPath{spec}, miss...))
 				}
 			}
 		}
-		if matched {
-			continue
-		}
 
-		// try matching against the element type
+		// filter the elem to the root as well (if it exists)
 		if !strict && field.Elem != nil {
-			filtered, missed := filterFieldsByPath(*field.Elem, target, strict)
-			if idx, ok := foundKeys[field.Elem.Name]; ok {
-				field := &result.Subfields[idx]
-				mergeTopLevelField(field, &filtered)
-			} else {
-				subfield := *field.Elem
-				subfield.Name = spec
-				subfield.Subfields = filtered.Subfields
-				foundKeys[field.Elem.Name] = len(result.Subfields)
+			subfield, missed := filterFieldsByPath(*field.Elem, target, strict)
+			if !strict {
+				matched = true
+				subfield.Name = spec // NOTE: override the name
 				result.Subfields = append(result.Subfields, subfield)
-			}
 
-			for _, miss := range missed {
-				missing = append(missing, append(FieldPath{spec}, miss...))
+				for _, miss := range missed {
+					missing = append(missing, append(FieldPath{spec}, miss...))
+				}
 			}
-
-			continue
 		}
 
-		missing = append(missing, FieldPath{spec})
+		if !matched {
+			missing = append(missing, FieldPath{spec})
+		}
 	}
 
-	field.Subfields = result.Subfields
-	return field, missing
+	return result, missing
 }
 
-func mergeTopLevelField(dest *Field, src *Field) {
-	dest.Subfields = append(dest.Subfields, slices.DeleteFunc(slices.Clone(src.Subfields), func(f Field) bool {
-		for _, existing := range dest.Subfields {
-			if f.Name == existing.Name {
-				return true
-			}
-		}
-		return false
-	})...)
-}
-
-func mergeFieldElems(field Field) Field {
+func pruneFields(field Field) Field {
+	if field.Elem != nil {
+		elem := pruneFields(*field.Elem)
+		field.Elem = &elem
+	}
+	if field.Value != nil {
+		field.Subfields = nil
+		return field
+	}
 	field.Subfields = slices.Clone(field.Subfields)
-	if field.Elem != nil && len(field.Subfields) == 0 {
-		elem := *field.Elem
-		elem.Name = "*"
-		field.Subfields = append(field.Subfields, elem)
-		field.Elem = nil
-	}
 	for i := range field.Subfields {
-		field.Subfields[i] = mergeFieldElems(field.Subfields[i])
+		field.Subfields[i] = pruneFields(field.Subfields[i])
 	}
 	return field
 }

--- a/internal/resource/sandbox.go
+++ b/internal/resource/sandbox.go
@@ -148,14 +148,45 @@ func (s *Sandbox) Teardown(ctx context.Context) (rerr error) {
 	return rerr
 }
 
-func (s *Sandbox) Add(r Resource) {
+func (s *Sandbox) Add(ctx context.Context, r Resource) error {
 	if s == nil {
-		return
+		return nil
 	}
 	if _, ok := s.Keys[r.Type().Name]; !ok {
-		return
+		return nil
 	}
 	s.Keys[r.Type().Name][r.Key()] = struct{}{}
+
+	fields, err := r.Fields()
+	if err != nil {
+		return fmt.Errorf("failed to get fields for resource %s: %w", r.Key(), err)
+	}
+	for _, field := range IterFields(fields) {
+		for _, link := range field.Links {
+			for _, r := range s.Cleanup {
+				if r.Type().Name != link.Type {
+					continue
+				}
+
+				r, ok := r.(GettableResource)
+				if !ok {
+					continue
+				}
+				linkedResources, err := r.Get(ctx, []string{link.Key})
+				if err != nil {
+					return fmt.Errorf("failed to get linked resource %s %s: %w", link.Type, link.Key, err)
+				}
+				for _, linkedResource := range linkedResources {
+					if err := s.Add(ctx, linkedResource); err != nil {
+						return err
+					}
+				}
+				break
+			}
+		}
+	}
+
+	return nil
 }
 
 func (s *Sandbox) Remove(r Resource) {
@@ -299,8 +330,7 @@ func (r sandboxedCreatableResource) Create(ctx context.Context, fields []Field) 
 	if err != nil {
 		return nil, err
 	}
-	r.sandbox.Add(res)
-	return res, nil
+	return res, r.sandbox.Add(ctx, res)
 }
 
 type sandboxedDeletableResource struct {

--- a/internal/resource/struct.go
+++ b/internal/resource/struct.go
@@ -73,6 +73,8 @@ func fieldFromStruct(pkgPath string, v reflect.Value) (field *Field, err error) 
 			Value: fieldVal.Interface(),
 		}
 		switch {
+		case slices.Contains(opts, "invisible"):
+			result.Verbosity = FieldVerbosityInvisible
 		case slices.Contains(opts, "hidden"):
 			result.Verbosity = FieldVerbosityHidden
 		case slices.Contains(opts, "short"):

--- a/internal/resource/struct.go
+++ b/internal/resource/struct.go
@@ -17,28 +17,38 @@ import (
 // FieldsFromStruct is a helper that converts a struct into a slice of Fields
 // based on the `field` tags defined on the struct's fields.
 func FieldsFromStruct(s any) (fields []Field, err error) {
-	field, err := fieldFromStruct(reflect.ValueOf(s), true)
+	field, err := fieldFromStruct("", reflect.ValueOf(s))
 	if err != nil {
 		return nil, err
 	}
 	return field.Subfields, nil
 }
 
-func fieldFromStruct(v reflect.Value, topLevel bool) (field *Field, err error) {
-	if v.Kind() == reflect.Pointer {
-		if v.IsNil() {
-			v = reflect.New(v.Type().Elem())
-		} else {
-			v = v.Elem()
+type valueField interface {
+	String() string
+	Parse(s string) error
+}
+
+func fieldFromStruct(pkgPath string, v reflect.Value) (field *Field, err error) {
+	s := v
+	if s.Kind() == reflect.Pointer {
+		if s.IsNil() {
+			v2 := reflect.New(s.Type().Elem())
+			s = v2
 		}
+		s = s.Elem()
 	}
-	if v.Kind() != reflect.Struct {
+	if s.Kind() != reflect.Struct {
 		return nil, nil
 	}
-	if !topLevel && v.Type().Name() != "" {
+	t := s.Type()
+
+	if pkgPath == "" {
+		pkgPath = s.Type().PkgPath()
+	}
+	if t.PkgPath() != "" && t.PkgPath() != pkgPath {
 		return nil, nil
 	}
-	t := v.Type()
 
 	var fields []Field
 	for i := range t.NumField() {
@@ -46,7 +56,7 @@ func fieldFromStruct(v reflect.Value, topLevel bool) (field *Field, err error) {
 		if !field.IsExported() {
 			continue
 		}
-		fieldVal := v.Field(i)
+		fieldVal := s.Field(i)
 
 		name := field.Tag.Get("field")
 		if name == "-" {
@@ -62,29 +72,33 @@ func fieldFromStruct(v reflect.Value, topLevel bool) (field *Field, err error) {
 			Name:  name,
 			Value: fieldVal.Interface(),
 		}
-		if slices.Contains(opts, "short") {
-			result.Verbosity = max(result.Verbosity, FieldVerbosityShort)
-		}
-		if slices.Contains(opts, "long") {
-			result.Verbosity = max(result.Verbosity, FieldVerbosityLong)
+		switch {
+		case slices.Contains(opts, "hidden"):
+			result.Verbosity = FieldVerbosityHidden
+		case slices.Contains(opts, "short"):
+			result.Verbosity = FieldVerbosityShort
+		case slices.Contains(opts, "long"):
+			result.Verbosity = FieldVerbosityLong
+		default:
+			result.Verbosity = FieldVerbosityHidden
 		}
 
-		newField, err := fieldFromStruct(fieldVal, false)
+		newField, err := fieldFromStruct(pkgPath, fieldVal)
 		if err != nil {
 			return nil, err
 		}
 		if newField != nil {
-			result.Value = nil
+			result.Value = newField.Value
 			result.Subfields = newField.Subfields
 			result.Verbosity = max(result.Verbosity, newField.Verbosity)
 		}
 
-		newField, err = fieldFromSlice(fieldVal)
+		newField, err = fieldFromSlice(pkgPath, fieldVal)
 		if err != nil {
 			return nil, err
 		}
 		if newField != nil {
-			result.Value = nil
+			result.Value = newField.Value
 			result.Elem = newField.Elem
 			result.Subfields = newField.Subfields
 			result.Verbosity = max(result.Verbosity, newField.Verbosity)
@@ -93,17 +107,23 @@ func fieldFromStruct(v reflect.Value, topLevel bool) (field *Field, err error) {
 		fields = append(fields, result)
 	}
 
-	verbosity := FieldVerbosityHidden
+	var value any
+	if valueField, ok := v.Interface().(valueField); ok {
+		value = valueField
+	}
+
+	verbosity := FieldVerbosity(0)
 	for _, f := range fields {
 		verbosity = max(verbosity, f.Verbosity)
 	}
 	return &Field{
+		Value:     value,
 		Subfields: fields,
 		Verbosity: verbosity,
 	}, nil
 }
 
-func fieldFromSlice(v reflect.Value) (field *Field, err error) {
+func fieldFromSlice(pkgPath string, v reflect.Value) (field *Field, err error) {
 	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			v = reflect.New(v.Type().Elem())
@@ -117,7 +137,7 @@ func fieldFromSlice(v reflect.Value) (field *Field, err error) {
 
 	elemType := v.Type().Elem()
 	elemVal := reflect.New(elemType).Elem()
-	elem, err := fieldFromStruct(elemVal, false)
+	elem, err := fieldFromStruct(pkgPath, elemVal)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +148,7 @@ func fieldFromSlice(v reflect.Value) (field *Field, err error) {
 	var fields []Field
 	for i := range v.Len() {
 		vv := v.Index(i)
-		field, err := fieldFromStruct(vv, false)
+		field, err := fieldFromStruct(pkgPath, vv)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/resource/struct.go
+++ b/internal/resource/struct.go
@@ -10,8 +10,10 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ettle/strcase"
+	"github.com/mitchellh/mapstructure"
 )
 
 // FieldsFromStruct is a helper that converts a struct into a slice of Fields
@@ -58,31 +60,14 @@ func fieldFromStruct(pkgPath string, v reflect.Value) (field *Field, err error) 
 		}
 		fieldVal := s.Field(i)
 
-		name := field.Tag.Get("field")
-		if name == "-" {
+		parsedField := parseField(field)
+		if parsedField == nil {
 			continue
 		}
-		opts := strings.Split(name, ",")
-		name, opts = opts[0], opts[1:]
-		if name == "" {
-			name = field.Name
-			name = strcase.ToKebab(name)
-		}
 		result := Field{
-			Name:  name,
-			Value: fieldVal.Interface(),
-		}
-		switch {
-		case slices.Contains(opts, "invisible"):
-			result.Verbosity = FieldVerbosityInvisible
-		case slices.Contains(opts, "hidden"):
-			result.Verbosity = FieldVerbosityHidden
-		case slices.Contains(opts, "short"):
-			result.Verbosity = FieldVerbosityShort
-		case slices.Contains(opts, "long"):
-			result.Verbosity = FieldVerbosityLong
-		default:
-			result.Verbosity = FieldVerbosityHidden
+			Name:      parsedField.name,
+			Verbosity: parsedField.verbosity,
+			Value:     fieldVal.Interface(),
 		}
 
 		newField, err := fieldFromStruct(pkgPath, fieldVal)
@@ -166,4 +151,64 @@ func fieldFromSlice(pkgPath string, v reflect.Value) (field *Field, err error) {
 		Subfields: fields,
 		Verbosity: elem.Verbosity,
 	}, nil
+}
+
+type parsedField struct {
+	name      string
+	verbosity FieldVerbosity
+}
+
+func parseField(field reflect.StructField) *parsedField {
+	if !field.IsExported() {
+		return nil
+	}
+	tag := field.Tag.Get("field")
+	if tag == "-" {
+		return nil
+	}
+
+	opts := strings.Split(tag, ",")
+	name, opts := opts[0], opts[1:]
+	if name == "" {
+		name = field.Name
+		name = strcase.ToKebab(name)
+	}
+
+	var verbosity FieldVerbosity
+	switch {
+	case slices.Contains(opts, "invisible"):
+		verbosity = FieldVerbosityInvisible
+	case slices.Contains(opts, "hidden"):
+		verbosity = FieldVerbosityHidden
+	case slices.Contains(opts, "short"):
+		verbosity = FieldVerbosityShort
+	case slices.Contains(opts, "long"):
+		verbosity = FieldVerbosityLong
+	default:
+		verbosity = FieldVerbosityHidden
+	}
+
+	return &parsedField{
+		name:      name,
+		verbosity: verbosity,
+	}
+}
+
+// HACK: avoid use of this method, and prefer using the info available directly
+// on the Field - this function makes heavy assumptions about the structure of
+// field data and how values are read/written. Currently it is only used for
+// visual editing.
+func decodeStruct(input any, output any) error {
+	config := mapstructure.DecoderConfig{
+		TagName:     "field",
+		ErrorUnused: true,
+		Result:      output,
+		// TODO: more hooks probably needed
+		DecodeHook: mapstructure.StringToTimeHookFunc(time.RFC3339),
+	}
+	decoder, err := mapstructure.NewDecoder(&config)
+	if err != nil {
+		return err
+	}
+	return decoder.Decode(input)
 }

--- a/internal/resource/struct.go
+++ b/internal/resource/struct.go
@@ -68,6 +68,7 @@ func fieldFromStruct(pkgPath string, v reflect.Value) (field *Field, err error) 
 			Name:      parsedField.name,
 			Verbosity: parsedField.verbosity,
 			Value:     fieldVal.Interface(),
+			Empty:     fieldVal.IsZero(),
 		}
 
 		newField, err := fieldFromStruct(pkgPath, fieldVal)
@@ -150,6 +151,7 @@ func fieldFromSlice(pkgPath string, v reflect.Value) (field *Field, err error) {
 		Elem:      elem,
 		Subfields: fields,
 		Verbosity: elem.Verbosity,
+		Empty:     len(fields) == 0,
 	}, nil
 }
 

--- a/internal/resource/visual.go
+++ b/internal/resource/visual.go
@@ -6,30 +6,33 @@
 package resource
 
 import (
-	"errors"
+	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"reflect"
+	"slices"
 
 	"github.com/mitchellh/mapstructure"
 	"sigs.k8s.io/yaml"
 	"unikraft.com/cli/internal/config"
+	"unikraft.com/x/log"
 )
 
-func VisualEdit(cfg *config.Config, fields []Field, patches []Field) ([]Field, error) {
-	return visualEdit(cfg, fields, patches, false)
+func VisualEdit(ctx context.Context, cfg *config.Config, fields []Field, patches []Field) ([]Field, error) {
+	return visualEdit(ctx, cfg, fields, patches, false)
 }
 
-func VisualCreate(cfg *config.Config, fields []Field, creates []Field) ([]Field, error) {
-	return visualEdit(cfg, fields, creates, true)
+func VisualCreate(ctx context.Context, cfg *config.Config, fields []Field, creates []Field) ([]Field, error) {
+	return visualEdit(ctx, cfg, fields, creates, true)
 }
 
 // visualEdit opens an editor for the user to modify fields visually.
 //
 // It takes all the fields and already existing patched fields as input, and
 // returns all patched fields after editing.
-func visualEdit(cfg *config.Config, fields []Field, patches []Field, create bool) ([]Field, error) {
+func visualEdit(ctx context.Context, cfg *config.Config, fields []Field, patches []Field, create bool) ([]Field, error) {
 	data, err := saveFields(fields, patches, create)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize fields: %w", err)
@@ -54,7 +57,7 @@ func visualEdit(cfg *config.Config, fields []Field, patches []Field, create bool
 		return nil, err
 	}
 
-	cmd := exec.Command(editor, tmpfile.Name())
+	cmd := exec.CommandContext(ctx, editor, tmpfile.Name())
 	cmd.Stdin = cfg.Stdin
 	cmd.Stdout = cfg.Stdout
 	cmd.Stderr = cfg.Stderr
@@ -66,8 +69,12 @@ func visualEdit(cfg *config.Config, fields []Field, patches []Field, create bool
 	if err != nil {
 		return nil, fmt.Errorf("failed to read edited file: %w", err)
 	}
+	editedData = bytes.TrimSpace(editedData)
+	if len(editedData) == 0 {
+		return nil, fmt.Errorf("edited data is empty")
+	}
 
-	fields, err = loadFieldPatches(fields, editedData, create)
+	fields, err = loadFieldPatches(ctx, fields, editedData, create)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deserialize edited fields: %w", err)
 	}
@@ -75,32 +82,55 @@ func visualEdit(cfg *config.Config, fields []Field, patches []Field, create bool
 }
 
 func saveFields(fields []Field, patches []Field, create bool) ([]byte, error) {
-	patchMap := make(map[string]any)
+	fields = CloneFields(fields)
+
+	patchMap := make(map[string]Field)
 	for key, field := range IterFields(patches) {
+		patchMap[key.String()] = *field
+	}
+
+	for key, field := range IterFields(fields) {
 		keyStr := key.String()
+
 		var patch *Patch
 		if create {
 			patch = field.Create
 		} else {
 			patch = field.Patch
 		}
-		if patch == nil {
-			return nil, fmt.Errorf("cannot visual edit field %s with no patch", keyStr)
-		}
-		if patch.Add != nil {
-			return nil, fmt.Errorf("cannot visual edit field %s with Add patch", keyStr)
-		}
-		if patch.Del != nil {
-			return nil, fmt.Errorf("cannot visual edit field %s with Del patch", keyStr)
-		}
-		if patch.Set == nil {
+		if patch == nil || patch.Set == nil {
 			continue
 		}
 
-		if !reflect.TypeOf(patch.Set).AssignableTo(reflect.TypeOf(field.Value)) {
-			return nil, fmt.Errorf("patch set type for field %s is not assignable to value type", field.Name)
+		// verify that the patch set type is assignable to the value type
+		value, err := collectValue(*field, reflect.TypeOf(patch.Set))
+		if err != nil {
+			return nil, fmt.Errorf("failed to collect value for field %s: %w", keyStr, err)
 		}
-		patchMap[keyStr] = patch.Set
+		// TODO: instead of relying on patch.Set and field.Value being the same
+		// type, we should have each Resource store the actual patch.Set content
+		// (not just the type-info). Then patching should only update the
+		// patch.Set, and never actually touch the Value.
+		if !reflect.TypeOf(value).AssignableTo(reflect.TypeOf(patch.Set)) {
+			return nil, fmt.Errorf("%s of value %T cannot be patched with %T", keyStr, value, patch.Set)
+		}
+
+		// write already set patches into fields
+		if patchedField, ok := patchMap[keyStr]; ok {
+			var patch *Patch
+			if create {
+				patch = patchedField.Create
+			} else {
+				patch = patchedField.Patch
+			}
+			if patch == nil || patch.Set == nil {
+				return nil, fmt.Errorf("%s is not settable", keyStr)
+			}
+			if !reflect.TypeOf(value).AssignableTo(reflect.TypeOf(patch.Set)) {
+				return nil, fmt.Errorf("%s of value %T cannot be patched with %T", keyStr, value, patch.Set)
+			}
+			field.Value = patch.Set
+		}
 	}
 
 	var patchableFields []Field
@@ -109,17 +139,27 @@ func saveFields(fields []Field, patches []Field, create bool) ([]byte, error) {
 	} else {
 		patchableFields = filterPatchableFields(fields)
 	}
-	for key, field := range IterFields(patchableFields) {
-		keyStr := key.String()
-		if val, ok := patchMap[keyStr]; ok {
-			field.Value = val
-		}
+	result, err := yaml.Marshal(FieldsToMap(patchableFields))
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal fields to YAML: %w", err)
 	}
-	obj := fieldsToMap(patchableFields)
-	return yaml.Marshal(obj)
+
+	result = append(result, []byte("\n# Edit the fields above. Lines starting with '#' will be ignored.\n#")...)
+	result = append(result, []byte("\n# Original:\n")...)
+
+	rest, err := yaml.Marshal(FieldsToMap(fields))
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal fields to YAML: %w", err)
+	}
+	for line := range bytes.Lines(rest) {
+		result = append(result, []byte("#\t")...)
+		result = append(result, line...)
+	}
+
+	return result, nil
 }
 
-func loadFieldPatches(fields []Field, data []byte, create bool) ([]Field, error) {
+func loadFieldPatches(ctx context.Context, fields []Field, data []byte, create bool) ([]Field, error) {
 	fields = CloneFields(fields)
 
 	var obj map[string]any
@@ -127,61 +167,160 @@ func loadFieldPatches(fields []Field, data []byte, create bool) ([]Field, error)
 		return nil, fmt.Errorf("failed to unmarshal edited data: %w", err)
 	}
 
-	var forbiddenFields []string
-
-	for key, field := range IterFields(fields) {
-		if field.HasChildren() {
-			continue
-		}
-
-		var patch *Patch
-		if create {
-			patch = field.Create
-			field.Create = nil
-		} else {
-			patch = field.Patch
-			field.Patch = nil
-		}
-
-		result, ok := mapdig(obj, key...)
-		if !ok {
-			continue
-		}
-		if patch == nil || patch.Set == nil {
-			forbiddenFields = append(forbiddenFields, key.String())
-			continue
-		}
-
-		newValue := reflect.New(reflect.TypeOf(field.Value))
-		err := mapstructure.Decode(result, newValue.Interface())
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode field %s: %w", key, err)
-		}
-
-		if reflect.DeepEqual(field.Value, newValue.Elem().Interface()) {
-			continue
-		}
-
-		patch = &Patch{Set: newValue.Elem().Interface()}
-		if create {
-			field.Create = patch
-		} else {
-			field.Patch = patch
-		}
+	patchedFields, missing, err := MapToFields(fields, obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to map edited data to fields: %w", err)
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("unknown fields: %v", missing)
 	}
 
-	var err error
-	if len(forbiddenFields) > 0 {
-		err = errors.Join(err, fmt.Errorf("fields not settable: %v", forbiddenFields))
-	}
+	before := Field{Subfields: fields}
+	after := Field{Subfields: patchedFields}
+	err = patchField(FieldPath{}, &before, &after, create)
 	if err != nil {
 		return nil, err
 	}
 
-	if create {
-		return filterCreatableFields(fields), nil
+	for fieldPath, field := range IterFields(fields) {
+		var patch *Patch
+		if create {
+			patch = field.Create
+		} else {
+			patch = field.Patch
+		}
+		if patch == nil || patch.Set == nil {
+			continue
+		}
+		value, err := collectValue(*field, reflect.TypeOf(patch.Set))
+		if err != nil {
+			return nil, fmt.Errorf("failed to collect value for field %s: %w", fieldPath.String(), err)
+		}
+		log.G(ctx).
+			Debug().
+			Str("field", fieldPath.String()).
+			Any("old", value).
+			Any("new", patch.Set).
+			Msg("patched field")
 	}
-	return filterPatchableFields(fields), nil
+
+	if create {
+		fields = filterCreatableFields(fields)
+	} else {
+		fields = filterPatchableFields(fields)
+	}
+	return fields, nil
+}
+
+// patchField applies the changes from after to before, modifying before in
+// place by setting Patch fields.
+func patchField(path FieldPath, before *Field, after *Field, create bool) error {
+	var patch *Patch
+	if create {
+		patch = before.Create
+	} else {
+		patch = before.Patch
+	}
+
+	if before.Name != after.Name {
+		return fmt.Errorf("field name changed from %s to %s at %s", before.Name, after.Name, path.String())
+	}
+	if len(before.Subfields) != len(after.Subfields) {
+		return fmt.Errorf("number of subfields changed for field %s", path.String())
+	}
+
+	if !reflect.DeepEqual(before.Value, after.Value) {
+		if patch == nil {
+			return fmt.Errorf("no patch available for field %s", path.String())
+		}
+		if patch.Set == nil {
+			return fmt.Errorf("field %s is not settable", path.String())
+		}
+		if !reflect.TypeOf(after.Value).AssignableTo(reflect.TypeOf(patch.Set)) {
+			return fmt.Errorf("cannot assign value of type %T to patch of type %T for field %s", after.Value, patch.Set, path.String())
+		}
+		patch.Set = after.Value
+	} else if before.Elem != nil && !reflect.DeepEqual(before.Subfields, after.Subfields) {
+		if patch == nil {
+			return fmt.Errorf("no patch available for field %s", path.String())
+		}
+		if patch.Set == nil {
+			return fmt.Errorf("field %s is not settable", path.String())
+		}
+		original, err := collectValue(*before, reflect.TypeOf(patch.Set))
+		if err != nil {
+			return fmt.Errorf("failed to collect value for field %s: %w", path.String(), err)
+		}
+		next, err := collectValue(*after, reflect.TypeOf(patch.Set))
+		if err != nil {
+			return fmt.Errorf("failed to collect value for field %s: %w", path.String(), err)
+		}
+		if reflect.DeepEqual(original, next) {
+			return fmt.Errorf("subfields of field %s changed but collected value is the same", path.String())
+		}
+		patch.Set = next
+	} else {
+		patch = nil
+		for i := range before.Subfields {
+			before := &before.Subfields[i]
+			after := &after.Subfields[i]
+			path := append(slices.Clone(path), before.Name)
+			err := patchField(path, before, after, create)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if create {
+		before.Create = patch
+	} else {
+		before.Patch = patch
+	}
+
+	return nil
+}
+
+func collectValue(field Field, into reflect.Type) (any, error) {
+	v, err := collectValueRaw(field)
+	if err != nil {
+		return nil, err
+	}
+	target := reflect.New(into).Elem().Interface()
+	err = mapstructure.Decode(v, &target)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode value into type %s: %w", into.String(), err)
+	}
+	return target, nil
+}
+
+func collectValueRaw(field Field) (any, error) {
+	if field.Value != nil {
+		return field.Value, nil
+	}
+	if field.Elem != nil {
+		sl := make([]any, 0, len(field.Subfields))
+		for _, subfield := range field.Subfields {
+			elemValue, err := collectValueRaw(subfield)
+			if err != nil {
+				return nil, err
+			}
+			sl = append(sl, elemValue)
+		}
+		return sl, nil
+	}
+	if len(field.Subfields) > 0 {
+		m := make(map[string]any, len(field.Subfields))
+		for _, subfield := range field.Subfields {
+			subfieldValue, err := collectValueRaw(subfield)
+			if err != nil {
+				return nil, err
+			}
+			m[subfield.Name] = subfieldValue
+		}
+		return m, nil
+	}
+	return nil, fmt.Errorf("field has no value")
 }
 
 func getEditor() (string, error) {
@@ -192,21 +331,4 @@ func getEditor() (string, error) {
 		return editor, nil
 	}
 	return "", fmt.Errorf("no editor set: please set $VISUAL or $EDITOR")
-}
-
-func mapdig(m map[string]any, keys ...string) (any, bool) {
-	var current any = m
-
-	for _, key := range keys {
-		currentMap, ok := current.(map[string]any)
-		if !ok {
-			return nil, false
-		}
-		current, ok = currentMap[key]
-		if !ok {
-			return nil, false
-		}
-	}
-
-	return current, true
 }

--- a/internal/resource/visual.go
+++ b/internal/resource/visual.go
@@ -14,7 +14,6 @@ import (
 	"reflect"
 	"slices"
 
-	"github.com/mitchellh/mapstructure"
 	"sigs.k8s.io/yaml"
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/x/log"
@@ -123,13 +122,22 @@ func saveFields(fields []Field, patches []Field, create bool) ([]byte, error) {
 			} else {
 				patch = patchedField.Patch
 			}
-			if patch == nil || patch.Set == nil {
+			if patch == nil {
+				return nil, fmt.Errorf("no patch available for field %s", keyStr)
+			}
+			if patch.Add != nil {
+				return nil, fmt.Errorf("%s was added, but visual editing does not support this", keyStr)
+			}
+			if patch.Del != nil {
+				return nil, fmt.Errorf("%s was deleted, but visual editing does not support this", keyStr)
+			}
+			if patch.Set == nil {
 				return nil, fmt.Errorf("%s is not settable", keyStr)
 			}
-			if !reflect.TypeOf(value).AssignableTo(reflect.TypeOf(patch.Set)) {
-				return nil, fmt.Errorf("%s of value %T cannot be patched with %T", keyStr, value, patch.Set)
+			err := storeValue(field, reflect.ValueOf(patch.Set))
+			if err != nil {
+				return nil, fmt.Errorf("failed to store patched value for field %s: %w", keyStr, err)
 			}
-			field.Value = patch.Set
 		}
 	}
 
@@ -225,9 +233,6 @@ func patchField(path FieldPath, before *Field, after *Field, create bool) error 
 	if before.Name != after.Name {
 		return fmt.Errorf("field name changed from %s to %s at %s", before.Name, after.Name, path.String())
 	}
-	if len(before.Subfields) != len(after.Subfields) {
-		return fmt.Errorf("number of subfields changed for field %s", path.String())
-	}
 
 	if !reflect.DeepEqual(before.Value, after.Value) {
 		if patch == nil {
@@ -260,7 +265,9 @@ func patchField(path FieldPath, before *Field, after *Field, create bool) error 
 		}
 		patch.Set = next
 	} else {
-		patch = nil
+		if len(before.Subfields) != len(after.Subfields) {
+			return fmt.Errorf("number of subfields changed for field %s", path.String())
+		}
 		for i := range before.Subfields {
 			before := &before.Subfields[i]
 			after := &after.Subfields[i]
@@ -270,6 +277,7 @@ func patchField(path FieldPath, before *Field, after *Field, create bool) error 
 				return err
 			}
 		}
+		patch = nil
 	}
 
 	if create {
@@ -279,48 +287,6 @@ func patchField(path FieldPath, before *Field, after *Field, create bool) error 
 	}
 
 	return nil
-}
-
-func collectValue(field Field, into reflect.Type) (any, error) {
-	v, err := collectValueRaw(field)
-	if err != nil {
-		return nil, err
-	}
-	target := reflect.New(into).Elem().Interface()
-	err = mapstructure.Decode(v, &target)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode value into type %s: %w", into.String(), err)
-	}
-	return target, nil
-}
-
-func collectValueRaw(field Field) (any, error) {
-	if field.Value != nil {
-		return field.Value, nil
-	}
-	if field.Elem != nil {
-		sl := make([]any, 0, len(field.Subfields))
-		for _, subfield := range field.Subfields {
-			elemValue, err := collectValueRaw(subfield)
-			if err != nil {
-				return nil, err
-			}
-			sl = append(sl, elemValue)
-		}
-		return sl, nil
-	}
-	if len(field.Subfields) > 0 {
-		m := make(map[string]any, len(field.Subfields))
-		for _, subfield := range field.Subfields {
-			subfieldValue, err := collectValueRaw(subfield)
-			if err != nil {
-				return nil, err
-			}
-			m[subfield.Name] = subfieldValue
-		}
-		return m, nil
-	}
-	return nil, fmt.Errorf("field has no value")
 }
 
 func getEditor() (string, error) {

--- a/internal/x/slices/slices.go
+++ b/internal/x/slices/slices.go
@@ -5,6 +5,11 @@
 
 package slices
 
+import (
+	"fmt"
+	"iter"
+)
+
 // Flatten flattens a slice of slices into a single slice.
 func Flatten[T any](slices [][]T) []T {
 	total := 0
@@ -14,6 +19,43 @@ func Flatten[T any](slices [][]T) []T {
 	result := make([]T, 0, total)
 	for _, slice := range slices {
 		result = append(result, slice...)
+	}
+	return result
+}
+
+// Collect2 collects an iter.Seq2 into two slices.
+func Collect2[A any, B any](iter iter.Seq2[A, B]) (as []A, bs []B) {
+	for k, v := range iter {
+		as = append(as, k)
+		bs = append(bs, v)
+	}
+	return as, bs
+}
+
+// Dedupe removes duplicate elements from a slice while preserving order.
+func Dedupe[T comparable](slice []T) []T {
+	seen := make(map[T]struct{})
+	result := make([]T, 0, len(slice))
+	for _, item := range slice {
+		if _, ok := seen[item]; !ok {
+			seen[item] = struct{}{}
+			result = append(result, item)
+		}
+	}
+	return result
+}
+
+// DedupeStringer removes duplicate elements from a slice of fmt.Stringer while
+// preserving order.
+func DedupeStringer[T fmt.Stringer](slice []T) []T {
+	seen := make(map[string]struct{})
+	result := make([]T, 0, len(slice))
+	for _, item := range slice {
+		str := item.String()
+		if _, ok := seen[str]; !ok {
+			seen[str] = struct{}{}
+			result = append(result, item)
+		}
 	}
 	return result
 }


### PR DESCRIPTION
This is a big yak shave for `unikraft run`:

- Started with `unikraft instance create`
- Realized we needed to be able to attach to a service group
- Currently cannot create a service group, because we can't patch the list of `Services`, so it can't actually expose anything.
- So scaled back to working on `unikraft service edit` (and `unikraft service create` later)

This all kind of culimates in: [![asciicast](https://asciinema.org/a/MDmU8dsa0YOvVpe2.svg)](https://asciinema.org/a/MDmU8dsa0YOvVpe2)

There's a *lot* in here. But the main bit is that we now support editing list fields, as well as working with fields that contain both values + children (e.g. the new `Service` type that can be referred to in shorthand `<src>:<dest>/<handler>`).