### PR TITLE
fix: Ensure image fields are correctly parsed

### DIFF
--- a/cmd/unikraft/main_test.go
+++ b/cmd/unikraft/main_test.go
@@ -154,6 +154,23 @@ var testCases = []testCase{
 			{args: []string{unikraftCmd, "certificate", "delete", "test-$UNIQ_CERT_A", "test-$UNIQ_CERT_B"}},
 		},
 	},
+
+	{
+		name:   "images",
+		online: true,
+		commands: []command{
+			{args: []string{unikraftCmd, "login"}, token: true},
+			{args: []string{unikraftCmd, "image", "list", "--filter", "ref~=^nginx:"}},
+			{args: []string{unikraftCmd, "image", "inspect", "nginx:latest"}},
+		},
+		cleaners: []cleaner{
+			{
+				// exact nginx version numbers may change between runs
+				pattern: regexp.MustCompile(`nginx:[0-9]+\.[0-9]+`),
+				repl:    "nginx:X.Y",
+			},
+		},
+	},
 }
 
 var (
@@ -377,6 +394,11 @@ var cleaners = []cleaner{
 		// uuids like "12345678-1234-1234-1234-123456789abc" change between runs
 		pattern: regexp.MustCompile(`\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b`),
 		repl:    "12345678-1234-1234-1234-123456789abc",
+	},
+	{
+		// image digests like "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" may change between runs
+		pattern: regexp.MustCompile(`\bsha256:[0-9a-f]{64}\b`),
+		repl:    "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
 	},
 }
 

--- a/cmd/unikraft/testdata/TestGolden/images
+++ b/cmd/unikraft/testdata/TestGolden/images
@@ -1,0 +1,23 @@
+$ unikraft login
+
+stderr:
+	HH:MM INF using authentication token from UKC_TOKEN environment variable
+	HH:MM WRN no metros configured; please add them manually
+	HH:MM INF login successful
+
+$ unikraft image list --filter ref~=^nginx:
+
+stdout:
+	METRO  REF               DIGEST
+	test   nginx:latest-dbg  sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
+	test   nginx:X.Y-dbg    sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
+	test   nginx:latest      sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
+	test   nginx:X.Y        sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
+
+$ unikraft image inspect nginx:latest
+
+stdout:
+	metro:  test
+	ref:    nginx:latest
+	refs:   [nginx:latest nginx:X.Y]
+	digest: sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890

--- a/internal/cmd/services.go
+++ b/internal/cmd/services.go
@@ -47,14 +47,14 @@ type ServiceGroup struct {
 		CreatedAt time.Time `mirror:"service_group.created_at"`
 	}
 
-	Domains []Domain `mirror:"service_group.domains" create:"set" edit:"set,add,del"`
+	Domains []Domain `mirror:"service_group.domains" field:",embed" create:"set" edit:"set,add,del"`
 
 	Instances []struct {
 		Name string `mirror:"name" field:",long"`
 		UUID string `mirror:"uuid" field:",long"`
 	} `mirror:"service_group.instances"`
 
-	Services []*Service `mirror:"service_group.services" create:"set,required" edit:"set,add,del"`
+	Services []*Service `mirror:"service_group.services" field:",embed" create:"set,required" edit:"set,add,del"`
 
 	ServiceGroup platform.ServiceGroup `field:"-" json:"service_group"`
 	Metro        *config.Metro         `field:"-" json:"metro"`

--- a/internal/resource/struct.go
+++ b/internal/resource/struct.go
@@ -20,7 +20,7 @@ import (
 // FieldsFromStruct is a helper that converts a struct into a slice of Fields
 // based on the `field` tags defined on the struct's fields.
 func FieldsFromStruct(s any) (fields []Field, err error) {
-	field, err := fieldFromStruct("", reflect.ValueOf(s))
+	field, err := fieldFromStruct(true, reflect.ValueOf(s))
 	if err != nil {
 		return nil, err
 	}
@@ -32,7 +32,7 @@ type ValueField interface {
 	Parse(s string) error
 }
 
-func fieldFromStruct(pkgPath string, v reflect.Value) (field *Field, err error) {
+func fieldFromStruct(embed bool, v reflect.Value) (field *Field, err error) {
 	s := v
 	if s.Kind() == reflect.Pointer {
 		if s.IsNil() {
@@ -46,10 +46,7 @@ func fieldFromStruct(pkgPath string, v reflect.Value) (field *Field, err error) 
 	}
 	t := s.Type()
 
-	if pkgPath == "" {
-		pkgPath = s.Type().PkgPath()
-	}
-	if t.PkgPath() != "" && t.PkgPath() != pkgPath {
+	if t.Name() != "" && !embed {
 		return nil, nil
 	}
 
@@ -76,7 +73,7 @@ func fieldFromStruct(pkgPath string, v reflect.Value) (field *Field, err error) 
 			Edit:      parsedField.Edit,
 		}
 
-		newField, err := fieldFromStruct(pkgPath, fieldVal)
+		newField, err := fieldFromStruct(parsedField.Embed, fieldVal)
 		if err != nil {
 			return nil, err
 		}
@@ -86,7 +83,7 @@ func fieldFromStruct(pkgPath string, v reflect.Value) (field *Field, err error) 
 			result.Verbosity = max(result.Verbosity, newField.Verbosity)
 		}
 
-		newField, err = fieldFromSlice(pkgPath, fieldVal)
+		newField, err = fieldFromSlice(parsedField.Embed, fieldVal)
 		if err != nil {
 			return nil, err
 		}
@@ -116,7 +113,7 @@ func fieldFromStruct(pkgPath string, v reflect.Value) (field *Field, err error) 
 	}, nil
 }
 
-func fieldFromSlice(pkgPath string, v reflect.Value) (field *Field, err error) {
+func fieldFromSlice(embed bool, v reflect.Value) (field *Field, err error) {
 	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			v = reflect.New(v.Type().Elem())
@@ -130,7 +127,7 @@ func fieldFromSlice(pkgPath string, v reflect.Value) (field *Field, err error) {
 
 	elemType := v.Type().Elem()
 	elemVal := reflect.New(elemType).Elem()
-	elem, err := fieldFromStruct(pkgPath, elemVal)
+	elem, err := fieldFromStruct(embed, elemVal)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +138,7 @@ func fieldFromSlice(pkgPath string, v reflect.Value) (field *Field, err error) {
 	var fields []Field
 	for i := range v.Len() {
 		vv := v.Index(i)
-		field, err := fieldFromStruct(pkgPath, vv)
+		field, err := fieldFromStruct(embed, vv)
 		if err != nil {
 			return nil, err
 		}
@@ -163,6 +160,8 @@ type ParsedField struct {
 	Name      string
 	Type      reflect.Type
 	Verbosity FieldVerbosity
+
+	Embed bool
 
 	Edit   *Patch
 	Create *Patch
@@ -207,10 +206,13 @@ func ParseField(field reflect.StructField) (*ParsedField, error) {
 		return nil, err
 	}
 
+	embed := slices.Contains(opts, "embed")
+
 	return &ParsedField{
 		Name:      name,
 		Verbosity: verbosity,
 		Type:      field.Type,
+		Embed:     embed,
 		Edit:      edit,
 		Create:    create,
 	}, nil


### PR DESCRIPTION
Due to a change in how fields were parsed, we were incorrectly inspecting the contents of the ImageRef struct, when it should be treated as entirely opaque.

To do handle this, we instead hopefully fix this once and for all by fixing the navigation rules:
- We always inspect anonymous structs
- Otherwise, the field needs the "embed" value in the field tag

Also, adds an integration test which would have caught this behavior in the first place.