### PR TITLE
feat: Show help when running parent command

### DIFF
--- a/cmd/unikraft/testdata/TestGolden/empty
+++ b/cmd/unikraft/testdata/TestGolden/empty
@@ -1,5 +1,57 @@
 $ unikraft
 
+stdout:
+	Usage:
+	  unikraft <command> [flags]
+
+	Version:
+	  dev (GOOS/GOARCH)
+
+	Commands:
+	  login
+	          Login to Unikraft Cloud.
+	  logout
+	          Logout from Unikraft Cloud.
+	  profile, profiles
+	          Manage Unikraft Cloud profiles.
+	  metros, metro
+	          Manage Unikraft Cloud metros.
+	  instances, instance
+	          Manage Unikraft Cloud instances.
+	  volumes, volume
+	          Manage Unikraft Cloud volumes.
+	  services, service
+	          Manage Unikraft Cloud services.
+	  certificates, certificate
+	          Manage Unikraft Cloud certificates.
+	  images, image
+	          Manage Unikraft Cloud images.
+
+	Global flags:
+	  -h, --help
+	          Show context-sensitive help.
+	  -c, --config ($UNIKRAFT_CONFIG)
+	          Set the configuration file.
+	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	          Enable or disable telemetry.
+	          [default: true]
+	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	          Enable or disable emojis in the CLI output.
+	          [default: true]
+	      --log-level ($UNIKRAFT_LOG_LEVEL)
+	          Set the logging level.
+	          [default: info, choice: trace,debug,info,warn,error,fatal]
+	      --log-type ($UNIKRAFT_LOG_TYPE)
+	          Set the log type.
+	          [default: text, choice: text,json]
+	      --profile ($UNIKRAFT_PROFILE)
+	          Set the current profile.
+	          [default: default]
+	  -v, --version
+	          Print version information.
+
+	Run "unikraft <command> --help" for more information on a command.
+
 stderr:
 	HH:MM ERR  
 	HH:MM ERR error:

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -7,11 +7,15 @@ package cmd
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"maps"
+	"os"
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strings"
 
 	"github.com/alecthomas/kong"
 	kongyaml "github.com/alecthomas/kong-yaml"
@@ -53,6 +57,18 @@ func NewRootCmd(ctx context.Context, args []string, stdin io.Reader, stdout, std
 	parser.Stderr = stderr
 
 	kctx, err := parser.Parse(args)
+
+	var parseErr *kong.ParseError
+	if errors.As(err, &parseErr) {
+		// HACK: kong provides UsageOnError, but this shows help for *all* parse
+		// errors - we only want to show it only for parent commands.
+		// See https://github.com/alecthomas/kong/issues/33
+		if strings.HasPrefix(parseErr.Error(), "expected one of") {
+			_ = parseErr.Context.PrintUsage(false)
+			fmt.Fprintln(os.Stdout)
+		}
+	}
+
 	if err != nil {
 		return nil, nil, nil, jujuerrors.Annotate(err, "parsing arguments")
 	}


### PR DESCRIPTION
Before:

```
❯ unikraft
8:10PM ERR  
8:10PM ERR error:
8:10PM ERR   parsing arguments: expected one of "login", "logout", "profile", "metros", "instances", ...
8:10PM ERR  
```

After:

```
❯ unikraft
Usage:
  unikraft <command> [flags]

Version:
  dev (linux/amd64)

Commands:
  login
          Login to Unikraft Cloud.
  logout
          Logout from Unikraft Cloud.
  profile, profiles
          Manage Unikraft Cloud profiles.
  metros, metro
          Manage Unikraft Cloud metros.
  instances, instance
          Manage Unikraft Cloud instances.
  volumes, volume
          Manage Unikraft Cloud volumes.
  services, service
          Manage Unikraft Cloud services.
  certificates, certificate
          Manage Unikraft Cloud certificates.
  images, image
          Manage Unikraft Cloud images.

Global flags:
  -h, --help
          Show context-sensitive help.
  -c, --config ($UNIKRAFT_CONFIG)
          Set the configuration file.
      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
          Enable or disable telemetry.
          [default: true]
      --[no-]emojis ($UNIKRAFT_EMOJIS)
          Enable or disable emojis in the CLI output.
          [default: true]
      --log-level ($UNIKRAFT_LOG_LEVEL)
          Set the logging level.
          [default: info, choice: trace,debug,info,warn,error,fatal]
      --log-type ($UNIKRAFT_LOG_TYPE)
          Set the log type.
          [default: text, choice: text,json]
      --profile ($UNIKRAFT_PROFILE)
          Set the current profile.
          [default: default]
  -v, --version
          Print version information.

Run "unikraft <command> --help" for more information on a command.
```