### PR TITLE
refactor: Simplify patch population

### DIFF
--- a/internal/cmd/certificates.go
+++ b/internal/cmd/certificates.go
@@ -28,9 +28,13 @@ type CertificatesCmd struct {
 }
 
 type Certificate struct {
-	MetroName string `mirror:"metro.name" field:"metro,short"`
-	Name      string `mirror:"certificate.name" field:",short"`
+	MetroName string `mirror:"metro.name" field:"metro,short" create:"set,required"`
+	Name      string `mirror:"certificate.name" field:",short" create:"set"`
 	UUID      string `mirror:"certificate.uuid" field:",long"`
+
+	CN         string `field:"cn,invisible" create:"set,required"`
+	Chain      string `field:"chain,invisible" create:"set,required"`
+	PrivateKey string `field:"pkey,invisible" create:"set,required"`
 
 	CommonName   string `mirror:"certificate.common_name" field:",short"`
 	Subject      string `mirror:"certificate.subject" field:",long"`
@@ -73,49 +77,7 @@ func (c Certificate) Raw() any {
 }
 
 func (c Certificate) Fields() ([]resource.Field, error) {
-	result, err := resource.FieldsFromStruct(c)
-	if err != nil {
-		return nil, err
-	}
-
-	for idx, field := range result {
-		switch field.Name {
-		case "name":
-			result[idx].Create = &resource.Patch{
-				Set: "",
-			}
-		case "metro":
-			result[idx].Create = &resource.Patch{
-				Set:      "",
-				Required: true,
-			}
-		}
-	}
-
-	// Add create-only fields for certificate upload
-	result = append(result, resource.Field{
-		Name: "cn",
-		Create: &resource.Patch{
-			Set:      "",
-			Required: true,
-		},
-	})
-	result = append(result, resource.Field{
-		Name: "chain",
-		Create: &resource.Patch{
-			Set:      "",
-			Required: true,
-		},
-	})
-	result = append(result, resource.Field{
-		Name: "pkey",
-		Create: &resource.Patch{
-			Set:      "",
-			Required: true,
-		},
-	})
-
-	return result, nil
+	return resource.FieldsFromStruct(c)
 }
 
 func (Certificate) List(ctx context.Context) ([]resource.Resource, error) {

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -45,16 +45,16 @@ type Instance struct {
 	Tags []string `mirror:"instance.tags"`
 
 	State InstanceState `mirror:"instance.state" field:",short"`
-	Image string        `mirror:"instance.image" field:",short"`
+	Image string        `mirror:"instance.image" field:",short" edit:"set"`
 
 	Runtime struct {
-		Args []string          `mirror:"instance.args" field:",short"`
-		Env  map[string]string `mirror:"instance.env" field:",long"`
+		Args []string          `mirror:"instance.args" field:",short" edit:"set"`
+		Env  map[string]string `mirror:"instance.env" field:",long" edit:"set,add,del=keys"`
 	}
 
 	Resources struct {
-		Memory int `mirror:"instance.memory_mb" field:",short"`
-		VCPUs  int `mirror:"instance.vcpus" field:"vcpus,short"`
+		Memory int `mirror:"instance.memory_mb" field:",short" edit:"set"`
+		VCPUs  int `mirror:"instance.vcpus" field:"vcpus,short" edit:"set"`
 	}
 
 	Volumes []*struct {
@@ -149,20 +149,6 @@ func (i Instance) Fields() ([]resource.Field, error) {
 		switch key.String() {
 		case "name":
 			field.Hyperlink = i.hyperlink()
-		case "image":
-			field.Patch = &resource.Patch{Set: ""}
-		case "runtime.args":
-			field.Patch = &resource.Patch{Set: []string{}}
-		case "runtime.env":
-			field.Patch = &resource.Patch{
-				Set: map[string]string{},
-				Add: map[string]string{},
-				Del: []string{},
-			}
-		case "resources.memory":
-			field.Patch = &resource.Patch{Set: 0}
-		case "resources.vcpus":
-			field.Patch = &resource.Patch{Set: 0}
 		}
 	}
 
@@ -324,17 +310,17 @@ func (Instance) Edit(ctx context.Context, target resource.Resource, fields []res
 }
 
 func (Instance) getFieldRequests(uuid string, path resource.FieldPath, field resource.Field) (reqs []platform.UpdateInstancesRequestItem) {
-	if field.Patch == nil {
+	if field.Edit == nil {
 		return reqs
 	}
-	if field.Patch.Set != nil {
-		reqs = append(reqs, Instance{}.getPatchRequest(uuid, path, field.Patch.Set, platform.UpdateInstancesRequestItemOpSet))
+	if field.Edit.Set != nil {
+		reqs = append(reqs, Instance{}.getPatchRequest(uuid, path, field.Edit.Set, platform.UpdateInstancesRequestItemOpSet))
 	}
-	if field.Patch.Add != nil {
-		reqs = append(reqs, Instance{}.getPatchRequest(uuid, path, field.Patch.Add, platform.UpdateInstancesRequestItemOpAdd))
+	if field.Edit.Add != nil {
+		reqs = append(reqs, Instance{}.getPatchRequest(uuid, path, field.Edit.Add, platform.UpdateInstancesRequestItemOpAdd))
 	}
-	if field.Patch.Del != nil {
-		reqs = append(reqs, Instance{}.getPatchRequest(uuid, path, field.Patch.Del, platform.UpdateInstancesRequestItemOpDel))
+	if field.Edit.Del != nil {
+		reqs = append(reqs, Instance{}.getPatchRequest(uuid, path, field.Edit.Del, platform.UpdateInstancesRequestItemOpDel))
 	}
 	return reqs
 }

--- a/internal/cmd/services.go
+++ b/internal/cmd/services.go
@@ -31,30 +31,30 @@ type ServicesCmd struct {
 }
 
 type ServiceGroup struct {
-	MetroName string `mirror:"metro.name" field:"metro,short"`
-	Name      string `mirror:"service_group.name" field:",short"`
+	MetroName string `mirror:"metro.name" field:"metro,short" create:"set,required"`
+	Name      string `mirror:"service_group.name" field:",short" create:"set"`
 	UUID      string `mirror:"service_group.uuid" field:",long"`
 
 	Persistent bool `mirror:"service_group.persistent" field:",long"`
 	Autoscale  bool `mirror:"service_group.autoscale" field:",short"`
 
 	Limits struct {
-		Soft uint64 `mirror:"service_group.soft_limit" field:",long"`
-		Hard uint64 `mirror:"service_group.hard_limit" field:",long"`
+		Soft uint64 `mirror:"service_group.soft_limit" field:",long" create:"set" edit:"set"`
+		Hard uint64 `mirror:"service_group.hard_limit" field:",long" create:"set" edit:"set"`
 	}
 
 	Timestamps struct {
 		CreatedAt time.Time `mirror:"service_group.created_at"`
 	}
 
-	Domains []Domain `mirror:"service_group.domains"`
+	Domains []Domain `mirror:"service_group.domains" create:"set" edit:"set,add,del"`
 
 	Instances []struct {
 		Name string `mirror:"name" field:",long"`
 		UUID string `mirror:"uuid" field:",long"`
 	} `mirror:"service_group.instances"`
 
-	Services []*Service `mirror:"service_group.services"`
+	Services []*Service `mirror:"service_group.services" create:"set,required" edit:"set,add,del"`
 
 	ServiceGroup platform.ServiceGroup `field:"-" json:"service_group"`
 	Metro        *config.Metro         `field:"-" json:"metro"`
@@ -142,25 +142,6 @@ func (s ServiceGroup) Fields() ([]resource.Field, error) {
 	}
 
 	for key, field := range resource.IterFields(result) {
-		switch key.String() {
-		case "metro":
-			field.Create = &resource.Patch{Set: "", Required: true}
-		case "name":
-			field.Create = &resource.Patch{Set: ""}
-		case "services":
-			// FIXME: del should support deleting by *just* port
-			field.Patch = &resource.Patch{Set: []*Service{}, Add: []*Service{}, Del: []*Service{}}
-			field.Create = &resource.Patch{Set: []*Service{}, Required: true}
-		case "domains":
-			field.Patch = &resource.Patch{Set: []Domain{}, Add: []Domain{}, Del: []Domain{}}
-			field.Create = &resource.Patch{Set: []Domain{}}
-		case "limits.soft":
-			field.Patch = &resource.Patch{Set: uint64(0)}
-			field.Create = &resource.Patch{Set: uint64(0)}
-		case "limits.hard":
-			field.Patch = &resource.Patch{Set: uint64(0)}
-			field.Create = &resource.Patch{Set: uint64(0)}
-		}
 		if key.MatchesString("domains.*.certificate") {
 			name, _ := field.Get("name")
 			uuid, _ := field.Get("uuid")
@@ -366,17 +347,17 @@ func (ServiceGroup) Edit(ctx context.Context, target resource.Resource, fields [
 }
 
 func (ServiceGroup) getFieldRequests(uuid string, key resource.FieldPath, field resource.Field) (reqs []platform.UpdateServiceGroupsRequestItem) {
-	if field.Patch == nil {
+	if field.Edit == nil {
 		return reqs
 	}
-	if field.Patch.Set != nil {
-		reqs = append(reqs, ServiceGroup{}.getPatchRequest(uuid, key, field.Patch.Set, platform.UpdateServiceGroupsRequestItemOpSet))
+	if field.Edit.Set != nil {
+		reqs = append(reqs, ServiceGroup{}.getPatchRequest(uuid, key, field.Edit.Set, platform.UpdateServiceGroupsRequestItemOpSet))
 	}
-	if field.Patch.Add != nil {
-		reqs = append(reqs, ServiceGroup{}.getPatchRequest(uuid, key, field.Patch.Add, platform.UpdateServiceGroupsRequestItemOpAdd))
+	if field.Edit.Add != nil {
+		reqs = append(reqs, ServiceGroup{}.getPatchRequest(uuid, key, field.Edit.Add, platform.UpdateServiceGroupsRequestItemOpAdd))
 	}
-	if field.Patch.Del != nil {
-		reqs = append(reqs, ServiceGroup{}.getPatchRequest(uuid, key, field.Patch.Del, platform.UpdateServiceGroupsRequestItemOpDel))
+	if field.Edit.Del != nil {
+		reqs = append(reqs, ServiceGroup{}.getPatchRequest(uuid, key, field.Edit.Del, platform.UpdateServiceGroupsRequestItemOpDel))
 	}
 	return reqs
 }

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -29,14 +29,14 @@ type VolumesCmd struct {
 }
 
 type Volume struct {
-	MetroName string `mirror:"metro.name" field:"metro,short"`
-	Name      string `mirror:"volume.name" field:",short"`
+	MetroName string `mirror:"metro.name" field:"metro,short" create:"set,required"`
+	Name      string `mirror:"volume.name" field:",short" create:"set"`
 	UUID      string `mirror:"volume.uuid" field:",long"`
 
 	Tags []string `mirror:"volume.tags"`
 
 	State      VolumeState `mirror:"volume.state" field:",short"`
-	Size       SizeMB      `mirror:"volume.size_mb" field:",short"`
+	Size       SizeMB      `mirror:"volume.size_mb" field:",short" create:"set,required" edit:"set"`
 	Persistent bool        `mirror:"volume.persistent" field:",long"`
 
 	Timestamps struct {
@@ -82,34 +82,7 @@ func (i Volume) Raw() any {
 }
 
 func (i Volume) Fields() ([]resource.Field, error) {
-	result, err := resource.FieldsFromStruct(i)
-	if err != nil {
-		return nil, err
-	}
-
-	for idx, field := range result {
-		switch field.Name {
-		case "name":
-			result[idx].Create = &resource.Patch{
-				Set: "",
-			}
-		case "metro":
-			result[idx].Create = &resource.Patch{
-				Set:      "",
-				Required: true,
-			}
-		case "size":
-			result[idx].Create = &resource.Patch{
-				Set:      SizeMB(0),
-				Required: true,
-			}
-			result[idx].Patch = &resource.Patch{
-				Set: SizeMB(0),
-			}
-		}
-	}
-
-	return result, nil
+	return resource.FieldsFromStruct(i)
 }
 
 func (Volume) List(ctx context.Context) ([]resource.Resource, error) {
@@ -286,17 +259,17 @@ func (Volume) Edit(ctx context.Context, target resource.Resource, fields []resou
 }
 
 func (Volume) getFieldRequests(uuid string, key resource.FieldPath, field resource.Field) (reqs []platform.UpdateVolumesRequestItem) {
-	if field.Patch == nil {
+	if field.Edit == nil {
 		return reqs
 	}
-	if field.Patch.Set != nil {
-		reqs = append(reqs, Volume{}.getPatchRequest(uuid, key, field.Patch.Set, platform.UpdateVolumesRequestItemOpSet))
+	if field.Edit.Set != nil {
+		reqs = append(reqs, Volume{}.getPatchRequest(uuid, key, field.Edit.Set, platform.UpdateVolumesRequestItemOpSet))
 	}
-	if field.Patch.Add != nil {
-		reqs = append(reqs, Volume{}.getPatchRequest(uuid, key, field.Patch.Add, platform.UpdateVolumesRequestItemOpAdd))
+	if field.Edit.Add != nil {
+		reqs = append(reqs, Volume{}.getPatchRequest(uuid, key, field.Edit.Add, platform.UpdateVolumesRequestItemOpAdd))
 	}
-	if field.Patch.Del != nil {
-		reqs = append(reqs, Volume{}.getPatchRequest(uuid, key, field.Patch.Del, platform.UpdateVolumesRequestItemOpDel))
+	if field.Edit.Del != nil {
+		reqs = append(reqs, Volume{}.getPatchRequest(uuid, key, field.Edit.Del, platform.UpdateVolumesRequestItemOpDel))
 	}
 	return reqs
 }

--- a/internal/resource/cmd/cmd_test.go
+++ b/internal/resource/cmd/cmd_test.go
@@ -422,14 +422,14 @@ func TestEdit(t *testing.T) {
 	require.NoError(t, err)
 
 	for key, field := range resource.IterFields(templateFields) {
-		if field.Patch == nil {
+		if field.Edit == nil {
 			continue
 		}
 		switch key.String() {
 		case "settings.x":
-			field.Patch.Set = 999
+			field.Edit.Set = 999
 		case "settings.y":
-			field.Patch.Set = "modified"
+			field.Edit.Set = "modified"
 		}
 	}
 

--- a/internal/resource/patch/collect.go
+++ b/internal/resource/patch/collect.go
@@ -106,7 +106,10 @@ func storeValue(field *resource.Field, base reflect.Value) error {
 			return fmt.Errorf("expected struct for field %s, got %s", field.Name, value.Kind().String())
 		}
 		for i := range value.NumField() {
-			parsedField := resource.ParseField(value.Type().Field(i))
+			parsedField, err := resource.ParseField(value.Type().Field(i))
+			if err != nil {
+				return err
+			}
 			if parsedField == nil {
 				continue
 			}
@@ -121,7 +124,7 @@ func storeValue(field *resource.Field, base reflect.Value) error {
 			if subfield == nil {
 				return fmt.Errorf("no subfield named %s in field %s", parsedField.Name, field.Name)
 			}
-			err := storeValue(subfield, value.Field(i))
+			err = storeValue(subfield, value.Field(i))
 			if err != nil {
 				return err
 			}

--- a/internal/resource/patch/filter.go
+++ b/internal/resource/patch/filter.go
@@ -9,7 +9,7 @@ import "unikraft.com/cli/internal/resource"
 
 func FilterPatchableFields(fields []resource.Field) []resource.Field {
 	return resource.FilterFields(fields, func(field resource.Field) resource.FilterResult {
-		if field.Patch != nil {
+		if field.Edit != nil {
 			return resource.FilterInclude
 		}
 		return resource.FilterPrune

--- a/internal/resource/patch/patch.go
+++ b/internal/resource/patch/patch.go
@@ -68,9 +68,9 @@ func PatchedFields(fields []resource.Field, spec PatchSpec) ([]resource.Field, e
 			field.Create = nil
 			patch = &field.Create
 		} else {
-			original = field.Patch
-			field.Patch = nil
-			patch = &field.Patch
+			original = field.Edit
+			field.Edit = nil
+			patch = &field.Edit
 		}
 		if original == nil {
 			original = &resource.Patch{}

--- a/internal/resource/patch/visual.go
+++ b/internal/resource/patch/visual.go
@@ -97,7 +97,7 @@ func saveFields(fields []resource.Field, patches []resource.Field, create bool) 
 		if create {
 			patch = field.Create
 		} else {
-			patch = field.Patch
+			patch = field.Edit
 		}
 		if patch == nil || patch.Set == nil {
 			continue
@@ -122,7 +122,7 @@ func saveFields(fields []resource.Field, patches []resource.Field, create bool) 
 			if create {
 				patch = patchedField.Create
 			} else {
-				patch = patchedField.Patch
+				patch = patchedField.Edit
 			}
 			if patch == nil {
 				return nil, fmt.Errorf("no patch available for field %s", keyStr)
@@ -197,7 +197,7 @@ func loadFieldPatches(ctx context.Context, fields []resource.Field, data []byte,
 		if create {
 			patch = field.Create
 		} else {
-			patch = field.Patch
+			patch = field.Edit
 		}
 		if patch == nil || patch.Set == nil {
 			continue
@@ -229,7 +229,7 @@ func patchField(path resource.FieldPath, before *resource.Field, after *resource
 	if create {
 		patch = before.Create
 	} else {
-		patch = before.Patch
+		patch = before.Edit
 	}
 
 	if before.Name != after.Name {
@@ -289,7 +289,7 @@ func patchField(path resource.FieldPath, before *resource.Field, after *resource
 	if create {
 		before.Create = patch
 	} else {
-		before.Patch = patch
+		before.Edit = patch
 	}
 
 	return nil

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -70,7 +70,7 @@ type Field struct {
 
 	// settings for creating or patching resources
 	Create *Patch `json:"create,omitempty"`
-	Patch  *Patch `json:"patch,omitempty"`
+	Edit   *Patch `json:"edit,omitempty"`
 }
 
 func (f Field) HasChildren() bool {

--- a/internal/resource/struct.go
+++ b/internal/resource/struct.go
@@ -6,6 +6,7 @@
 package resource
 
 import (
+	"fmt"
 	"reflect"
 	"slices"
 	"strconv"
@@ -60,7 +61,10 @@ func fieldFromStruct(pkgPath string, v reflect.Value) (field *Field, err error) 
 		}
 		fieldVal := s.Field(i)
 
-		parsedField := ParseField(field)
+		parsedField, err := ParseField(field)
+		if err != nil {
+			return nil, err
+		}
 		if parsedField == nil {
 			continue
 		}
@@ -68,6 +72,8 @@ func fieldFromStruct(pkgPath string, v reflect.Value) (field *Field, err error) 
 			Name:      parsedField.Name,
 			Verbosity: parsedField.Verbosity,
 			Value:     fieldVal.Interface(),
+			Create:    parsedField.Create,
+			Edit:      parsedField.Edit,
 		}
 
 		newField, err := fieldFromStruct(pkgPath, fieldVal)
@@ -155,16 +161,20 @@ func fieldFromSlice(pkgPath string, v reflect.Value) (field *Field, err error) {
 
 type ParsedField struct {
 	Name      string
+	Type      reflect.Type
 	Verbosity FieldVerbosity
+
+	Edit   *Patch
+	Create *Patch
 }
 
-func ParseField(field reflect.StructField) *ParsedField {
+func ParseField(field reflect.StructField) (*ParsedField, error) {
 	if !field.IsExported() {
-		return nil
+		return nil, nil
 	}
 	tag := field.Tag.Get("field")
 	if tag == "-" {
-		return nil
+		return nil, nil
 	}
 
 	opts := strings.Split(tag, ",")
@@ -188,9 +198,61 @@ func ParseField(field reflect.StructField) *ParsedField {
 		verbosity = FieldVerbosityHidden
 	}
 
+	edit, err := parsePatch(field.Type, field.Tag.Get("edit"))
+	if err != nil {
+		return nil, err
+	}
+	create, err := parsePatch(field.Type, field.Tag.Get("create"))
+	if err != nil {
+		return nil, err
+	}
+
 	return &ParsedField{
 		Name:      name,
 		Verbosity: verbosity,
+		Type:      field.Type,
+		Edit:      edit,
+		Create:    create,
+	}, nil
+}
+
+func parsePatch(tp reflect.Type, tag string) (*Patch, error) {
+	if tag == "" {
+		return nil, nil
+	}
+	parts := strings.Split(tag, ",")
+	patch := &Patch{}
+	for _, part := range parts {
+		k, v, _ := strings.Cut(part, "=")
+		var err error
+		switch k {
+		case "set":
+			patch.Set, err = parsePatchValue(tp, v)
+		case "add":
+			patch.Add, err = parsePatchValue(tp, v)
+		case "del":
+			patch.Del, err = parsePatchValue(tp, v)
+		case "required":
+			patch.Required = true
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	return patch, nil
+}
+
+func parsePatchValue(tp reflect.Type, value string) (any, error) {
+	switch value {
+	case "":
+		return reflect.Zero(tp).Interface(), nil
+	case "keys":
+		if tp.Kind() == reflect.Map {
+			return reflect.Zero(tp.Key()).Interface(), nil
+		}
+		return nil, fmt.Errorf("keys patch value only valid for map types")
+	default:
+		return nil, fmt.Errorf("unknown patch value: %s", value)
 	}
 }
 

--- a/internal/resource/testing/resource.go
+++ b/internal/resource/testing/resource.go
@@ -88,7 +88,7 @@ func (t TestResource) Fields() ([]resource.Field, error) {
 					Create: &resource.Patch{
 						Set: 0,
 					},
-					Patch: &resource.Patch{
+					Edit: &resource.Patch{
 						Set: 0,
 					},
 				},
@@ -99,7 +99,7 @@ func (t TestResource) Fields() ([]resource.Field, error) {
 					Create: &resource.Patch{
 						Set: "",
 					},
-					Patch: &resource.Patch{
+					Edit: &resource.Patch{
 						Set: "",
 					},
 				},
@@ -204,14 +204,14 @@ func (TestResource) Edit(ctx context.Context, target resource.Resource, fields [
 	t := target.(TestResource)
 
 	for key, field := range resource.IterFields(fields) {
-		if field.Patch == nil || field.Patch.Set == nil {
+		if field.Edit == nil || field.Edit.Set == nil {
 			continue
 		}
 		switch key.String() {
 		case "settings.x":
-			t.Settings.X = field.Patch.Set.(int)
+			t.Settings.X = field.Edit.Set.(int)
 		case "settings.y":
-			t.Settings.Y = field.Patch.Set.(string)
+			t.Settings.Y = field.Edit.Set.(string)
 		}
 	}
 


### PR DESCRIPTION
We can automatically pull these from the type of the field, we don't need to do the weird iteration + population in most cases.

Resolves https://linear.app/unikraft/issue/CLI-57/simpler-patch-creation