### PR TITLE
fix(login): Ignore UKC_TOKEN

### DIFF
--- a/cmd/unikraft/auth_test.go
+++ b/cmd/unikraft/auth_test.go
@@ -10,10 +10,12 @@ var authTestCases = []testCase{
 		name:   "auth",
 		online: true,
 		commands: []command{
-			{args: []string{unikraftCmd, "login"}, token: true},
+			{args: []string{unikraftCmd, "login", "--check"}},
 			{args: []string{unikraftCmd, "profile", "list"}},
 			{args: []string{unikraftCmd, "metro", "list"}},
 			{args: []string{unikraftCmd, "logout"}},
+			{args: []string{unikraftCmd, "profile", "list"}, allowErr: true},
+			{args: []string{unikraftCmd, "metro", "list"}, allowErr: true},
 		},
 	},
 }

--- a/cmd/unikraft/certificates_test.go
+++ b/cmd/unikraft/certificates_test.go
@@ -10,7 +10,6 @@ var certificatesTestCases = []testCase{
 		name:   "certificates",
 		online: true,
 		commands: []command{
-			{args: []string{unikraftCmd, "login"}, token: true},
 			{args: []string{unikraftCmd, "certificate", "list"}},
 			{args: []string{unikraftCmd, "certificate", "create", "--set", "name=test-$UNIQ_CERT_A", "--set", "cn=$CERT_A_CN", "--set", "chain=$CERT_A_CHAIN", "--set", "pkey=$CERT_A_KEY", "--set", "metro=" + defaultMetro}},
 			{args: []string{unikraftCmd, "certificate", "create", "--set", "name=test-$UNIQ_CERT_B", "--set", "cn=$CERT_B_CN", "--set", "chain=$CERT_B_CHAIN", "--set", "pkey=$CERT_B_KEY", "--set", "metro=" + defaultMetro}},

--- a/cmd/unikraft/images_test.go
+++ b/cmd/unikraft/images_test.go
@@ -3,8 +3,6 @@
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
 
-//go:build integration
-
 package main
 
 import "regexp"
@@ -14,7 +12,6 @@ var imagesTestCases = []testCase{
 		name:   "images",
 		online: true,
 		commands: []command{
-			{args: []string{unikraftCmd, "login"}, token: true},
 			{args: []string{unikraftCmd, "image", "list", "--filter", `ref~="^nginx:latest$"`}},
 			{args: []string{unikraftCmd, "image", "inspect", "nginx:latest"}},
 		},

--- a/cmd/unikraft/instances_test.go
+++ b/cmd/unikraft/instances_test.go
@@ -12,7 +12,6 @@ var instancesTestCases = []testCase{
 		name:   "instances",
 		online: true,
 		commands: []command{
-			{args: []string{unikraftCmd, "login"}, token: true},
 			{args: []string{unikraftCmd, "instance", "list"}},
 
 			// Create an nginx instance with a service

--- a/cmd/unikraft/main_test.go
+++ b/cmd/unikraft/main_test.go
@@ -53,7 +53,6 @@ type testCase struct {
 type command struct {
 	args       []string
 	allowErr   bool
-	token      bool
 	captureEnv string
 }
 
@@ -134,9 +133,6 @@ func TestGolden(t *testing.T) {
 				cmd.Env = append(cmd.Env, "NO_COLOR=1") // color makes golden files harder to read
 				cmd.Env = append(cmd.Env, resource.UnikraftSandboxEnv+"="+sandboxPath)
 				cmd.Env = append(cmd.Env, config.UnikraftConfigDirEnv+"="+configdir)
-				if command.token {
-					cmd.Env = append(cmd.Env, "UKC_TOKEN="+testToken)
-				}
 
 				err := cmd.Run()
 				if command.captureEnv != "" {
@@ -418,7 +414,7 @@ func defaultCfg() (*config.Config, *config.Profile) {
 	profile := &config.Profile{
 		Type:  config.ProfileTypeCloud,
 		Name:  "default",
-		Token: "", // populated via login
+		Token: testToken,
 	}
 	for _, metro := range testMetros {
 		profile.Metros = append(profile.Metros, config.Metro{
@@ -429,9 +425,9 @@ func defaultCfg() (*config.Config, *config.Profile) {
 		break
 	}
 	cfg := &config.Config{
-		Profile: "test",
+		Profile: profile.Name,
 		Profiles: map[string]config.Profile{
-			"test": *profile,
+			profile.Name: *profile,
 		},
 	}
 	return cfg, profile

--- a/cmd/unikraft/services_test.go
+++ b/cmd/unikraft/services_test.go
@@ -12,7 +12,6 @@ var servicesTestCases = []testCase{
 		name:   "services",
 		online: true,
 		commands: []command{
-			{args: []string{unikraftCmd, "login"}, token: true},
 			{args: []string{unikraftCmd, "service", "list"}},
 			{args: []string{
 				unikraftCmd, "service", "create",

--- a/cmd/unikraft/testdata/TestGolden/auth
+++ b/cmd/unikraft/testdata/TestGolden/auth
@@ -1,15 +1,12 @@
-$ unikraft login
+$ unikraft login --check
 
 stderr:
-	HH:MM INF using authentication token from UKC_TOKEN environment variable
-	HH:MM WRN no metros configured; please add them manually
-	HH:MM INF login successful
+	HH:MM INF existing authentication token found
 
 $ unikraft profile list
 
 stdout:
 	NAME     ACTIVE  METROS
-	default  true    [test]
 	default  true    [test]
 
 $ unikraft metro list
@@ -22,3 +19,23 @@ $ unikraft logout
 
 stderr:
 	HH:MM INF logout successful
+
+$ unikraft profile list
+
+stdout:
+	NAME  ACTIVE  METROS
+
+$ unikraft metro list
+
+stderr:
+	HH:MM ERR  
+	HH:MM ERR error:
+	HH:MM ERR   profile not setup;
+	HH:MM ERR   
+	HH:MM ERR   use `unikraft login` to get started,
+	HH:MM ERR   
+	HH:MM ERR   or visit https://unikraft.com/docs/cli for more information
+	HH:MM ERR  
+	exit status 1
+
+exit code: 1

--- a/cmd/unikraft/testdata/TestGolden/certificates
+++ b/cmd/unikraft/testdata/TestGolden/certificates
@@ -1,10 +1,3 @@
-$ unikraft login
-
-stderr:
-	HH:MM INF using authentication token from UKC_TOKEN environment variable
-	HH:MM WRN no metros configured; please add them manually
-	HH:MM INF login successful
-
 $ unikraft certificate list
 
 stdout:

--- a/cmd/unikraft/testdata/TestGolden/images
+++ b/cmd/unikraft/testdata/TestGolden/images
@@ -1,10 +1,3 @@
-$ unikraft login
-
-stderr:
-	HH:MM INF using authentication token from UKC_TOKEN environment variable
-	HH:MM WRN no metros configured; please add them manually
-	HH:MM INF login successful
-
 $ unikraft image list --filter ref~="^nginx:latest$"
 
 stdout:

--- a/cmd/unikraft/testdata/TestGolden/instances
+++ b/cmd/unikraft/testdata/TestGolden/instances
@@ -1,10 +1,3 @@
-$ unikraft login
-
-stderr:
-	HH:MM INF using authentication token from UKC_TOKEN environment variable
-	HH:MM WRN no metros configured; please add them manually
-	HH:MM INF login successful
-
 $ unikraft instance list
 
 stdout:

--- a/cmd/unikraft/testdata/TestGolden/services
+++ b/cmd/unikraft/testdata/TestGolden/services
@@ -1,10 +1,3 @@
-$ unikraft login
-
-stderr:
-	HH:MM INF using authentication token from UKC_TOKEN environment variable
-	HH:MM WRN no metros configured; please add them manually
-	HH:MM INF login successful
-
 $ unikraft service list
 
 stdout:

--- a/cmd/unikraft/testdata/TestGolden/volumes
+++ b/cmd/unikraft/testdata/TestGolden/volumes
@@ -1,10 +1,3 @@
-$ unikraft login
-
-stderr:
-	HH:MM INF using authentication token from UKC_TOKEN environment variable
-	HH:MM WRN no metros configured; please add them manually
-	HH:MM INF login successful
-
 $ unikraft volume list
 
 stdout:

--- a/cmd/unikraft/volumes_test.go
+++ b/cmd/unikraft/volumes_test.go
@@ -10,7 +10,6 @@ var volumesTestCases = []testCase{
 		name:   "volumes",
 		online: true,
 		commands: []command{
-			{args: []string{unikraftCmd, "login"}, token: true},
 			{args: []string{unikraftCmd, "volume", "list"}},
 			{args: []string{unikraftCmd, "volume", "create", "--set", "name=test-$UNIQ_VOLUME", "--set", "size=10", "--set", "metro=" + defaultMetro}},
 			{args: []string{unikraftCmd, "volume", "list"}},

--- a/internal/cmd/login/login.go
+++ b/internal/cmd/login/login.go
@@ -7,7 +7,6 @@ package login
 
 import (
 	"context"
-	"os"
 	"time"
 
 	jujuerrors "github.com/juju/errors"
@@ -20,10 +19,13 @@ import (
 )
 
 type LoginCmd struct {
-	Timeout       time.Duration `short:"t" long:"timeout" default:"5m" help:"Timeout for the login request."`
-	Controlplane  string        `long:"controlplane" default:"https://controlplane.unikraft.cloud" help:"Control plane URL to use for login."`
-	AllowInsecure bool          `long:"allow-insecure" short:"k" help:"Allow insecure server connections when using SSL."`
-	NoBrowser     bool          `long:"no-browser" help:"Do not open the browser automatically for login."`
+	Check   bool          `long:"check" help:"Check if the user is already logged in."`
+	Timeout time.Duration `short:"t" long:"timeout" default:"5m" help:"Timeout for the login request."`
+
+	Controlplane  string `long:"controlplane" default:"https://controlplane.unikraft.cloud" help:"Control plane URL to use for login."`
+	AllowInsecure bool   `long:"allow-insecure" short:"k" help:"Allow insecure server connections when using SSL."`
+
+	NoBrowser bool `long:"no-browser" help:"Do not open the browser automatically for login."`
 }
 
 func (cmd *LoginCmd) Run(cfg *config.Config) error {
@@ -48,24 +50,26 @@ func (cmd *LoginCmd) Run(cfg *config.Config) error {
 		return jujuerrors.Annotate(err, "getting current profile")
 	}
 
+	if cmd.Check {
+		if profile.Token != "" {
+			log.G(ctx).Info().
+				Msg("existing authentication token found")
+			return nil
+		}
+		return jujuerrors.Errorf("no existing authentication token found")
+	}
+
 	if profile.Token != "" {
 		log.G(ctx).Info().
 			Msg("existing authentication token found, re-authenticating")
 	}
 
-	if token := os.Getenv("UKC_TOKEN"); token != "" {
-		// TODO: validate token
-		log.G(ctx).Info().
-			Msg("using authentication token from UKC_TOKEN environment variable")
-		profile.Token = token
-	} else {
-		resp, err := cmd.getAuth(ctx, profile)
-		if err != nil {
-			return jujuerrors.Annotate(err, "getting authentication token")
-		}
-		profile.Token = *resp.Token
-		profile.Organization = *resp.OrganizationName
+	resp, err := cmd.getAuth(ctx, profile)
+	if err != nil {
+		return jujuerrors.Annotate(err, "getting authentication token")
 	}
+	profile.Token = *resp.Token
+	profile.Organization = *resp.OrganizationName
 
 	log.G(ctx).
 		Warn().


### PR DESCRIPTION
We can ignore `UKC_TOKEN` - it was only added for testing, and we can just construct our config in the test instead of hijacking that old legacy env var.

This was my "other idea" for https://github.com/unikraft/cli/pull/42.