### PR TITLE
fix: Use --output instead of --format in tests

### DIFF
--- a/.github/workflows/check-static.yaml
+++ b/.github/workflows/check-static.yaml
@@ -2,7 +2,7 @@ name: check/static
 
 on:
   push:
-    branches: [prod-staging, prod-stable]
+    branches: [staging, stable]
   pull_request:
     branches:
     - staging

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ permissions:
 
 on:
   push:
-    branches: [prod-staging, prod-stable]
+    branches: [staging, stable]
   pull_request:
     branches: [staging]
     paths:

--- a/cmd/unikraft/instances_test.go
+++ b/cmd/unikraft/instances_test.go
@@ -41,7 +41,7 @@ var instancesTestCases = []testCase{
 			{
 				args: []string{
 					unikraftCmd, "instance", "inspect", "test-$UNIQ_INST",
-					"--format", `{{ (index (index (index (index . 0) "service") "domains") 0).fqdn }}`,
+					"--output", "template=" + `{{ (index (index (index (index . 0) "service") "domains") 0).fqdn }}`,
 				},
 				captureEnv: "FQDN",
 			},

--- a/cmd/unikraft/testdata/TestGolden/instances
+++ b/cmd/unikraft/testdata/TestGolden/instances
@@ -104,7 +104,7 @@ stdout:
 	  private-ip: 10.X.X.X
 	  mac:        aa:bb:cc:dd:ee:ff
 
-$ FQDN=$(unikraft instance inspect test-$UNIQ_INST --format '{{ (index (index (index (index . 0) "service") "domains") 0).fqdn }}')
+$ FQDN=$(unikraft instance inspect test-$UNIQ_INST --output 'template={{ (index (index (index (index . 0) "service") "domains") 0).fqdn }}')
 
 $ curl -k --fail --silent --show-error --output /dev/null --write-out 'HTTP %{http_code} OK\n%header{server}\n' --retry 10 --retry-delay 2 --retry-all-errors --connect-timeout 5 --max-time 10 https://$FQDN
 


### PR DESCRIPTION
Looks like merging:
- https://github.com/unikraft/cli/pull/62
- https://github.com/unikraft/cli/pull/52
In quick succession made the tests start failing.

This PR fixes the failing issue, and also ensures we actually run tests on `staging` to catch these.