### PR TITLE
refactor: Split resource package and add basic command tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/juju/ansiterm v1.0.0
 	github.com/juju/errors v1.0.0
 	github.com/lunixbochs/vtclean v1.0.0
+	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/muesli/termenv v0.16.0
 	github.com/opencontainers/go-digest v1.0.0
@@ -63,7 +64,6 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
-	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/internal/cmd/certificates.go
+++ b/internal/cmd/certificates.go
@@ -17,13 +17,14 @@ import (
 	"unikraft.com/cli/internal/mirror"
 	"unikraft.com/cli/internal/multimetro"
 	"unikraft.com/cli/internal/resource"
+	"unikraft.com/cli/internal/resource/cmd"
 	xslices "unikraft.com/cli/internal/x/slices"
 )
 
 type CertificatesCmd struct {
-	resource.ResourceCmd[Certificate]          `set:"name=certificate" set:"names=certificates"`
-	resource.DeletableResourceCmd[Certificate] `set:"name=certificate" set:"names=certificates"`
-	resource.CreatableResourceCmd[Certificate] `set:"name=certificate" set:"names=certificates"`
+	cmd.ResourceCmd[Certificate]          `set:"name=certificate" set:"names=certificates"`
+	cmd.DeletableResourceCmd[Certificate] `set:"name=certificate" set:"names=certificates"`
+	cmd.CreatableResourceCmd[Certificate] `set:"name=certificate" set:"names=certificates"`
 }
 
 type Certificate struct {

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -20,11 +20,12 @@ import (
 	"unikraft.com/cli/internal/mirror"
 	"unikraft.com/cli/internal/multimetro"
 	"unikraft.com/cli/internal/resource"
+	"unikraft.com/cli/internal/resource/cmd"
 	xslices "unikraft.com/cli/internal/x/slices"
 )
 
 type ImagesCmd struct {
-	resource.ResourceCmd[Image] `set:"name=image" set:"names=images"`
+	cmd.ResourceCmd[Image] `set:"name=image" set:"names=images"`
 }
 
 type Image struct {

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -22,13 +22,14 @@ import (
 	"unikraft.com/cli/internal/mirror"
 	"unikraft.com/cli/internal/multimetro"
 	"unikraft.com/cli/internal/resource"
+	"unikraft.com/cli/internal/resource/cmd"
 	xslices "unikraft.com/cli/internal/x/slices"
 )
 
 type InstancesCmd struct {
-	resource.ResourceCmd[Instance]          `set:"name=instance" set:"names=instances"`
-	resource.DeletableResourceCmd[Instance] `set:"name=instance" set:"names=instances"`
-	resource.EditableResourceCmd[Instance]  `set:"name=instance" set:"names=instances"`
+	cmd.ResourceCmd[Instance]          `set:"name=instance" set:"names=instances"`
+	cmd.DeletableResourceCmd[Instance] `set:"name=instance" set:"names=instances"`
+	cmd.EditableResourceCmd[Instance]  `set:"name=instance" set:"names=instances"`
 
 	Logs    InstancesLogsCmd    `cmd:"" help:"Fetch and display instance logs"`
 	Start   InstancesStartCmd   `cmd:"" help:"Start one or more instances"`

--- a/internal/cmd/metros.go
+++ b/internal/cmd/metros.go
@@ -14,10 +14,11 @@ import (
 
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/resource"
+	"unikraft.com/cli/internal/resource/cmd"
 )
 
 type MetrosCmd struct {
-	resource.ResourceCmd[Metro] `set:"name=metro" set:"names=metros"`
+	cmd.ResourceCmd[Metro] `set:"name=metro" set:"names=metros"`
 }
 
 type Metro struct {

--- a/internal/cmd/profile.go
+++ b/internal/cmd/profile.go
@@ -15,11 +15,12 @@ import (
 	jujuerrors "github.com/juju/errors"
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/resource"
+	"unikraft.com/cli/internal/resource/cmd"
 	"unikraft.com/x/log"
 )
 
 type ProfileCmd struct {
-	resource.ResourceCmd[Profile] `set:"name=profile" set:"names=profiles"`
+	cmd.ResourceCmd[Profile] `set:"name=profile" set:"names=profiles"`
 
 	Use UseCmd `cmd:"" help:"Switch between profiles."`
 }

--- a/internal/cmd/services.go
+++ b/internal/cmd/services.go
@@ -19,14 +19,15 @@ import (
 	"unikraft.com/cli/internal/mirror"
 	"unikraft.com/cli/internal/multimetro"
 	"unikraft.com/cli/internal/resource"
+	"unikraft.com/cli/internal/resource/cmd"
 	xslices "unikraft.com/cli/internal/x/slices"
 )
 
 type ServicesCmd struct {
-	resource.ResourceCmd[ServiceGroup]          `set:"name=service" set:"names=services"`
-	resource.DeletableResourceCmd[ServiceGroup] `set:"name=service" set:"names=services"`
-	resource.EditableResourceCmd[ServiceGroup]  `set:"name=service" set:"names=services"`
-	resource.CreatableResourceCmd[ServiceGroup] `set:"name=service" set:"names=services"`
+	cmd.ResourceCmd[ServiceGroup]          `set:"name=service" set:"names=services"`
+	cmd.DeletableResourceCmd[ServiceGroup] `set:"name=service" set:"names=services"`
+	cmd.EditableResourceCmd[ServiceGroup]  `set:"name=service" set:"names=services"`
+	cmd.CreatableResourceCmd[ServiceGroup] `set:"name=service" set:"names=services"`
 }
 
 type ServiceGroup struct {

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -17,14 +17,15 @@ import (
 	"unikraft.com/cli/internal/mirror"
 	"unikraft.com/cli/internal/multimetro"
 	"unikraft.com/cli/internal/resource"
+	"unikraft.com/cli/internal/resource/cmd"
 	xslices "unikraft.com/cli/internal/x/slices"
 )
 
 type VolumesCmd struct {
-	resource.ResourceCmd[Volume]          `set:"name=volume" set:"names=volumes"`
-	resource.DeletableResourceCmd[Volume] `set:"name=volume" set:"names=volumes"`
-	resource.EditableResourceCmd[Volume]  `set:"name=volume" set:"names=volumes"`
-	resource.CreatableResourceCmd[Volume] `set:"name=volume" set:"names=volumes"`
+	cmd.ResourceCmd[Volume]          `set:"name=volume" set:"names=volumes"`
+	cmd.DeletableResourceCmd[Volume] `set:"name=volume" set:"names=volumes"`
+	cmd.EditableResourceCmd[Volume]  `set:"name=volume" set:"names=volumes"`
+	cmd.CreatableResourceCmd[Volume] `set:"name=volume" set:"names=volumes"`
 }
 
 type Volume struct {

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -3,7 +3,7 @@
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
 
-package resource
+package cmd
 
 import (
 	"bytes"
@@ -19,19 +19,21 @@ import (
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/kvwriter"
 	"unikraft.com/cli/internal/prettydiff"
+	"unikraft.com/cli/internal/resource"
+	"unikraft.com/cli/internal/resource/patch"
 )
 
-type ResourceCmd[R GettableResource] struct {
+type ResourceCmd[R resource.GettableResource] struct {
 	List ResourceListCmd[R]    `cmd:"" help:"List ${names}." aliases:"ls"`
 	Get  ResourceInspectCmd[R] `cmd:"" help:"Inspect a ${name}." aliases:"inspect,show"`
 }
-type DeletableResourceCmd[R DeletableResource] struct {
+type DeletableResourceCmd[R resource.DeletableResource] struct {
 	Delete ResourceRemoveCmd[R] `cmd:"" help:"Remove a ${name}." aliases:"rm,remove"`
 }
-type EditableResourceCmd[R EditableResource] struct {
+type EditableResourceCmd[R resource.EditableResource] struct {
 	Edit ResourceEditCmd[R] `cmd:"" help:"Edit a ${name}."`
 }
-type CreatableResourceCmd[R CreatableResource] struct {
+type CreatableResourceCmd[R resource.CreatableResource] struct {
 	Create ResourceCreateCmd[R] `cmd:"" help:"Create a ${name}."`
 }
 
@@ -51,7 +53,7 @@ type FormatOpts struct {
 	Raw    bool   `help:"Output raw JSON API response."`
 }
 
-type ResourceListCmd[R GettableResource] struct {
+type ResourceListCmd[R resource.GettableResource] struct {
 	Name []string `arg:"" optional:"" help:"Names of the ${names} to list."`
 
 	FormatOpts
@@ -61,16 +63,16 @@ func (cmd *ResourceListCmd[R]) Help() string {
 	return "Lister"
 }
 
-func (cmd *ResourceListCmd[R]) Run(ctx context.Context, cfg *config.Config, sandbox *Sandbox) error {
+func (cmd *ResourceListCmd[R]) Run(ctx context.Context, cfg *config.Config, sandbox *resource.Sandbox) error {
 	filter, err := filters.ParseAll(cmd.Filter...)
 	if err != nil {
 		return err
 	}
-	ctx = WithFilter(ctx, filter)
+	ctx = resource.WithFilter(ctx, filter)
 
 	var empty R
 	r := sandbox.WrapGettable(empty)
-	var resources []Resource
+	var resources []resource.Resource
 	if len(cmd.Name) > 0 {
 		resources, err = r.Get(ctx, cmd.Name)
 	} else {
@@ -97,18 +99,18 @@ func (cmd *ResourceListCmd[R]) Run(ctx context.Context, cfg *config.Config, sand
 	}
 }
 
-type ResourceInspectCmd[R GettableResource] struct {
+type ResourceInspectCmd[R resource.GettableResource] struct {
 	Name []string `arg:"" help:"Names of the ${names} to inspect."`
 
 	FormatOpts
 }
 
-func (cmd *ResourceInspectCmd[R]) Run(ctx context.Context, cfg *config.Config, sandbox *Sandbox) error {
+func (cmd *ResourceInspectCmd[R]) Run(ctx context.Context, cfg *config.Config, sandbox *resource.Sandbox) error {
 	filter, err := filters.ParseAll(cmd.Filter...)
 	if err != nil {
 		return err
 	}
-	ctx = WithFilter(ctx, filter)
+	ctx = resource.WithFilter(ctx, filter)
 
 	var empty R
 	r := sandbox.WrapGettable(empty)
@@ -134,17 +136,17 @@ func (cmd *ResourceInspectCmd[R]) Run(ctx context.Context, cfg *config.Config, s
 	}
 }
 
-func filterResources(resources []Resource, filter filters.Filter) (filtered []Resource, rerr error) {
-	for _, resource := range resources {
+func filterResources(resources []resource.Resource, filter filters.Filter) (filtered []resource.Resource, rerr error) {
+	for _, res := range resources {
 		if filter.Match(filters.AdapterFunc(func(key []string) (string, bool) {
-			fields, err := resource.Fields()
+			fields, err := res.Fields()
 			if err != nil {
 				if rerr == nil {
-					rerr = fmt.Errorf("failed to get fields for resource %s: %w", resource.Key(), err)
+					rerr = fmt.Errorf("failed to get fields for resource %s: %w", res.Key(), err)
 				}
 				return "", false
 			}
-			fields = GetFieldByPath(fields, key)
+			fields = resource.GetFieldByPath(fields, key)
 			if fields == nil {
 				return "", false
 			}
@@ -156,17 +158,17 @@ func filterResources(resources []Resource, filter filters.Filter) (filtered []Re
 			// HACK: vtclean to remove any escape sequences from rendered output
 			return vtclean.Clean(fields[0].ValueString(), false), true
 		})) {
-			filtered = append(filtered, resource)
+			filtered = append(filtered, res)
 		}
 	}
 	return filtered, rerr
 }
 
-type ResourceRemoveCmd[R DeletableResource] struct {
+type ResourceRemoveCmd[R resource.DeletableResource] struct {
 	Name []string `arg:"" help:"Names of the ${names} to remove."`
 }
 
-func (cmd *ResourceRemoveCmd[R]) Run(ctx context.Context, sandbox *Sandbox) error {
+func (cmd *ResourceRemoveCmd[R]) Run(ctx context.Context, sandbox *resource.Sandbox) error {
 	var empty R
 	r := sandbox.WrapDeletable(empty)
 	resources, err := r.Get(ctx, cmd.Name)
@@ -176,7 +178,7 @@ func (cmd *ResourceRemoveCmd[R]) Run(ctx context.Context, sandbox *Sandbox) erro
 	return r.Delete(ctx, resources)
 }
 
-type ResourceEditCmd[R EditableResource] struct {
+type ResourceEditCmd[R resource.EditableResource] struct {
 	Name string `arg:"" help:"Name of the ${name} to edit."`
 
 	Set []map[string]string `help:"Key-value pairs to update the ${name} with." sep:"none" mapsep:"none"`
@@ -186,8 +188,8 @@ type ResourceEditCmd[R EditableResource] struct {
 	Visual bool `short:"e" help:"Open an editor to modify fields visually."`
 }
 
-func (cmd *ResourceEditCmd[R]) toPatchSpec() PatchSpec {
-	spec := PatchSpec{
+func (cmd *ResourceEditCmd[R]) toPatchSpec() patch.PatchSpec {
+	spec := patch.PatchSpec{
 		Set: make(map[string][]string),
 		Add: make(map[string][]string),
 		Del: make(map[string][]string),
@@ -210,7 +212,7 @@ func (cmd *ResourceEditCmd[R]) toPatchSpec() PatchSpec {
 	return spec
 }
 
-func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, cfg *config.Config, sandbox *Sandbox) error {
+func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, cfg *config.Config, sandbox *resource.Sandbox) error {
 	var empty R
 	r := sandbox.WrapEditable(empty)
 	resources, err := r.Get(ctx, []string{cmd.Name})
@@ -227,7 +229,7 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, cfg *config.Config, sand
 		}
 		return fmt.Errorf("ambiguous resource name: %s (found %v)", cmd.Name, keys)
 	}
-	resource := resources[0]
+	res := resources[0]
 
 	spec := cmd.toPatchSpec()
 
@@ -248,35 +250,35 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, cfg *config.Config, sand
 		}
 	}
 
-	fields, err := resource.Fields()
+	fields, err := res.Fields()
 	if err != nil {
 		return fmt.Errorf("failed to get fields: %w", err)
 	}
-	patched, err := PatchedFields(fields, spec)
+	patched, err := patch.PatchedFields(fields, spec)
 	if err != nil {
 		return err
 	}
 	if cmd.Visual {
-		patched, err = VisualEdit(ctx, cfg, fields, patched)
+		patched, err = patch.VisualEdit(ctx, cfg, fields, patched)
 		if err != nil {
 			return err
 		}
 	}
-	patched = filterPatchableFields(patched)
+	patched = patch.FilterPatchableFields(patched)
 
 	start := &bytes.Buffer{}
-	err = printKV(start, nil, resource)
+	err = printKV(start, nil, res)
 	if err != nil {
 		return err
 	}
 	if len(patched) > 0 {
-		resource, err = r.Edit(ctx, resource, patched)
+		res, err = r.Edit(ctx, res, patched)
 		if err != nil {
 			return err
 		}
 	}
 	end := &bytes.Buffer{}
-	err = printKV(end, nil, resource)
+	err = printKV(end, nil, res)
 	if err != nil {
 		return err
 	}
@@ -291,14 +293,14 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, cfg *config.Config, sand
 	return tw.Flush()
 }
 
-type ResourceCreateCmd[R CreatableResource] struct {
+type ResourceCreateCmd[R resource.CreatableResource] struct {
 	Set []map[string]string `help:"Key-value pairs for creating the ${name}." sep:"none" mapsep:"none"`
 
 	Visual bool `short:"e" help:"Open an editor to set fields visually."`
 }
 
-func (cmd *ResourceCreateCmd[R]) toPatchSpec() PatchSpec {
-	spec := PatchSpec{
+func (cmd *ResourceCreateCmd[R]) toPatchSpec() patch.PatchSpec {
+	spec := patch.PatchSpec{
 		Create: true,
 		Set:    make(map[string][]string),
 	}
@@ -310,31 +312,31 @@ func (cmd *ResourceCreateCmd[R]) toPatchSpec() PatchSpec {
 	return spec
 }
 
-func (cmd *ResourceCreateCmd[R]) Run(ctx context.Context, cfg *config.Config, sandbox *Sandbox) error {
+func (cmd *ResourceCreateCmd[R]) Run(ctx context.Context, cfg *config.Config, sandbox *resource.Sandbox) error {
 	var empty R
 	r := sandbox.WrapCreatable(empty)
 	fields, err := r.Fields()
 	if err != nil {
 		return fmt.Errorf("failed to get fields: %w", err)
 	}
-	patched, err := PatchedFields(fields, cmd.toPatchSpec())
+	patched, err := patch.PatchedFields(fields, cmd.toPatchSpec())
 	if err != nil {
 		return err
 	}
 
 	if cmd.Visual {
 		// FIXME: should allow required fields
-		patched, err = VisualCreate(ctx, cfg, fields, patched)
+		patched, err = patch.VisualCreate(ctx, cfg, fields, patched)
 		if err != nil {
 			return err
 		}
 	}
 
-	fields = filterCreatableFields(patched)
+	fields = patch.FilterCreatableFields(patched)
 
-	resource, err := r.Create(ctx, fields)
+	res, err := r.Create(ctx, fields)
 	if err != nil {
 		return err
 	}
-	return printInspect(cfg.Stdout, nil, resource)
+	return printInspect(cfg.Stdout, nil, res)
 }

--- a/internal/resource/cmd/cmd_test.go
+++ b/internal/resource/cmd/cmd_test.go
@@ -19,198 +19,466 @@ import (
 	"unikraft.com/cli/internal/resource"
 )
 
-func TestCommands(t *testing.T) {
+var baseTestStore = map[string]resource.Test{
+	"test1": {
+		ID:   "id-test1",
+		Name: "test1",
+		URL:  "https://example.com",
+		Settings: resource.TestSettings{
+			X: 42,
+			Y: "hello",
+		},
+		Authors: []resource.TestAuthor{
+			{Name: "Alice", Email: "alice@example.com"},
+			{Name: "Bob", Email: "bob@example.com"},
+		},
+	},
+	"test2": {
+		ID:   "id-test2",
+		Name: "test2",
+		URL:  "https://example.org",
+		Settings: resource.TestSettings{
+			X: 7,
+			Y: "world",
+		},
+		Authors: []resource.TestAuthor{
+			{Name: "Charlie", Email: "charlie@example.com"},
+			{Name: "Dana", Email: "dana@example.com"},
+		},
+	},
+}
+
+func TestList(t *testing.T) {
 	ctx := context.Background()
 	sandbox := &resource.Sandbox{}
 
-	baseTestStore := map[string]resource.Test{
-		"test1": {
-			Name: "test1",
+	cloned, err := copystructure.Copy(baseTestStore)
+	require.NoError(t, err)
+	resource.TestStore = cloned.(map[string]resource.Test)
+
+	var empty resource.Test
+	resources, err := empty.List(ctx)
+	require.NoError(t, err)
+	assert.Len(t, resources, 2)
+
+	var listOut bytes.Buffer
+	listCmd := &ResourceListCmd[resource.Test]{}
+	err = listCmd.Run(ctx, testConfig(&listOut), sandbox)
+	require.NoError(t, err)
+
+	output := listOut.String()
+	assert.Contains(t, output, "test1")
+	assert.Contains(t, output, "test2")
+	assert.Contains(t, output, "id-test1")
+	assert.Contains(t, output, "id-test2")
+
+	t.Run("quiet", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := &ResourceListCmd[resource.Test]{
+			FormatOpts: FormatOpts{
+				Quiet: true,
+			},
+		}
+		err := cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+		assert.Equal(t, "test1\ntest2\n", out.String())
+
+		out.Reset()
+		cmd.Name = []string{"test2"}
+		err = cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+		assert.Equal(t, "test2\n", out.String())
+	})
+
+	t.Run("raw", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := &ResourceListCmd[resource.Test]{
+			FormatOpts: FormatOpts{
+				Raw: true,
+			},
+		}
+		err := cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+
+		output := out.String()
+		assert.Contains(t, output, `"Name": "test1"`)
+		assert.Contains(t, output, `"ID": "id-test1"`)
+
+		out.Reset()
+		cmd.Name = []string{"test1"}
+		err = cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+
+		output = out.String()
+		assert.Contains(t, output, `"Name": "test1"`)
+		assert.Contains(t, output, `"ID": "id-test1"`)
+		assert.NotContains(t, output, `"Name": "test2"`)
+	})
+
+	t.Run("format", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := &ResourceListCmd[resource.Test]{
+			FormatOpts: FormatOpts{
+				Format: "{{range .}}{{.name}}\n{{end}}",
+			},
+		}
+		err := cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+		assert.Equal(t, "test1\ntest2\n", out.String())
+
+		out.Reset()
+		cmd.Name = []string{"test2", "test1"}
+		err = cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+		assert.Equal(t, "test2\ntest1\n", out.String())
+	})
+
+	t.Run("field", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := &ResourceListCmd[resource.Test]{
+			FormatOpts: FormatOpts{
+				Field: []string{"name", "id"},
+			},
+		}
+		err := cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+
+		output := out.String()
+		assert.Contains(t, output, "test1")
+		assert.Contains(t, output, "id-test1")
+		assert.NotContains(t, output, "https://example.com")
+
+		out.Reset()
+		cmd.Name = []string{"test1"}
+		err = cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+
+		output = out.String()
+		assert.Contains(t, output, "test1")
+		assert.Contains(t, output, "id-test1")
+		assert.NotContains(t, output, "test2")
+	})
+
+	t.Run("filter", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := &ResourceListCmd[resource.Test]{
+			FormatOpts: FormatOpts{
+				Filter: []string{"name==test1"},
+			},
+		}
+		err := cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+
+		output := out.String()
+		assert.Contains(t, output, "test1")
+		assert.NotContains(t, output, "test2")
+
+		out.Reset()
+		cmd.Name = []string{"test1", "test2"}
+		err = cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+
+		output = out.String()
+		assert.Contains(t, output, "test1")
+		assert.NotContains(t, output, "test2")
+	})
+}
+
+func TestGet(t *testing.T) {
+	ctx := context.Background()
+	sandbox := &resource.Sandbox{}
+
+	cloned, err := copystructure.Copy(baseTestStore)
+	require.NoError(t, err)
+	resource.TestStore = cloned.(map[string]resource.Test)
+
+	var empty resource.Test
+	resources, err := empty.Get(ctx, []string{"test1"})
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+
+	test := resources[0].(resource.Test)
+	assert.Equal(t, "test1", test.Name)
+	assert.Equal(t, "id-test1", test.ID)
+	assert.Equal(t, 42, test.Settings.X)
+	assert.Equal(t, "hello", test.Settings.Y)
+
+	fields, err := test.Fields()
+	require.NoError(t, err)
+	assert.NotEmpty(t, fields)
+
+	var inspectOut bytes.Buffer
+	inspectCmd := &ResourceInspectCmd[resource.Test]{
+		Name: []string{"test1"},
+	}
+	err = inspectCmd.Run(ctx, testConfig(&inspectOut), sandbox)
+	require.NoError(t, err)
+
+	output := inspectOut.String()
+	assert.Contains(t, output, "test1")
+	assert.Contains(t, output, "id-test1")
+	assert.Contains(t, output, "https://example.com")
+
+	t.Run("no_args", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := &ResourceInspectCmd[resource.Test]{
+			Name: []string{},
+		}
+		err := cmd.Run(ctx, testConfig(&out), sandbox)
+		require.Error(t, err)
+	})
+
+	t.Run("multiple", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := &ResourceInspectCmd[resource.Test]{
+			Name: []string{"test1", "test2"},
+		}
+		err := cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+
+		output := out.String()
+		assert.Contains(t, output, "test1")
+		assert.Contains(t, output, "test2")
+		assert.Contains(t, output, "id-test1")
+		assert.Contains(t, output, "id-test2")
+	})
+
+	t.Run("quiet", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := &ResourceInspectCmd[resource.Test]{
+			Name: []string{"test1"},
+			FormatOpts: FormatOpts{
+				Quiet: true,
+			},
+		}
+		err := cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+		assert.Equal(t, "test1\n", out.String())
+
+		out.Reset()
+		cmd.Name = []string{"test2", "test1"}
+		err = cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+		assert.Equal(t, "test2\ntest1\n", out.String())
+	})
+
+	t.Run("raw", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := &ResourceInspectCmd[resource.Test]{
+			Name: []string{"test1"},
+			FormatOpts: FormatOpts{
+				Raw: true,
+			},
+		}
+		err := cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+
+		output := out.String()
+		assert.Contains(t, output, `"Name": "test1"`)
+		assert.Contains(t, output, `"ID": "id-test1"`)
+
+		out.Reset()
+		cmd.Name = []string{"test1", "test2"}
+		err = cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+
+		output = out.String()
+		assert.Contains(t, output, `"Name": "test1"`)
+		assert.Contains(t, output, `"ID": "id-test1"`)
+		assert.Contains(t, output, `"Name": "test2"`)
+		assert.Contains(t, output, `"ID": "id-test2"`)
+	})
+
+	t.Run("format", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := &ResourceInspectCmd[resource.Test]{
+			Name: []string{"test1"},
+			FormatOpts: FormatOpts{
+				Format: "{{range .}}{{.name}}: {{.url}}\n{{end}}",
+			},
+		}
+		err := cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+		assert.Equal(t, "test1: https://example.com\n", out.String())
+
+		out.Reset()
+		cmd.Name = []string{"test2", "test1"}
+		err = cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+		assert.Equal(t, "test2: https://example.org\ntest1: https://example.com\n", out.String())
+	})
+
+	t.Run("field", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := &ResourceInspectCmd[resource.Test]{
+			Name: []string{"test1"},
+			FormatOpts: FormatOpts{
+				Field: []string{"id", "url"},
+			},
+		}
+		err := cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+
+		output := out.String()
+		assert.Contains(t, output, "id-test1")
+		assert.Contains(t, output, "https://example.com")
+
+		out.Reset()
+		cmd.Name = []string{"test1", "test2"}
+		err = cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+
+		output = out.String()
+		assert.Contains(t, output, "id-test1")
+		assert.Contains(t, output, "https://example.com")
+		assert.Contains(t, output, "id-test2")
+		assert.Contains(t, output, "https://example.org")
+	})
+
+	t.Run("filter", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := &ResourceInspectCmd[resource.Test]{
+			Name: []string{"test1"},
+			FormatOpts: FormatOpts{
+				Filter: []string{"id==id-test1"},
+			},
+		}
+		err := cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+
+		output := out.String()
+		assert.Contains(t, output, "test1")
+
+		out.Reset()
+		cmd.Name = []string{"test1", "test2"}
+		err = cmd.Run(ctx, testConfig(&out), sandbox)
+		require.NoError(t, err)
+
+		output = out.String()
+		assert.Contains(t, output, "test1")
+		assert.NotContains(t, output, "test2")
+	})
+}
+
+func TestCreate(t *testing.T) {
+	ctx := context.Background()
+
+	resource.TestStore = map[string]resource.Test{}
+
+	var empty resource.Test
+	templateFields, err := empty.Fields()
+	require.NoError(t, err)
+
+	for key, field := range resource.IterFields(templateFields) {
+		if field.Create == nil {
+			continue
+		}
+		switch key.String() {
+		case "name":
+			field.Create.Set = "test-new"
+		case "settings.x":
+			field.Create.Set = 100
+		case "settings.y":
+			field.Create.Set = "created"
+		}
+	}
+
+	res, err := empty.Create(ctx, templateFields)
+	require.NoError(t, err)
+
+	created := res.(resource.Test)
+	assert.Equal(t, "test-new", created.Name)
+	assert.Equal(t, 100, created.Settings.X)
+	assert.Equal(t, "created", created.Settings.Y)
+	assert.Contains(t, resource.TestStore, "test-new")
+}
+
+func TestEdit(t *testing.T) {
+	ctx := context.Background()
+
+	editStore := map[string]resource.Test{
+		"test-edit": {
+			ID:   "id-edit",
+			Name: "test-edit",
 			URL:  "https://example.com",
 			Settings: resource.TestSettings{
-				X: 42,
-				Y: "hello",
-			},
-			Authors: []resource.TestAuthor{
-				{Name: "Alice", Email: "alice@example.com"},
-				{Name: "Bob", Email: "bob@example.com"},
-			},
-		},
-		"test2": {
-			Name: "test2",
-			URL:  "https://example.org",
-			Settings: resource.TestSettings{
-				X: 7,
-				Y: "world",
-			},
-			Authors: []resource.TestAuthor{
-				{Name: "Charlie", Email: "charlie@example.com"},
-				{Name: "Dana", Email: "dana@example.com"},
+				X: 10,
+				Y: "original",
 			},
 		},
 	}
+	cloned, err := copystructure.Copy(editStore)
+	require.NoError(t, err)
+	resource.TestStore = cloned.(map[string]resource.Test)
 
-	t.Run("list", func(t *testing.T) {
-		cloned, err := copystructure.Copy(baseTestStore)
-		require.NoError(t, err)
-		resource.TestStore = cloned.(map[string]resource.Test)
+	var empty resource.Test
+	resources, err := empty.Get(ctx, []string{"test-edit"})
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
 
-		var empty resource.Test
-		resources, err := empty.List(ctx)
-		require.NoError(t, err)
-		assert.Len(t, resources, 2)
+	target := resources[0]
+	templateFields, err := target.Fields()
+	require.NoError(t, err)
 
-		var listOut bytes.Buffer
-		listCmd := &ResourceListCmd[resource.Test]{}
-		err = listCmd.Run(ctx, testConfig(&listOut), sandbox)
-		require.NoError(t, err)
-
-		output := listOut.String()
-		assert.Contains(t, output, "test1")
-		assert.Contains(t, output, "test2")
-	})
-
-	t.Run("get", func(t *testing.T) {
-		cloned, err := copystructure.Copy(baseTestStore)
-		require.NoError(t, err)
-		resource.TestStore = cloned.(map[string]resource.Test)
-
-		var empty resource.Test
-		resources, err := empty.Get(ctx, []string{"test1"})
-		require.NoError(t, err)
-		require.Len(t, resources, 1)
-
-		test := resources[0].(resource.Test)
-		assert.Equal(t, "test1", test.Name)
-		assert.Equal(t, 42, test.Settings.X)
-		assert.Equal(t, "hello", test.Settings.Y)
-
-		fields, err := test.Fields()
-		require.NoError(t, err)
-		assert.NotEmpty(t, fields)
-
-		var inspectOut bytes.Buffer
-		inspectCmd := &ResourceInspectCmd[resource.Test]{
-			Name: []string{"test1"},
+	for key, field := range resource.IterFields(templateFields) {
+		if field.Patch == nil {
+			continue
 		}
-		err = inspectCmd.Run(ctx, testConfig(&inspectOut), sandbox)
-		require.NoError(t, err)
-
-		output := inspectOut.String()
-		assert.Contains(t, output, "test1")
-		assert.Contains(t, output, "https://example.com")
-	})
-
-	t.Run("create", func(t *testing.T) {
-		resource.TestStore = map[string]resource.Test{}
-
-		var empty resource.Test
-		templateFields, err := empty.Fields()
-		require.NoError(t, err)
-
-		for key, field := range resource.IterFields(templateFields) {
-			if field.Create == nil {
-				continue
-			}
-			switch key.String() {
-			case "name":
-				field.Create.Set = "test-new"
-			case "settings.x":
-				field.Create.Set = 100
-			case "settings.y":
-				field.Create.Set = "created"
-			}
+		switch key.String() {
+		case "settings.x":
+			field.Patch.Set = 999
+		case "settings.y":
+			field.Patch.Set = "modified"
 		}
+	}
 
-		res, err := empty.Create(ctx, templateFields)
-		require.NoError(t, err)
+	res, err := empty.Edit(ctx, target, templateFields)
+	require.NoError(t, err)
 
-		created := res.(resource.Test)
-		assert.Equal(t, "test-new", created.Name)
-		assert.Equal(t, 100, created.Settings.X)
-		assert.Equal(t, "created", created.Settings.Y)
-		assert.Contains(t, resource.TestStore, "test-new")
-	})
+	edited := res.(resource.Test)
+	assert.Equal(t, "test-edit", edited.Name)
+	assert.Equal(t, "id-edit", edited.ID)
+	assert.Equal(t, 999, edited.Settings.X)
+	assert.Equal(t, "modified", edited.Settings.Y)
 
-	t.Run("edit", func(t *testing.T) {
-		editStore := map[string]resource.Test{
-			"test-edit": {
-				Name: "test-edit",
-				URL:  "https://example.com",
-				Settings: resource.TestSettings{
-					X: 10,
-					Y: "original",
-				},
-			},
-		}
-		cloned, err := copystructure.Copy(editStore)
-		require.NoError(t, err)
-		resource.TestStore = cloned.(map[string]resource.Test)
+	stored := resource.TestStore["test-edit"]
+	assert.Equal(t, 999, stored.Settings.X)
+	assert.Equal(t, "modified", stored.Settings.Y)
+}
 
-		var empty resource.Test
-		resources, err := empty.Get(ctx, []string{"test-edit"})
-		require.NoError(t, err)
-		require.Len(t, resources, 1)
+func TestDelete(t *testing.T) {
+	ctx := context.Background()
 
-		target := resources[0]
-		templateFields, err := target.Fields()
-		require.NoError(t, err)
+	deleteStore := map[string]resource.Test{
+		"test-delete": {
+			ID:   "id-delete",
+			Name: "test-delete",
+			URL:  "https://example.com",
+		},
+		"test-keep": {
+			ID:   "id-keep",
+			Name: "test-keep",
+			URL:  "https://example.org",
+		},
+	}
+	cloned, err := copystructure.Copy(deleteStore)
+	require.NoError(t, err)
+	resource.TestStore = cloned.(map[string]resource.Test)
 
-		for key, field := range resource.IterFields(templateFields) {
-			if field.Patch == nil {
-				continue
-			}
-			switch key.String() {
-			case "settings.x":
-				field.Patch.Set = 999
-			case "settings.y":
-				field.Patch.Set = "modified"
-			}
-		}
+	var empty resource.Test
+	resources, err := empty.Get(ctx, []string{"test-delete"})
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
 
-		res, err := empty.Edit(ctx, target, templateFields)
-		require.NoError(t, err)
+	err = empty.Delete(ctx, resources)
+	require.NoError(t, err)
 
-		edited := res.(resource.Test)
-		assert.Equal(t, "test-edit", edited.Name)
-		assert.Equal(t, 999, edited.Settings.X)
-		assert.Equal(t, "modified", edited.Settings.Y)
+	assert.NotContains(t, resource.TestStore, "test-delete")
+	assert.Contains(t, resource.TestStore, "test-keep")
 
-		stored := resource.TestStore["test-edit"]
-		assert.Equal(t, 999, stored.Settings.X)
-		assert.Equal(t, "modified", stored.Settings.Y)
-	})
-
-	t.Run("delete", func(t *testing.T) {
-		deleteStore := map[string]resource.Test{
-			"test-delete": {
-				Name: "test-delete",
-				URL:  "https://example.com",
-			},
-			"test-keep": {
-				Name: "test-keep",
-				URL:  "https://example.org",
-			},
-		}
-		cloned, err := copystructure.Copy(deleteStore)
-		require.NoError(t, err)
-		resource.TestStore = cloned.(map[string]resource.Test)
-
-		var empty resource.Test
-		resources, err := empty.Get(ctx, []string{"test-delete"})
-		require.NoError(t, err)
-		require.Len(t, resources, 1)
-
-		err = empty.Delete(ctx, resources)
-		require.NoError(t, err)
-
-		assert.NotContains(t, resource.TestStore, "test-delete")
-		assert.Contains(t, resource.TestStore, "test-keep")
-
-		resources, err = empty.Get(ctx, []string{"test-delete"})
-		require.NoError(t, err)
-		assert.Empty(t, resources)
-	})
+	resources, err = empty.Get(ctx, []string{"test-delete"})
+	require.NoError(t, err)
+	assert.Empty(t, resources)
 }
 
 func testConfig(out io.Writer) *config.Config {

--- a/internal/resource/cmd/cmd_test.go
+++ b/internal/resource/cmd/cmd_test.go
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/mitchellh/copystructure"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"unikraft.com/cli/internal/config"
+	"unikraft.com/cli/internal/resource"
+)
+
+func TestCommands(t *testing.T) {
+	ctx := context.Background()
+	sandbox := &resource.Sandbox{}
+
+	baseTestStore := map[string]resource.Test{
+		"test1": {
+			Name: "test1",
+			URL:  "https://example.com",
+			Settings: resource.TestSettings{
+				X: 42,
+				Y: "hello",
+			},
+			Authors: []resource.TestAuthor{
+				{Name: "Alice", Email: "alice@example.com"},
+				{Name: "Bob", Email: "bob@example.com"},
+			},
+		},
+		"test2": {
+			Name: "test2",
+			URL:  "https://example.org",
+			Settings: resource.TestSettings{
+				X: 7,
+				Y: "world",
+			},
+			Authors: []resource.TestAuthor{
+				{Name: "Charlie", Email: "charlie@example.com"},
+				{Name: "Dana", Email: "dana@example.com"},
+			},
+		},
+	}
+
+	t.Run("list", func(t *testing.T) {
+		cloned, err := copystructure.Copy(baseTestStore)
+		require.NoError(t, err)
+		resource.TestStore = cloned.(map[string]resource.Test)
+
+		var empty resource.Test
+		resources, err := empty.List(ctx)
+		require.NoError(t, err)
+		assert.Len(t, resources, 2)
+
+		var listOut bytes.Buffer
+		listCmd := &ResourceListCmd[resource.Test]{}
+		err = listCmd.Run(ctx, testConfig(&listOut), sandbox)
+		require.NoError(t, err)
+
+		output := listOut.String()
+		assert.Contains(t, output, "test1")
+		assert.Contains(t, output, "test2")
+	})
+
+	t.Run("get", func(t *testing.T) {
+		cloned, err := copystructure.Copy(baseTestStore)
+		require.NoError(t, err)
+		resource.TestStore = cloned.(map[string]resource.Test)
+
+		var empty resource.Test
+		resources, err := empty.Get(ctx, []string{"test1"})
+		require.NoError(t, err)
+		require.Len(t, resources, 1)
+
+		test := resources[0].(resource.Test)
+		assert.Equal(t, "test1", test.Name)
+		assert.Equal(t, 42, test.Settings.X)
+		assert.Equal(t, "hello", test.Settings.Y)
+
+		fields, err := test.Fields()
+		require.NoError(t, err)
+		assert.NotEmpty(t, fields)
+
+		var inspectOut bytes.Buffer
+		inspectCmd := &ResourceInspectCmd[resource.Test]{
+			Name: []string{"test1"},
+		}
+		err = inspectCmd.Run(ctx, testConfig(&inspectOut), sandbox)
+		require.NoError(t, err)
+
+		output := inspectOut.String()
+		assert.Contains(t, output, "test1")
+		assert.Contains(t, output, "https://example.com")
+	})
+
+	t.Run("create", func(t *testing.T) {
+		resource.TestStore = map[string]resource.Test{}
+
+		var empty resource.Test
+		templateFields, err := empty.Fields()
+		require.NoError(t, err)
+
+		for key, field := range resource.IterFields(templateFields) {
+			if field.Create == nil {
+				continue
+			}
+			switch key.String() {
+			case "name":
+				field.Create.Set = "test-new"
+			case "settings.x":
+				field.Create.Set = 100
+			case "settings.y":
+				field.Create.Set = "created"
+			}
+		}
+
+		res, err := empty.Create(ctx, templateFields)
+		require.NoError(t, err)
+
+		created := res.(resource.Test)
+		assert.Equal(t, "test-new", created.Name)
+		assert.Equal(t, 100, created.Settings.X)
+		assert.Equal(t, "created", created.Settings.Y)
+		assert.Contains(t, resource.TestStore, "test-new")
+	})
+
+	t.Run("edit", func(t *testing.T) {
+		editStore := map[string]resource.Test{
+			"test-edit": {
+				Name: "test-edit",
+				URL:  "https://example.com",
+				Settings: resource.TestSettings{
+					X: 10,
+					Y: "original",
+				},
+			},
+		}
+		cloned, err := copystructure.Copy(editStore)
+		require.NoError(t, err)
+		resource.TestStore = cloned.(map[string]resource.Test)
+
+		var empty resource.Test
+		resources, err := empty.Get(ctx, []string{"test-edit"})
+		require.NoError(t, err)
+		require.Len(t, resources, 1)
+
+		target := resources[0]
+		templateFields, err := target.Fields()
+		require.NoError(t, err)
+
+		for key, field := range resource.IterFields(templateFields) {
+			if field.Patch == nil {
+				continue
+			}
+			switch key.String() {
+			case "settings.x":
+				field.Patch.Set = 999
+			case "settings.y":
+				field.Patch.Set = "modified"
+			}
+		}
+
+		res, err := empty.Edit(ctx, target, templateFields)
+		require.NoError(t, err)
+
+		edited := res.(resource.Test)
+		assert.Equal(t, "test-edit", edited.Name)
+		assert.Equal(t, 999, edited.Settings.X)
+		assert.Equal(t, "modified", edited.Settings.Y)
+
+		stored := resource.TestStore["test-edit"]
+		assert.Equal(t, 999, stored.Settings.X)
+		assert.Equal(t, "modified", stored.Settings.Y)
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		deleteStore := map[string]resource.Test{
+			"test-delete": {
+				Name: "test-delete",
+				URL:  "https://example.com",
+			},
+			"test-keep": {
+				Name: "test-keep",
+				URL:  "https://example.org",
+			},
+		}
+		cloned, err := copystructure.Copy(deleteStore)
+		require.NoError(t, err)
+		resource.TestStore = cloned.(map[string]resource.Test)
+
+		var empty resource.Test
+		resources, err := empty.Get(ctx, []string{"test-delete"})
+		require.NoError(t, err)
+		require.Len(t, resources, 1)
+
+		err = empty.Delete(ctx, resources)
+		require.NoError(t, err)
+
+		assert.NotContains(t, resource.TestStore, "test-delete")
+		assert.Contains(t, resource.TestStore, "test-keep")
+
+		resources, err = empty.Get(ctx, []string{"test-delete"})
+		require.NoError(t, err)
+		assert.Empty(t, resources)
+	})
+}
+
+func testConfig(out io.Writer) *config.Config {
+	return &config.Config{
+		Context: context.Background(),
+		Stdin:   &bytes.Buffer{},
+		Stdout:  out,
+		Stderr:  out,
+	}
+}

--- a/internal/resource/cmd/cmd_test.go
+++ b/internal/resource/cmd/cmd_test.go
@@ -17,18 +17,19 @@ import (
 
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/resource"
+	resourcet "unikraft.com/cli/internal/resource/testing"
 )
 
-var baseTestStore = map[string]resource.Test{
+var baseTestStore = map[string]resourcet.TestResource{
 	"test1": {
 		ID:   "id-test1",
 		Name: "test1",
 		URL:  "https://example.com",
-		Settings: resource.TestSettings{
+		Settings: resourcet.TestSettings{
 			X: 42,
 			Y: "hello",
 		},
-		Authors: []resource.TestAuthor{
+		Authors: []resourcet.TestAuthor{
 			{Name: "Alice", Email: "alice@example.com"},
 			{Name: "Bob", Email: "bob@example.com"},
 		},
@@ -37,11 +38,11 @@ var baseTestStore = map[string]resource.Test{
 		ID:   "id-test2",
 		Name: "test2",
 		URL:  "https://example.org",
-		Settings: resource.TestSettings{
+		Settings: resourcet.TestSettings{
 			X: 7,
 			Y: "world",
 		},
-		Authors: []resource.TestAuthor{
+		Authors: []resourcet.TestAuthor{
 			{Name: "Charlie", Email: "charlie@example.com"},
 			{Name: "Dana", Email: "dana@example.com"},
 		},
@@ -54,15 +55,15 @@ func TestList(t *testing.T) {
 
 	cloned, err := copystructure.Copy(baseTestStore)
 	require.NoError(t, err)
-	resource.TestStore = cloned.(map[string]resource.Test)
+	resourcet.TestStore = cloned.(map[string]resourcet.TestResource)
 
-	var empty resource.Test
+	var empty resourcet.TestResource
 	resources, err := empty.List(ctx)
 	require.NoError(t, err)
 	assert.Len(t, resources, 2)
 
 	var listOut bytes.Buffer
-	listCmd := &ResourceListCmd[resource.Test]{}
+	listCmd := &ResourceListCmd[resourcet.TestResource]{}
 	err = listCmd.Run(ctx, testConfig(&listOut), sandbox)
 	require.NoError(t, err)
 
@@ -74,7 +75,7 @@ func TestList(t *testing.T) {
 
 	t.Run("quiet", func(t *testing.T) {
 		var out bytes.Buffer
-		cmd := &ResourceListCmd[resource.Test]{
+		cmd := &ResourceListCmd[resourcet.TestResource]{
 			FormatOpts: FormatOpts{
 				Quiet: true,
 			},
@@ -92,7 +93,7 @@ func TestList(t *testing.T) {
 
 	t.Run("raw", func(t *testing.T) {
 		var out bytes.Buffer
-		cmd := &ResourceListCmd[resource.Test]{
+		cmd := &ResourceListCmd[resourcet.TestResource]{
 			FormatOpts: FormatOpts{
 				Raw: true,
 			},
@@ -117,7 +118,7 @@ func TestList(t *testing.T) {
 
 	t.Run("format", func(t *testing.T) {
 		var out bytes.Buffer
-		cmd := &ResourceListCmd[resource.Test]{
+		cmd := &ResourceListCmd[resourcet.TestResource]{
 			FormatOpts: FormatOpts{
 				Format: "{{range .}}{{.name}}\n{{end}}",
 			},
@@ -135,7 +136,7 @@ func TestList(t *testing.T) {
 
 	t.Run("field", func(t *testing.T) {
 		var out bytes.Buffer
-		cmd := &ResourceListCmd[resource.Test]{
+		cmd := &ResourceListCmd[resourcet.TestResource]{
 			FormatOpts: FormatOpts{
 				Field: []string{"name", "id"},
 			},
@@ -161,7 +162,7 @@ func TestList(t *testing.T) {
 
 	t.Run("filter", func(t *testing.T) {
 		var out bytes.Buffer
-		cmd := &ResourceListCmd[resource.Test]{
+		cmd := &ResourceListCmd[resourcet.TestResource]{
 			FormatOpts: FormatOpts{
 				Filter: []string{"name==test1"},
 			},
@@ -190,14 +191,14 @@ func TestGet(t *testing.T) {
 
 	cloned, err := copystructure.Copy(baseTestStore)
 	require.NoError(t, err)
-	resource.TestStore = cloned.(map[string]resource.Test)
+	resourcet.TestStore = cloned.(map[string]resourcet.TestResource)
 
-	var empty resource.Test
+	var empty resourcet.TestResource
 	resources, err := empty.Get(ctx, []string{"test1"})
 	require.NoError(t, err)
 	require.Len(t, resources, 1)
 
-	test := resources[0].(resource.Test)
+	test := resources[0].(resourcet.TestResource)
 	assert.Equal(t, "test1", test.Name)
 	assert.Equal(t, "id-test1", test.ID)
 	assert.Equal(t, 42, test.Settings.X)
@@ -208,7 +209,7 @@ func TestGet(t *testing.T) {
 	assert.NotEmpty(t, fields)
 
 	var inspectOut bytes.Buffer
-	inspectCmd := &ResourceInspectCmd[resource.Test]{
+	inspectCmd := &ResourceInspectCmd[resourcet.TestResource]{
 		Name: []string{"test1"},
 	}
 	err = inspectCmd.Run(ctx, testConfig(&inspectOut), sandbox)
@@ -221,7 +222,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("no_args", func(t *testing.T) {
 		var out bytes.Buffer
-		cmd := &ResourceInspectCmd[resource.Test]{
+		cmd := &ResourceInspectCmd[resourcet.TestResource]{
 			Name: []string{},
 		}
 		err := cmd.Run(ctx, testConfig(&out), sandbox)
@@ -230,7 +231,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("multiple", func(t *testing.T) {
 		var out bytes.Buffer
-		cmd := &ResourceInspectCmd[resource.Test]{
+		cmd := &ResourceInspectCmd[resourcet.TestResource]{
 			Name: []string{"test1", "test2"},
 		}
 		err := cmd.Run(ctx, testConfig(&out), sandbox)
@@ -245,7 +246,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("quiet", func(t *testing.T) {
 		var out bytes.Buffer
-		cmd := &ResourceInspectCmd[resource.Test]{
+		cmd := &ResourceInspectCmd[resourcet.TestResource]{
 			Name: []string{"test1"},
 			FormatOpts: FormatOpts{
 				Quiet: true,
@@ -264,7 +265,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("raw", func(t *testing.T) {
 		var out bytes.Buffer
-		cmd := &ResourceInspectCmd[resource.Test]{
+		cmd := &ResourceInspectCmd[resourcet.TestResource]{
 			Name: []string{"test1"},
 			FormatOpts: FormatOpts{
 				Raw: true,
@@ -291,7 +292,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("format", func(t *testing.T) {
 		var out bytes.Buffer
-		cmd := &ResourceInspectCmd[resource.Test]{
+		cmd := &ResourceInspectCmd[resourcet.TestResource]{
 			Name: []string{"test1"},
 			FormatOpts: FormatOpts{
 				Format: "{{range .}}{{.name}}: {{.url}}\n{{end}}",
@@ -310,7 +311,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("field", func(t *testing.T) {
 		var out bytes.Buffer
-		cmd := &ResourceInspectCmd[resource.Test]{
+		cmd := &ResourceInspectCmd[resourcet.TestResource]{
 			Name: []string{"test1"},
 			FormatOpts: FormatOpts{
 				Field: []string{"id", "url"},
@@ -337,7 +338,7 @@ func TestGet(t *testing.T) {
 
 	t.Run("filter", func(t *testing.T) {
 		var out bytes.Buffer
-		cmd := &ResourceInspectCmd[resource.Test]{
+		cmd := &ResourceInspectCmd[resourcet.TestResource]{
 			Name: []string{"test1"},
 			FormatOpts: FormatOpts{
 				Filter: []string{"id==id-test1"},
@@ -363,9 +364,9 @@ func TestGet(t *testing.T) {
 func TestCreate(t *testing.T) {
 	ctx := context.Background()
 
-	resource.TestStore = map[string]resource.Test{}
+	resourcet.TestStore = map[string]resourcet.TestResource{}
 
-	var empty resource.Test
+	var empty resourcet.TestResource
 	templateFields, err := empty.Fields()
 	require.NoError(t, err)
 
@@ -386,22 +387,22 @@ func TestCreate(t *testing.T) {
 	res, err := empty.Create(ctx, templateFields)
 	require.NoError(t, err)
 
-	created := res.(resource.Test)
+	created := res.(resourcet.TestResource)
 	assert.Equal(t, "test-new", created.Name)
 	assert.Equal(t, 100, created.Settings.X)
 	assert.Equal(t, "created", created.Settings.Y)
-	assert.Contains(t, resource.TestStore, "test-new")
+	assert.Contains(t, resourcet.TestStore, "test-new")
 }
 
 func TestEdit(t *testing.T) {
 	ctx := context.Background()
 
-	editStore := map[string]resource.Test{
+	editStore := map[string]resourcet.TestResource{
 		"test-edit": {
 			ID:   "id-edit",
 			Name: "test-edit",
 			URL:  "https://example.com",
-			Settings: resource.TestSettings{
+			Settings: resourcet.TestSettings{
 				X: 10,
 				Y: "original",
 			},
@@ -409,9 +410,9 @@ func TestEdit(t *testing.T) {
 	}
 	cloned, err := copystructure.Copy(editStore)
 	require.NoError(t, err)
-	resource.TestStore = cloned.(map[string]resource.Test)
+	resourcet.TestStore = cloned.(map[string]resourcet.TestResource)
 
-	var empty resource.Test
+	var empty resourcet.TestResource
 	resources, err := empty.Get(ctx, []string{"test-edit"})
 	require.NoError(t, err)
 	require.Len(t, resources, 1)
@@ -435,13 +436,13 @@ func TestEdit(t *testing.T) {
 	res, err := empty.Edit(ctx, target, templateFields)
 	require.NoError(t, err)
 
-	edited := res.(resource.Test)
+	edited := res.(resourcet.TestResource)
 	assert.Equal(t, "test-edit", edited.Name)
 	assert.Equal(t, "id-edit", edited.ID)
 	assert.Equal(t, 999, edited.Settings.X)
 	assert.Equal(t, "modified", edited.Settings.Y)
 
-	stored := resource.TestStore["test-edit"]
+	stored := resourcet.TestStore["test-edit"]
 	assert.Equal(t, 999, stored.Settings.X)
 	assert.Equal(t, "modified", stored.Settings.Y)
 }
@@ -449,7 +450,7 @@ func TestEdit(t *testing.T) {
 func TestDelete(t *testing.T) {
 	ctx := context.Background()
 
-	deleteStore := map[string]resource.Test{
+	deleteStore := map[string]resourcet.TestResource{
 		"test-delete": {
 			ID:   "id-delete",
 			Name: "test-delete",
@@ -463,9 +464,9 @@ func TestDelete(t *testing.T) {
 	}
 	cloned, err := copystructure.Copy(deleteStore)
 	require.NoError(t, err)
-	resource.TestStore = cloned.(map[string]resource.Test)
+	resourcet.TestStore = cloned.(map[string]resourcet.TestResource)
 
-	var empty resource.Test
+	var empty resourcet.TestResource
 	resources, err := empty.Get(ctx, []string{"test-delete"})
 	require.NoError(t, err)
 	require.Len(t, resources, 1)
@@ -473,8 +474,8 @@ func TestDelete(t *testing.T) {
 	err = empty.Delete(ctx, resources)
 	require.NoError(t, err)
 
-	assert.NotContains(t, resource.TestStore, "test-delete")
-	assert.Contains(t, resource.TestStore, "test-keep")
+	assert.NotContains(t, resourcet.TestStore, "test-delete")
+	assert.Contains(t, resourcet.TestStore, "test-keep")
 
 	resources, err = empty.Get(ctx, []string{"test-delete"})
 	require.NoError(t, err)

--- a/internal/resource/cmd/printers.go
+++ b/internal/resource/cmd/printers.go
@@ -3,7 +3,7 @@
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
 
-package resource
+package cmd
 
 import (
 	"bytes"
@@ -21,10 +21,11 @@ import (
 	"github.com/muesli/termenv"
 
 	"unikraft.com/cli/internal/kvwriter"
+	"unikraft.com/cli/internal/resource"
 	xslices "unikraft.com/cli/internal/x/slices"
 )
 
-func printTable[R Resource](out io.Writer, fieldSpecs []string, resources ...Resource) error {
+func printTable[R resource.Resource](out io.Writer, fieldSpecs []string, resources ...resource.Resource) error {
 	tw := ansiterm.NewTabWriter(out, 0, 8, 2, ' ', 0)
 	err := printTabSeparated[R](tw, fieldSpecs, resources...)
 	if err != nil {
@@ -33,7 +34,7 @@ func printTable[R Resource](out io.Writer, fieldSpecs []string, resources ...Res
 	return tw.Flush()
 }
 
-func printInspect(out io.Writer, fieldSpecs []string, resources ...Resource) error {
+func printInspect(out io.Writer, fieldSpecs []string, resources ...resource.Resource) error {
 	bw := kvwriter.KeyValueWriter(out, "")
 	err := printKV(bw, fieldSpecs, resources...)
 	if err != nil {
@@ -42,17 +43,17 @@ func printInspect(out io.Writer, fieldSpecs []string, resources ...Resource) err
 	return bw.Flush()
 }
 
-func printKV(out io.Writer, specs []string, resources ...Resource) error {
-	for i, resource := range resources {
-		fields, err := resource.Fields()
+func printKV(out io.Writer, specs []string, resources ...resource.Resource) error {
+	for i, res := range resources {
+		fields, err := res.Fields()
 		if err != nil {
 			return err
 		}
-		fields, err = resourceFields(fields, false, FieldVerbosityLong, specs)
+		fields, err = resourceFields(fields, false, resource.FieldVerbosityLong, specs)
 		if err != nil {
 			return err
 		}
-		fields = DedupeFields(fields)
+		fields = resource.DedupeFields(fields)
 
 		if i > 0 {
 			if _, err := fmt.Fprintln(out); err != nil {
@@ -66,7 +67,7 @@ func printKV(out io.Writer, specs []string, resources ...Resource) error {
 	return nil
 }
 
-func printKVFields(out io.Writer, parent *Field, fields []Field, current int, indent int) error {
+func printKVFields(out io.Writer, parent *resource.Field, fields []resource.Field, current int, indent int) error {
 	for i, field := range fields {
 		var line bytes.Buffer
 		nextCurrent := 0
@@ -106,19 +107,19 @@ func printKVFields(out io.Writer, parent *Field, fields []Field, current int, in
 	return nil
 }
 
-func printTabSeparated[R Resource](out io.Writer, fieldSpecs []string, resources ...Resource) error {
+func printTabSeparated[R resource.Resource](out io.Writer, fieldSpecs []string, resources ...resource.Resource) error {
 	var r R
 	headers, err := r.Fields()
 	if err != nil {
 		return err
 	}
 
-	headers, err = resourceFields(headers, true, FieldVerbosityShort, fieldSpecs)
+	headers, err = resourceFields(headers, true, resource.FieldVerbosityShort, fieldSpecs)
 	if err != nil {
 		return err
 	}
 
-	headerPaths, headerFields := xslices.Collect2(IterFields(headers))
+	headerPaths, headerFields := xslices.Collect2(resource.IterFields(headers))
 
 	for i, header := range headerFields {
 		if header.HasChildren() && header.Value == nil {
@@ -143,8 +144,8 @@ func printTabSeparated[R Resource](out io.Writer, fieldSpecs []string, resources
 		return err
 	}
 
-	for _, resource := range resources {
-		fields, err := resource.Fields()
+	for _, res := range resources {
+		fields, err := res.Fields()
 		if err != nil {
 			return err
 		}
@@ -162,9 +163,9 @@ func printTabSeparated[R Resource](out io.Writer, fieldSpecs []string, resources
 				}
 			}
 
-			fields := GetFieldByPath(fields, path)
+			fields := resource.GetFieldByPath(fields, path)
 			fieldIdx := -1
-			for _, field := range IterFields(fields) {
+			for _, field := range resource.IterFields(fields) {
 				if field.Value == nil {
 					continue
 				}
@@ -204,7 +205,7 @@ func printTabSeparated[R Resource](out io.Writer, fieldSpecs []string, resources
 	return nil
 }
 
-func headerName(path FieldPath) string {
+func headerName(path resource.FieldPath) string {
 	for _, part := range slices.Backward(path) {
 		if part == "*" {
 			continue
@@ -214,9 +215,9 @@ func headerName(path FieldPath) string {
 	return ""
 }
 
-func printQuiet(out io.Writer, resources ...Resource) error {
-	for _, resource := range resources {
-		_, err := fmt.Fprintln(out, resource.Key())
+func printQuiet(out io.Writer, resources ...resource.Resource) error {
+	for _, res := range resources {
+		_, err := fmt.Fprintln(out, res.Key())
 		if err != nil {
 			return err
 		}
@@ -224,10 +225,10 @@ func printQuiet(out io.Writer, resources ...Resource) error {
 	return nil
 }
 
-func printRaw(out io.Writer, resources ...Resource) error {
+func printRaw(out io.Writer, resources ...resource.Resource) error {
 	input := make([]any, 0, len(resources))
-	for _, resource := range resources {
-		input = append(input, resource.Raw())
+	for _, res := range resources {
+		input = append(input, res.Raw())
 	}
 	dt, err := json.MarshalIndent(input, "", "  ")
 	if err != nil {
@@ -237,14 +238,14 @@ func printRaw(out io.Writer, resources ...Resource) error {
 	return err
 }
 
-func printTemplate(out io.Writer, tmplStr string, resources ...Resource) error {
+func printTemplate(out io.Writer, tmplStr string, resources ...resource.Resource) error {
 	input := make([]any, 0, len(resources))
-	for _, resource := range resources {
-		fields, err := resource.Fields()
+	for _, res := range resources {
+		fields, err := res.Fields()
 		if err != nil {
 			return err
 		}
-		input = append(input, FieldsToMap(fields))
+		input = append(input, resource.FieldsToMap(fields))
 	}
 
 	tmpl, err := template.New("out").Funcs(sprig.TxtFuncMap()).Parse(tmplStr)
@@ -254,54 +255,54 @@ func printTemplate(out io.Writer, tmplStr string, resources ...Resource) error {
 	return tmpl.Execute(out, input)
 }
 
-func resourceFields(fields []Field, header bool, verbosity FieldVerbosity, fieldSpecs []string) ([]Field, error) {
-	var base []FieldPath
-	var include []FieldPath
-	var exclude []FieldPath
+func resourceFields(fields []resource.Field, header bool, verbosity resource.FieldVerbosity, fieldSpecs []string) ([]resource.Field, error) {
+	var base []resource.FieldPath
+	var include []resource.FieldPath
+	var exclude []resource.FieldPath
 	for _, field := range fieldSpecs {
 		if len(field) == 0 {
 			continue
 		}
 		if field == "all" {
-			verbosity = FieldVerbosityHidden
+			verbosity = resource.FieldVerbosityHidden
 			continue
 		}
 		switch field[0] {
 		case '+':
 			field = field[1:]
-			include = append(include, ParseFieldPath(field))
+			include = append(include, resource.ParseFieldPath(field))
 		case '-':
 			field = field[1:]
-			exclude = append(exclude, ParseFieldPath(field))
+			exclude = append(exclude, resource.ParseFieldPath(field))
 		default:
-			base = append(base, ParseFieldPath(field))
+			base = append(base, resource.ParseFieldPath(field))
 		}
 	}
 
-	var missing []FieldPath
+	var missing []resource.FieldPath
 
-	result, missing := FilterFieldsByPath(fields, base, !header)
+	result, missing := resource.FilterFieldsByPath(fields, base, !header)
 	if len(base) == 0 {
-		result = filterFields(result, func(field Field) filterResult {
+		result = resource.FilterFields(result, func(field resource.Field) resource.FilterResult {
 			if field.Verbosity < verbosity {
-				return filterExclude
+				return resource.FilterExclude
 			}
 			if !header && field.IsEmpty() {
-				return filterExclude
+				return resource.FilterExclude
 			}
-			return filterRecurse
+			return resource.FilterRecurse
 		})
 	}
 
 	if len(include) > 0 {
-		included, includeMissing := FilterFieldsByPath(fields, include, !header)
-		result = MergeFields(result, included)
+		included, includeMissing := resource.FilterFieldsByPath(fields, include, !header)
+		result = resource.MergeFields(result, included)
 		missing = append(missing, includeMissing...)
 	}
 
 	if len(exclude) > 0 {
-		excluded, excludeMissing := FilterFieldsByPath(fields, exclude, !header)
-		result = RemoveFields(result, excluded)
+		excluded, excludeMissing := resource.FilterFieldsByPath(fields, exclude, !header)
+		result = resource.RemoveFields(result, excluded)
 		missing = append(missing, excludeMissing...)
 	}
 

--- a/internal/resource/ctx.go
+++ b/internal/resource/ctx.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/containerd/containerd/v2/pkg/filters"
+
 	"unikraft.com/cli/internal/config"
 )
 

--- a/internal/resource/patch/collect.go
+++ b/internal/resource/patch/collect.go
@@ -3,32 +3,34 @@
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
 
-package resource
+package patch
 
 import (
 	"fmt"
 	"reflect"
+
+	"unikraft.com/cli/internal/resource"
 )
 
-// collectValue collects a value of the given type from the Field.
+// collectValue collects a value of the given type from the resource.Field.
 //
 // In the simplest case, this is just returning field.Value, but for nested
 // structures, like lists of fields, then we need to assemble a value from
-// the subfields. e.g. [Field{Value: 1}, Field{Value: 2}] -> []int{1, 2}
-func collectValue(field Field, into reflect.Type) (any, error) {
+// the subfields. e.g. [resource.Field{Value: 1}, resource.Field{Value: 2}] -> []int{1, 2}
+func collectValue(field resource.Field, into reflect.Type) (any, error) {
 	v, err := collectValueRaw(field)
 	if err != nil {
 		return nil, err
 	}
 	target := reflect.New(into).Elem().Interface()
 
-	if err := decodeStruct(v, &target); err != nil {
+	if err := resource.DecodeStruct(v, &target); err != nil {
 		return nil, fmt.Errorf("failed to decode value into type %s: %w", into.String(), err)
 	}
 	return target, nil
 }
 
-func collectValueRaw(field Field) (any, error) {
+func collectValueRaw(field resource.Field) (any, error) {
 	if field.Value != nil {
 		return field.Value, nil
 	}
@@ -57,12 +59,12 @@ func collectValueRaw(field Field) (any, error) {
 	return nil, fmt.Errorf("field has no value")
 }
 
-// storeValue stores a value into the given Field, as the reverse of collectValue.
+// storeValue stores a value into the given resource.Field, as the reverse of collectValue.
 //
 // In the simplest case, this is just setting field.Value, but for nested structures,
 // like lists of fields, then we need to decompose the value into the subfields.
-// e.g. []int{1, 2} -> [Field{Value: 1}, Field{Value: 2}].
-func storeValue(field *Field, base reflect.Value) error {
+// e.g. []int{1, 2} -> [resource.Field{Value: 1}, resource.Field{Value: 2}].
+func storeValue(field *resource.Field, base reflect.Value) error {
 	value := base
 	for value.Kind() == reflect.Interface || value.Kind() == reflect.Pointer {
 		value = value.Elem()
@@ -80,9 +82,9 @@ func storeValue(field *Field, base reflect.Value) error {
 			return fmt.Errorf("expected slice for field %s, got %s", field.Name, value.Kind().String())
 		}
 		if field.Subfields == nil {
-			field.Subfields = make([]Field, value.Len())
+			field.Subfields = make([]resource.Field, value.Len())
 			for i := range field.Subfields {
-				field.Subfields[i] = CloneField(*field.Elem)
+				field.Subfields[i] = resource.CloneField(*field.Elem)
 				field.Subfields[i].Name = fmt.Sprintf("%d", i)
 			}
 		}
@@ -104,20 +106,20 @@ func storeValue(field *Field, base reflect.Value) error {
 			return fmt.Errorf("expected struct for field %s, got %s", field.Name, value.Kind().String())
 		}
 		for i := range value.NumField() {
-			parsedField := parseField(value.Type().Field(i))
+			parsedField := resource.ParseField(value.Type().Field(i))
 			if parsedField == nil {
 				continue
 			}
 
-			var subfield *Field
+			var subfield *resource.Field
 			for j := range field.Subfields {
-				if field.Subfields[j].Name == parsedField.name {
+				if field.Subfields[j].Name == parsedField.Name {
 					subfield = &field.Subfields[j]
 					break
 				}
 			}
 			if subfield == nil {
-				return fmt.Errorf("no subfield named %s in field %s", parsedField.name, field.Name)
+				return fmt.Errorf("no subfield named %s in field %s", parsedField.Name, field.Name)
 			}
 			err := storeValue(subfield, value.Field(i))
 			if err != nil {

--- a/internal/resource/patch/filter.go
+++ b/internal/resource/patch/filter.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package patch
+
+import "unikraft.com/cli/internal/resource"
+
+func FilterPatchableFields(fields []resource.Field) []resource.Field {
+	return resource.FilterFields(fields, func(field resource.Field) resource.FilterResult {
+		if field.Patch != nil {
+			return resource.FilterInclude
+		}
+		return resource.FilterPrune
+	})
+}
+
+func FilterCreatableFields(fields []resource.Field) []resource.Field {
+	return resource.FilterFields(fields, func(field resource.Field) resource.FilterResult {
+		if field.Create != nil {
+			return resource.FilterInclude
+		}
+		return resource.FilterPrune
+	})
+}

--- a/internal/resource/patch/patch.go
+++ b/internal/resource/patch/patch.go
@@ -3,7 +3,7 @@
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
 
-package resource
+package patch
 
 import (
 	"errors"
@@ -14,6 +14,8 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+
+	"unikraft.com/cli/internal/resource"
 )
 
 type PatchSpec struct {
@@ -47,20 +49,20 @@ func (spec *PatchSpec) Keys() iter.Seq[string] {
 // PatchedFields applies the given PatchSpec to the provided fields, returning
 // only the modified fields or an error if the patching process encounters
 // issues.
-func PatchedFields(fields []Field, spec PatchSpec) ([]Field, error) {
+func PatchedFields(fields []resource.Field, spec PatchSpec) ([]resource.Field, error) {
 	foundFields := make(map[string]struct{})
 	unsetFields := make(map[string]struct{})
 	setForbiddenFields := make(map[string]struct{})
 	addForbiddenFields := make(map[string]struct{})
 	delForbiddenFields := make(map[string]struct{})
 
-	fields = CloneFields(fields)
-	for key, field := range IterFields(fields) {
+	fields = resource.CloneFields(fields)
+	for key, field := range resource.IterFields(fields) {
 		keyStr := key.String()
 		foundFields[keyStr] = struct{}{}
 
-		var original *Patch
-		var patch **Patch
+		var original *resource.Patch
+		var patch **resource.Patch
 		if spec.Create {
 			original = field.Create
 			field.Create = nil
@@ -71,7 +73,7 @@ func PatchedFields(fields []Field, spec PatchSpec) ([]Field, error) {
 			patch = &field.Patch
 		}
 		if original == nil {
-			original = &Patch{}
+			original = &resource.Patch{}
 		}
 
 		done := false
@@ -82,7 +84,7 @@ func PatchedFields(fields []Field, spec PatchSpec) ([]Field, error) {
 				if err != nil {
 					return nil, fmt.Errorf("failed to unpack set value for %s: %w", keyStr, err)
 				}
-				*patch = &Patch{Set: set}
+				*patch = &resource.Patch{Set: set}
 			} else {
 				setForbiddenFields[keyStr] = struct{}{}
 			}
@@ -94,7 +96,7 @@ func PatchedFields(fields []Field, spec PatchSpec) ([]Field, error) {
 				if err != nil {
 					return nil, fmt.Errorf("failed to unpack add value for %s: %w", keyStr, err)
 				}
-				*patch = &Patch{Add: add}
+				*patch = &resource.Patch{Add: add}
 			} else {
 				addForbiddenFields[keyStr] = struct{}{}
 			}
@@ -106,7 +108,7 @@ func PatchedFields(fields []Field, spec PatchSpec) ([]Field, error) {
 				if err != nil {
 					return nil, fmt.Errorf("failed to unpack del value for %s: %w", keyStr, err)
 				}
-				*patch = &Patch{Del: del}
+				*patch = &resource.Patch{Del: del}
 			} else {
 				delForbiddenFields[keyStr] = struct{}{}
 			}
@@ -144,9 +146,9 @@ func PatchedFields(fields []Field, spec PatchSpec) ([]Field, error) {
 	}
 
 	if spec.Create {
-		return filterCreatableFields(fields), nil
+		return FilterCreatableFields(fields), nil
 	}
-	return filterPatchableFields(fields), nil
+	return FilterPatchableFields(fields), nil
 }
 
 func parseNewValue(input []string, output any) (any, error) {
@@ -254,7 +256,7 @@ func parseReflect(input []string, value reflect.Value) error {
 		output.Set(mapp)
 		return nil
 	case reflect.Struct:
-		valueField, ok := value.Interface().(valueField)
+		valueField, ok := value.Interface().(resource.ValueField)
 		if ok {
 			return valueField.Parse(input[0])
 		}
@@ -266,7 +268,7 @@ func parseReflect(input []string, value reflect.Value) error {
 			k, v, _ := strings.Cut(field, "=")
 			kv[k] = v
 		}
-		return decodeStruct(kv, value.Addr().Interface())
+		return resource.DecodeStruct(kv, value.Addr().Interface())
 	default:
 		return fmt.Errorf("unsupported type: %T", value.Interface())
 	}

--- a/internal/resource/patch/visual.go
+++ b/internal/resource/patch/visual.go
@@ -3,7 +3,7 @@
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
 
-package resource
+package patch
 
 import (
 	"bytes"
@@ -15,15 +15,17 @@ import (
 	"slices"
 
 	"sigs.k8s.io/yaml"
-	"unikraft.com/cli/internal/config"
 	"unikraft.com/x/log"
+
+	"unikraft.com/cli/internal/config"
+	"unikraft.com/cli/internal/resource"
 )
 
-func VisualEdit(ctx context.Context, cfg *config.Config, fields []Field, patches []Field) ([]Field, error) {
+func VisualEdit(ctx context.Context, cfg *config.Config, fields []resource.Field, patches []resource.Field) ([]resource.Field, error) {
 	return visualEdit(ctx, cfg, fields, patches, false)
 }
 
-func VisualCreate(ctx context.Context, cfg *config.Config, fields []Field, creates []Field) ([]Field, error) {
+func VisualCreate(ctx context.Context, cfg *config.Config, fields []resource.Field, creates []resource.Field) ([]resource.Field, error) {
 	return visualEdit(ctx, cfg, fields, creates, true)
 }
 
@@ -31,7 +33,7 @@ func VisualCreate(ctx context.Context, cfg *config.Config, fields []Field, creat
 //
 // It takes all the fields and already existing patched fields as input, and
 // returns all patched fields after editing.
-func visualEdit(ctx context.Context, cfg *config.Config, fields []Field, patches []Field, create bool) ([]Field, error) {
+func visualEdit(ctx context.Context, cfg *config.Config, fields []resource.Field, patches []resource.Field, create bool) ([]resource.Field, error) {
 	data, err := saveFields(fields, patches, create)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize fields: %w", err)
@@ -80,18 +82,18 @@ func visualEdit(ctx context.Context, cfg *config.Config, fields []Field, patches
 	return fields, nil
 }
 
-func saveFields(fields []Field, patches []Field, create bool) ([]byte, error) {
-	fields = CloneFields(fields)
+func saveFields(fields []resource.Field, patches []resource.Field, create bool) ([]byte, error) {
+	fields = resource.CloneFields(fields)
 
-	patchMap := make(map[string]Field)
-	for key, field := range IterFields(patches) {
+	patchMap := make(map[string]resource.Field)
+	for key, field := range resource.IterFields(patches) {
 		patchMap[key.String()] = *field
 	}
 
-	for key, field := range IterFields(fields) {
+	for key, field := range resource.IterFields(fields) {
 		keyStr := key.String()
 
-		var patch *Patch
+		var patch *resource.Patch
 		if create {
 			patch = field.Create
 		} else {
@@ -116,7 +118,7 @@ func saveFields(fields []Field, patches []Field, create bool) ([]byte, error) {
 
 		// write already set patches into fields
 		if patchedField, ok := patchMap[keyStr]; ok {
-			var patch *Patch
+			var patch *resource.Patch
 			if create {
 				patch = patchedField.Create
 			} else {
@@ -141,13 +143,13 @@ func saveFields(fields []Field, patches []Field, create bool) ([]byte, error) {
 		}
 	}
 
-	var patchableFields []Field
+	var patchableFields []resource.Field
 	if create {
-		patchableFields = filterCreatableFields(fields)
+		patchableFields = FilterCreatableFields(fields)
 	} else {
-		patchableFields = filterPatchableFields(fields)
+		patchableFields = FilterPatchableFields(fields)
 	}
-	result, err := yaml.Marshal(FieldsToMap(patchableFields))
+	result, err := yaml.Marshal(resource.FieldsToMap(patchableFields))
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal fields to YAML: %w", err)
 	}
@@ -155,7 +157,7 @@ func saveFields(fields []Field, patches []Field, create bool) ([]byte, error) {
 	result = append(result, []byte("\n# Edit the fields above. Lines starting with '#' will be ignored.\n#")...)
 	result = append(result, []byte("\n# Original:\n")...)
 
-	rest, err := yaml.Marshal(FieldsToMap(fields))
+	rest, err := yaml.Marshal(resource.FieldsToMap(fields))
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal fields to YAML: %w", err)
 	}
@@ -167,15 +169,15 @@ func saveFields(fields []Field, patches []Field, create bool) ([]byte, error) {
 	return result, nil
 }
 
-func loadFieldPatches(ctx context.Context, fields []Field, data []byte, create bool) ([]Field, error) {
-	fields = CloneFields(fields)
+func loadFieldPatches(ctx context.Context, fields []resource.Field, data []byte, create bool) ([]resource.Field, error) {
+	fields = resource.CloneFields(fields)
 
 	var obj map[string]any
 	if err := yaml.Unmarshal(data, &obj); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal edited data: %w", err)
 	}
 
-	patchedFields, missing, err := MapToFields(fields, obj)
+	patchedFields, missing, err := resource.MapToFields(fields, obj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to map edited data to fields: %w", err)
 	}
@@ -183,15 +185,15 @@ func loadFieldPatches(ctx context.Context, fields []Field, data []byte, create b
 		return nil, fmt.Errorf("unknown fields: %v", missing)
 	}
 
-	before := Field{Subfields: fields}
-	after := Field{Subfields: patchedFields}
-	err = patchField(FieldPath{}, &before, &after, create)
+	before := resource.Field{Subfields: fields}
+	after := resource.Field{Subfields: patchedFields}
+	err = patchField(resource.FieldPath{}, &before, &after, create)
 	if err != nil {
 		return nil, err
 	}
 
-	for fieldPath, field := range IterFields(fields) {
-		var patch *Patch
+	for fieldPath, field := range resource.IterFields(fields) {
+		var patch *resource.Patch
 		if create {
 			patch = field.Create
 		} else {
@@ -213,17 +215,17 @@ func loadFieldPatches(ctx context.Context, fields []Field, data []byte, create b
 	}
 
 	if create {
-		fields = filterCreatableFields(fields)
+		fields = FilterCreatableFields(fields)
 	} else {
-		fields = filterPatchableFields(fields)
+		fields = FilterPatchableFields(fields)
 	}
 	return fields, nil
 }
 
 // patchField applies the changes from after to before, modifying before in
-// place by setting Patch fields.
-func patchField(path FieldPath, before *Field, after *Field, create bool) error {
-	var patch *Patch
+// place by setting resource.Patch fields.
+func patchField(path resource.FieldPath, before *resource.Field, after *resource.Field, create bool) error {
+	var patch *resource.Patch
 	if create {
 		patch = before.Create
 	} else {

--- a/internal/resource/resource_helpers.go
+++ b/internal/resource/resource_helpers.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 )
 
+// CloneField creates a deep copy of the given Field.
 func CloneField(field Field) Field {
 	newField := field
 	newField.Subfields = CloneFields(field.Subfields)
@@ -31,6 +32,9 @@ func CloneFields(fields []Field) []Field {
 	return result
 }
 
+// DedupeFields removes duplicate fields from the given slice of Fields.
+// If a field with the same Name exists multiple times, their Subfields are
+// merged recursively.
 func DedupeFields(fields []Field) []Field {
 	seen := make(map[string]int)
 	result := make([]Field, 0, len(fields))
@@ -124,7 +128,7 @@ func valueToField(field *Field, val any) (*Field, []FieldPath, error) {
 
 	if field.Value != nil {
 		field.Value = reflect.New(reflect.TypeOf(field.Value)).Elem().Interface()
-		if err := decodeStruct(val, &field.Value); err != nil {
+		if err := DecodeStruct(val, &field.Value); err != nil {
 			return nil, nil, fmt.Errorf("failed to decode value %v for field %q: %w", val, field.Name, err)
 		}
 	}
@@ -211,18 +215,9 @@ func slicesToFields(elem *Field, vals []any) ([]Field, []FieldPath, error) {
 	return fields, unknown, nil
 }
 
-type filterResult int
-
-const (
-	filterExclude filterResult = iota
-	filterInclude
-	filterRecurse
-	filterPrune
-)
-
-// filterFields filters the given fields based on the provided predicate
+// FilterFields filters the given fields based on the provided predicate
 // function f. It recursively filters subfields as well.
-func filterFields(fields []Field, f func(Field) filterResult) []Field {
+func FilterFields(fields []Field, f func(Field) FilterResult) []Field {
 	if fields == nil {
 		return nil
 	}
@@ -230,15 +225,15 @@ func filterFields(fields []Field, f func(Field) filterResult) []Field {
 	result := make([]Field, 0, len(fields))
 	for _, field := range fields {
 		ff := f(field)
-		if ff == filterExclude {
+		if ff == FilterExclude {
 			continue
 		}
-		if ff == filterInclude {
+		if ff == FilterInclude {
 			result = append(result, field)
 			continue
 		}
-		field.Subfields = filterFields(field.Subfields, f)
-		if ff == filterPrune && len(field.Subfields) == 0 {
+		field.Subfields = FilterFields(field.Subfields, f)
+		if ff == FilterPrune && len(field.Subfields) == 0 {
 			continue
 		}
 		result = append(result, field)
@@ -246,20 +241,11 @@ func filterFields(fields []Field, f func(Field) filterResult) []Field {
 	return result
 }
 
-func filterPatchableFields(fields []Field) []Field {
-	return filterFields(fields, func(field Field) filterResult {
-		if field.Patch != nil {
-			return filterInclude
-		}
-		return filterPrune
-	})
-}
+type FilterResult int
 
-func filterCreatableFields(fields []Field) []Field {
-	return filterFields(fields, func(field Field) filterResult {
-		if field.Create != nil {
-			return filterInclude
-		}
-		return filterPrune
-	})
-}
+const (
+	FilterExclude FilterResult = iota
+	FilterInclude
+	FilterRecurse
+	FilterPrune
+)

--- a/internal/resource/resource_test_helpers.go
+++ b/internal/resource/resource_test_helpers.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package resource
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+type Test struct {
+	ID       string
+	Name     string
+	URL      string
+	Settings TestSettings
+	Authors  []TestAuthor
+}
+
+var (
+	_ Resource          = (*Test)(nil)
+	_ GettableResource  = (*Test)(nil)
+	_ EditableResource  = (*Test)(nil)
+	_ CreatableResource = (*Test)(nil)
+	_ DeletableResource = (*Test)(nil)
+)
+
+type TestSettings struct {
+	X int
+	Y string
+}
+
+type TestAuthor struct {
+	Name  string
+	Email string
+}
+
+var TestStore = map[string]Test{}
+
+func (Test) Type() Type {
+	return Type{
+		Name:  "test",
+		Names: "tests",
+	}
+}
+
+func (t Test) Key() string {
+	return t.Name
+}
+
+func (t Test) Raw() any {
+	return t
+}
+
+func (t Test) Fields() ([]Field, error) {
+	return []Field{
+		{
+			Name:      "id",
+			Value:     t.ID,
+			Verbosity: FieldVerbosityShort,
+		},
+		{
+			Name:      "name",
+			Value:     t.Name,
+			Verbosity: FieldVerbosityShort,
+			Create: &Patch{
+				Set: "",
+			},
+		},
+		{
+			Name:      "url",
+			Value:     t.URL,
+			Verbosity: FieldVerbosityShort,
+		},
+		{
+			Name:      "settings",
+			Verbosity: FieldVerbosityLong,
+			Subfields: []Field{
+				{
+					Name:      "x",
+					Value:     t.Settings.X,
+					Verbosity: FieldVerbosityLong,
+					Create: &Patch{
+						Set: 0,
+					},
+					Patch: &Patch{
+						Set: 0,
+					},
+				},
+				{
+					Name:      "y",
+					Value:     t.Settings.Y,
+					Verbosity: FieldVerbosityLong,
+					Create: &Patch{
+						Set: "",
+					},
+					Patch: &Patch{
+						Set: "",
+					},
+				},
+			},
+		},
+		{
+			Name:      "authors",
+			Verbosity: FieldVerbosityLong,
+			Elem: &Field{
+				Subfields: []Field{
+					{
+						Name:      "name",
+						Verbosity: FieldVerbosityLong,
+					},
+					{
+						Name:      "email",
+						Verbosity: FieldVerbosityLong,
+					},
+				},
+			},
+			Subfields: func() []Field {
+				var fields []Field
+				for i, author := range t.Authors {
+					fields = append(fields, Field{
+						Name:      fmt.Sprintf("%d", i),
+						Verbosity: FieldVerbosityLong,
+						Subfields: []Field{
+							{
+								Name:      "name",
+								Value:     author.Name,
+								Verbosity: FieldVerbosityLong,
+							},
+							{
+								Name:      "email",
+								Value:     author.Email,
+								Verbosity: FieldVerbosityLong,
+							},
+						},
+					})
+				}
+				return fields
+			}(),
+		},
+	}, nil
+}
+
+func (Test) List(ctx context.Context) ([]Resource, error) {
+	var resources []Resource
+	for _, t := range TestStore {
+		resources = append(resources, t)
+	}
+	// Sort by ID for deterministic output
+	slices.SortFunc(resources, func(a, b Resource) int {
+		return strings.Compare(a.(Test).ID, b.(Test).ID)
+	})
+	return resources, nil
+}
+
+func (Test) Get(ctx context.Context, keys []string) ([]Resource, error) {
+	// Build a map for lookup
+	resourceMap := make(map[string]Test)
+	for _, key := range keys {
+		if t, ok := TestStore[key]; ok {
+			resourceMap[key] = t
+		}
+	}
+
+	// Return resources in the order of keys provided
+	var resources []Resource
+	for _, key := range keys {
+		if t, ok := resourceMap[key]; ok {
+			resources = append(resources, t)
+		}
+	}
+	return resources, nil
+}
+
+func (Test) Create(ctx context.Context, fields []Field) (Resource, error) {
+	t := Test{
+		Settings: TestSettings{},
+	}
+
+	for key, field := range IterFields(fields) {
+		if field.Create == nil || field.Create.Set == nil {
+			continue
+		}
+		switch key.String() {
+		case "name":
+			t.Name = field.Create.Set.(string)
+		case "settings.x":
+			t.Settings.X = field.Create.Set.(int)
+		case "settings.y":
+			t.Settings.Y = field.Create.Set.(string)
+		}
+	}
+
+	TestStore[t.Name] = t
+	return t, nil
+}
+
+func (Test) Edit(ctx context.Context, target Resource, fields []Field) (Resource, error) {
+	t := target.(Test)
+
+	for key, field := range IterFields(fields) {
+		if field.Patch == nil || field.Patch.Set == nil {
+			continue
+		}
+		switch key.String() {
+		case "settings.x":
+			t.Settings.X = field.Patch.Set.(int)
+		case "settings.y":
+			t.Settings.Y = field.Patch.Set.(string)
+		}
+	}
+
+	TestStore[t.Name] = t
+	return t, nil
+}
+
+func (Test) Delete(ctx context.Context, targets []Resource) error {
+	for _, target := range targets {
+		t := target.(Test)
+		delete(TestStore, t.Name)
+	}
+	return nil
+}

--- a/internal/resource/struct.go
+++ b/internal/resource/struct.go
@@ -26,7 +26,7 @@ func FieldsFromStruct(s any) (fields []Field, err error) {
 	return field.Subfields, nil
 }
 
-type valueField interface {
+type ValueField interface {
 	String() string
 	Parse(s string) error
 }
@@ -60,13 +60,13 @@ func fieldFromStruct(pkgPath string, v reflect.Value) (field *Field, err error) 
 		}
 		fieldVal := s.Field(i)
 
-		parsedField := parseField(field)
+		parsedField := ParseField(field)
 		if parsedField == nil {
 			continue
 		}
 		result := Field{
-			Name:      parsedField.name,
-			Verbosity: parsedField.verbosity,
+			Name:      parsedField.Name,
+			Verbosity: parsedField.Verbosity,
 			Value:     fieldVal.Interface(),
 		}
 
@@ -95,8 +95,8 @@ func fieldFromStruct(pkgPath string, v reflect.Value) (field *Field, err error) 
 	}
 
 	var value any
-	if valueField, ok := v.Interface().(valueField); ok {
-		value = valueField
+	if ValueField, ok := v.Interface().(ValueField); ok {
+		value = ValueField
 	}
 
 	verbosity := FieldVerbosity(0)
@@ -153,12 +153,12 @@ func fieldFromSlice(pkgPath string, v reflect.Value) (field *Field, err error) {
 	}, nil
 }
 
-type parsedField struct {
-	name      string
-	verbosity FieldVerbosity
+type ParsedField struct {
+	Name      string
+	Verbosity FieldVerbosity
 }
 
-func parseField(field reflect.StructField) *parsedField {
+func ParseField(field reflect.StructField) *ParsedField {
 	if !field.IsExported() {
 		return nil
 	}
@@ -188,9 +188,9 @@ func parseField(field reflect.StructField) *parsedField {
 		verbosity = FieldVerbosityHidden
 	}
 
-	return &parsedField{
-		name:      name,
-		verbosity: verbosity,
+	return &ParsedField{
+		Name:      name,
+		Verbosity: verbosity,
 	}
 }
 
@@ -198,7 +198,7 @@ func parseField(field reflect.StructField) *parsedField {
 // on the Field - this function makes heavy assumptions about the structure of
 // field data and how values are read/written. Currently it is only used for
 // visual editing.
-func decodeStruct(input any, output any) error {
+func DecodeStruct(input any, output any) error {
 	config := mapstructure.DecoderConfig{
 		TagName:     "field",
 		ErrorUnused: true,

--- a/internal/resource/testing/resource.go
+++ b/internal/resource/testing/resource.go
@@ -3,16 +3,18 @@
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
 
-package resource
+package testing
 
 import (
 	"context"
 	"fmt"
 	"slices"
 	"strings"
+
+	"unikraft.com/cli/internal/resource"
 )
 
-type Test struct {
+type TestResource struct {
 	ID       string
 	Name     string
 	URL      string
@@ -21,11 +23,11 @@ type Test struct {
 }
 
 var (
-	_ Resource          = (*Test)(nil)
-	_ GettableResource  = (*Test)(nil)
-	_ EditableResource  = (*Test)(nil)
-	_ CreatableResource = (*Test)(nil)
-	_ DeletableResource = (*Test)(nil)
+	_ resource.Resource          = (*TestResource)(nil)
+	_ resource.GettableResource  = (*TestResource)(nil)
+	_ resource.EditableResource  = (*TestResource)(nil)
+	_ resource.CreatableResource = (*TestResource)(nil)
+	_ resource.DeletableResource = (*TestResource)(nil)
 )
 
 type TestSettings struct {
@@ -38,66 +40,66 @@ type TestAuthor struct {
 	Email string
 }
 
-var TestStore = map[string]Test{}
+var TestStore = map[string]TestResource{}
 
-func (Test) Type() Type {
-	return Type{
+func (TestResource) Type() resource.Type {
+	return resource.Type{
 		Name:  "test",
 		Names: "tests",
 	}
 }
 
-func (t Test) Key() string {
+func (t TestResource) Key() string {
 	return t.Name
 }
 
-func (t Test) Raw() any {
+func (t TestResource) Raw() any {
 	return t
 }
 
-func (t Test) Fields() ([]Field, error) {
-	return []Field{
+func (t TestResource) Fields() ([]resource.Field, error) {
+	return []resource.Field{
 		{
 			Name:      "id",
 			Value:     t.ID,
-			Verbosity: FieldVerbosityShort,
+			Verbosity: resource.FieldVerbosityShort,
 		},
 		{
 			Name:      "name",
 			Value:     t.Name,
-			Verbosity: FieldVerbosityShort,
-			Create: &Patch{
+			Verbosity: resource.FieldVerbosityShort,
+			Create: &resource.Patch{
 				Set: "",
 			},
 		},
 		{
 			Name:      "url",
 			Value:     t.URL,
-			Verbosity: FieldVerbosityShort,
+			Verbosity: resource.FieldVerbosityShort,
 		},
 		{
 			Name:      "settings",
-			Verbosity: FieldVerbosityLong,
-			Subfields: []Field{
+			Verbosity: resource.FieldVerbosityLong,
+			Subfields: []resource.Field{
 				{
 					Name:      "x",
 					Value:     t.Settings.X,
-					Verbosity: FieldVerbosityLong,
-					Create: &Patch{
+					Verbosity: resource.FieldVerbosityLong,
+					Create: &resource.Patch{
 						Set: 0,
 					},
-					Patch: &Patch{
+					Patch: &resource.Patch{
 						Set: 0,
 					},
 				},
 				{
 					Name:      "y",
 					Value:     t.Settings.Y,
-					Verbosity: FieldVerbosityLong,
-					Create: &Patch{
+					Verbosity: resource.FieldVerbosityLong,
+					Create: &resource.Patch{
 						Set: "",
 					},
-					Patch: &Patch{
+					Patch: &resource.Patch{
 						Set: "",
 					},
 				},
@@ -105,35 +107,35 @@ func (t Test) Fields() ([]Field, error) {
 		},
 		{
 			Name:      "authors",
-			Verbosity: FieldVerbosityLong,
-			Elem: &Field{
-				Subfields: []Field{
+			Verbosity: resource.FieldVerbosityLong,
+			Elem: &resource.Field{
+				Subfields: []resource.Field{
 					{
 						Name:      "name",
-						Verbosity: FieldVerbosityLong,
+						Verbosity: resource.FieldVerbosityLong,
 					},
 					{
 						Name:      "email",
-						Verbosity: FieldVerbosityLong,
+						Verbosity: resource.FieldVerbosityLong,
 					},
 				},
 			},
-			Subfields: func() []Field {
-				var fields []Field
+			Subfields: func() []resource.Field {
+				var fields []resource.Field
 				for i, author := range t.Authors {
-					fields = append(fields, Field{
+					fields = append(fields, resource.Field{
 						Name:      fmt.Sprintf("%d", i),
-						Verbosity: FieldVerbosityLong,
-						Subfields: []Field{
+						Verbosity: resource.FieldVerbosityLong,
+						Subfields: []resource.Field{
 							{
 								Name:      "name",
 								Value:     author.Name,
-								Verbosity: FieldVerbosityLong,
+								Verbosity: resource.FieldVerbosityLong,
 							},
 							{
 								Name:      "email",
 								Value:     author.Email,
-								Verbosity: FieldVerbosityLong,
+								Verbosity: resource.FieldVerbosityLong,
 							},
 						},
 					})
@@ -144,21 +146,21 @@ func (t Test) Fields() ([]Field, error) {
 	}, nil
 }
 
-func (Test) List(ctx context.Context) ([]Resource, error) {
-	var resources []Resource
+func (TestResource) List(ctx context.Context) ([]resource.Resource, error) {
+	var resources []resource.Resource
 	for _, t := range TestStore {
 		resources = append(resources, t)
 	}
 	// Sort by ID for deterministic output
-	slices.SortFunc(resources, func(a, b Resource) int {
-		return strings.Compare(a.(Test).ID, b.(Test).ID)
+	slices.SortFunc(resources, func(a, b resource.Resource) int {
+		return strings.Compare(a.(TestResource).ID, b.(TestResource).ID)
 	})
 	return resources, nil
 }
 
-func (Test) Get(ctx context.Context, keys []string) ([]Resource, error) {
+func (TestResource) Get(ctx context.Context, keys []string) ([]resource.Resource, error) {
 	// Build a map for lookup
-	resourceMap := make(map[string]Test)
+	resourceMap := make(map[string]TestResource)
 	for _, key := range keys {
 		if t, ok := TestStore[key]; ok {
 			resourceMap[key] = t
@@ -166,7 +168,7 @@ func (Test) Get(ctx context.Context, keys []string) ([]Resource, error) {
 	}
 
 	// Return resources in the order of keys provided
-	var resources []Resource
+	var resources []resource.Resource
 	for _, key := range keys {
 		if t, ok := resourceMap[key]; ok {
 			resources = append(resources, t)
@@ -175,12 +177,12 @@ func (Test) Get(ctx context.Context, keys []string) ([]Resource, error) {
 	return resources, nil
 }
 
-func (Test) Create(ctx context.Context, fields []Field) (Resource, error) {
-	t := Test{
+func (TestResource) Create(ctx context.Context, fields []resource.Field) (resource.Resource, error) {
+	t := TestResource{
 		Settings: TestSettings{},
 	}
 
-	for key, field := range IterFields(fields) {
+	for key, field := range resource.IterFields(fields) {
 		if field.Create == nil || field.Create.Set == nil {
 			continue
 		}
@@ -198,10 +200,10 @@ func (Test) Create(ctx context.Context, fields []Field) (Resource, error) {
 	return t, nil
 }
 
-func (Test) Edit(ctx context.Context, target Resource, fields []Field) (Resource, error) {
-	t := target.(Test)
+func (TestResource) Edit(ctx context.Context, target resource.Resource, fields []resource.Field) (resource.Resource, error) {
+	t := target.(TestResource)
 
-	for key, field := range IterFields(fields) {
+	for key, field := range resource.IterFields(fields) {
 		if field.Patch == nil || field.Patch.Set == nil {
 			continue
 		}
@@ -217,9 +219,9 @@ func (Test) Edit(ctx context.Context, target Resource, fields []Field) (Resource
 	return t, nil
 }
 
-func (Test) Delete(ctx context.Context, targets []Resource) error {
+func (TestResource) Delete(ctx context.Context, targets []resource.Resource) error {
 	for _, target := range targets {
-		t := target.(Test)
+		t := target.(TestResource)
 		delete(TestStore, t.Name)
 	}
 	return nil


### PR DESCRIPTION
I've wanted to do the big resource package split for a while - this ensures that we can split up functionality to be a bit clearer.

The tests are also designed so that we can test command behavior outside of the integration tests.