### PR TITLE
feat: Add diffs for more instance commands

### DIFF
--- a/cmd/unikraft/instances_test.go
+++ b/cmd/unikraft/instances_test.go
@@ -90,6 +90,11 @@ var instancesTestCases = []testCase{
 				pattern: regexp.MustCompile(`\bstate:(\s+)(running|starting)`),
 				repl:    "state:${1}running",
 			},
+			{
+				// states can be stopping/stoped
+				pattern: regexp.MustCompile(`\bstate:(\s+)(stopping|stopped)`),
+				repl:    "state:${1}stopped",
+			},
 		},
 	},
 }

--- a/cmd/unikraft/main_test.go
+++ b/cmd/unikraft/main_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode"
 
 	"github.com/lunixbochs/vtclean"
 	"github.com/stretchr/testify/assert"
@@ -229,11 +230,11 @@ func (report *report) String() string {
 }
 
 func (report *report) cleanOutput(s string) string {
-	// remove ANSI escape sequences and trim whitespace
+	// remove ANSI escape sequences
 	s = vtclean.Clean(s, false)
-	s = strings.TrimSpace(s)
+	s = strings.TrimRightFunc(s, unicode.IsSpace)
 	if s == "" {
-		return s
+		return ""
 	}
 
 	// apply any necessary cleanup to the output here

--- a/cmd/unikraft/testdata/TestGolden/instances
+++ b/cmd/unikraft/testdata/TestGolden/instances
@@ -56,7 +56,7 @@ stdout:
 $ unikraft instance stop test-$UNIQ_INST
 
 stdout:
-	metro:         test
+	  metro:         test
 	  name:          test-<INST>
 	  uuid:          12345678-1234-1234-1234-123456789abc
 	- state:         running
@@ -101,7 +101,7 @@ stdout:
 $ unikraft instance start test-$UNIQ_INST
 
 stdout:
-	metro:         test
+	  metro:         test
 	  name:          test-<INST>
 	  uuid:          12345678-1234-1234-1234-123456789abc
 	- state:         stopped

--- a/cmd/unikraft/testdata/TestGolden/instances
+++ b/cmd/unikraft/testdata/TestGolden/instances
@@ -55,6 +55,27 @@ stdout:
 
 $ unikraft instance stop test-$UNIQ_INST
 
+stdout:
+	metro:         test
+	  name:          test-<INST>
+	  uuid:          12345678-1234-1234-1234-123456789abc
+	- state:         running
+	+ state:         stopped
+	  image:         nginx
+	  resources:
+	    memory:      128
+	    vcpus:       1
+	  service:
+	    uuid:        12345678-1234-1234-1234-123456789abc
+	    name:        <SERVICE_NAME>
+	    domains:
+	    - fqdn:      <DOMAIN>.unikraft.internal
+	  networks:
+	  - uuid:        12345678-1234-1234-1234-123456789abc
+	    private-ip:  10.X.X.X
+	    mac:         aa:bb:cc:dd:ee:ff
+	  scale-to-zero:
+
 $ unikraft instance inspect test-$UNIQ_INST
 
 stdout:
@@ -78,6 +99,27 @@ stdout:
 	scale-to-zero:
 
 $ unikraft instance start test-$UNIQ_INST
+
+stdout:
+	metro:         test
+	  name:          test-<INST>
+	  uuid:          12345678-1234-1234-1234-123456789abc
+	- state:         stopped
+	+ state:         running
+	  image:         nginx
+	  resources:
+	    memory:      128
+	    vcpus:       1
+	  service:
+	    uuid:        12345678-1234-1234-1234-123456789abc
+	    name:        <SERVICE_NAME>
+	    domains:
+	    - fqdn:      <DOMAIN>.unikraft.internal
+	  networks:
+	  - uuid:        12345678-1234-1234-1234-123456789abc
+	    private-ip:  10.X.X.X
+	    mac:         aa:bb:cc:dd:ee:ff
+	  scale-to-zero:
 
 $ unikraft instance inspect test-$UNIQ_INST
 

--- a/cmd/unikraft/testdata/TestGolden/services
+++ b/cmd/unikraft/testdata/TestGolden/services
@@ -86,7 +86,7 @@ stdout:
 $ unikraft service edit test-$UNIQ_SVC_A --add services=1000:2000/tls
 
 stdout:
-	metro:         test
+	  metro:         test
 	  name:          test-<SVC_A>
 	  uuid:          12345678-1234-1234-1234-123456789abc
 	  persistent:    true
@@ -106,7 +106,7 @@ stdout:
 $ unikraft service edit test-$UNIQ_SVC_B --set services=1000:2000/tls
 
 stdout:
-	metro:         test
+	  metro:         test
 	  name:          test-<SVC_B>
 	  uuid:          12345678-1234-1234-1234-123456789abc
 	  persistent:    true
@@ -162,7 +162,7 @@ stdout:
 $ unikraft service edit test-$UNIQ_SVC_A --del services=1000:2000/tls
 
 stdout:
-	metro:         test
+	  metro:         test
 	  name:          test-<SVC_A>
 	  uuid:          12345678-1234-1234-1234-123456789abc
 	  persistent:    true
@@ -182,7 +182,7 @@ stdout:
 $ unikraft service edit test-$UNIQ_SVC_B --del services=1000:2000/tls
 
 stdout:
-	metro:         test
+	  metro:         test
 	  name:          test-<SVC_B>
 	  uuid:          12345678-1234-1234-1234-123456789abc
 	  persistent:    true

--- a/cmd/unikraft/testdata/TestGolden/volumes
+++ b/cmd/unikraft/testdata/TestGolden/volumes
@@ -32,7 +32,7 @@ stdout:
 $ unikraft volume edit test-$UNIQ_VOLUME --set size=20
 
 stdout:
-	metro:      test
+	  metro:      test
 	  name:       test-<VOLUME>
 	  uuid:       12345678-1234-1234-1234-123456789abc
 	  state:      available

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -659,32 +659,32 @@ type InstancesStartCmd struct {
 	Name []string `arg:"" predictor:"resource-key-instance" help:"Names of the instances to start."`
 }
 
-func (cmd *InstancesStartCmd) Run(ctx context.Context) error {
+func (c *InstancesStartCmd) Run(ctx context.Context) error {
+	cfg := config.FromContextOrDefault(ctx)
+
+	keys := multimetro.ParseKeys(c.Name)
+	before, err := Instance{}.Get(ctx, keys.Strings())
+	if err != nil {
+		return err
+	}
 	cl, err := multimetro.NewClient(ctx)
 	if err != nil {
 		return err
 	}
-	_, err = multimetro.DoKeys(ctx, cl, multimetro.ParseKeys(cmd.Name), func(ctx context.Context, mc *multimetro.MetroClient, keys multimetro.Keys) ([]struct{}, []multimetro.Key, error) {
-		log.G(ctx).Trace().Msg("starting instances")
-		resp, err := mc.StartInstances(ctx, keys.NamesOrUUIDs())
-		if err != nil && !platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
-			return nil, nil, err
-		}
-		var started []multimetro.Key
-		for _, instance := range resp.Data.Instances {
-			if instance.Status == nil || *instance.Status != platform.ResponseStatusSUCCESS {
-				continue
-			}
-			started = append(started, multimetro.Key{
-				Metro: mc.Metro.Name,
-				Name:  *instance.Name,
-				UUID:  *instance.Uuid,
-			})
-		}
-		return nil, started, nil
-	})
-	// FIXME: show diff view
-	return err
+	var targetKeys []multimetro.Key
+	for _, res := range before {
+		targetKeys = append(targetKeys, res.(Instance).key())
+	}
+
+	started, err := startInstances(ctx, cl, targetKeys)
+	if err != nil {
+		return err
+	}
+	updated, err := Instance{}.Get(ctx, started.Strings())
+	if err != nil {
+		return err
+	}
+	return cmd.Diff(cfg.Stdout, before, updated)
 }
 
 type InstancesStopCmd struct {
@@ -693,36 +693,34 @@ type InstancesStopCmd struct {
 	StopOpts
 }
 
-func (cmd *InstancesStopCmd) Run(ctx context.Context) error {
+func (c *InstancesStopCmd) Run(ctx context.Context) error {
+	cfg := config.FromContextOrDefault(ctx)
+
+	keys := multimetro.ParseKeys(c.Name)
+	before, err := Instance{}.Get(ctx, keys.Strings())
+	if err != nil {
+		return err
+	}
 	cl, err := multimetro.NewClient(ctx)
 	if err != nil {
 		return err
 	}
-	_, err = multimetro.DoKeys(ctx, cl, multimetro.ParseKeys(cmd.Name), func(ctx context.Context, mc *multimetro.MetroClient, keys multimetro.Keys) ([]struct{}, []multimetro.Key, error) {
-		log.G(ctx).Trace().Msg("stopping instances")
-		reqs := make([]platform.StopInstancesRequestItem, 0, len(keys))
-		for _, key := range keys {
-			reqs = append(reqs, cmd.toReq(key.NameOrUUID()))
-		}
-		resp, err := mc.StopInstances(ctx, reqs)
-		if err != nil && !platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
-			return nil, nil, err
-		}
-		var stopped []multimetro.Key
-		for _, instance := range resp.Data.Instances {
-			if instance.Status == nil || *instance.Status != platform.ResponseStatusSUCCESS {
-				continue
-			}
-			stopped = append(stopped, multimetro.Key{
-				Metro: mc.Metro.Name,
-				Name:  *instance.Name,
-				UUID:  *instance.Uuid,
-			})
-		}
-		return nil, stopped, nil
-	})
-	// FIXME: show diff view
-	return err
+	var targetKeys []multimetro.Key
+	for _, res := range before {
+		targetKeys = append(targetKeys, res.(Instance).key())
+	}
+	if len(targetKeys) == 0 {
+		targetKeys = keys
+	}
+	stopped, err := stopInstances(ctx, cl, targetKeys, c.StopOpts)
+	if err != nil {
+		return err
+	}
+	updated, err := Instance{}.Get(ctx, stopped.Strings())
+	if err != nil {
+		return err
+	}
+	return cmd.Diff(cfg.Stdout, before, updated)
 }
 
 type InstancesRestartCmd struct {
@@ -731,65 +729,36 @@ type InstancesRestartCmd struct {
 	StopOpts
 }
 
-func (cmd *InstancesRestartCmd) Run(ctx context.Context) error {
+func (c *InstancesRestartCmd) Run(ctx context.Context) error {
+	cfg := config.FromContextOrDefault(ctx)
+
+	keys := multimetro.ParseKeys(c.Name)
+	before, err := Instance{}.Get(ctx, keys.Strings())
+	if err != nil {
+		return err
+	}
 	cl, err := multimetro.NewClient(ctx)
 	if err != nil {
 		return err
 	}
+	var targetKeys []multimetro.Key
+	for _, res := range before {
+		targetKeys = append(targetKeys, res.(Instance).key())
+	}
 
-	// First stop the instances
-	keys := multimetro.ParseKeys(cmd.Name)
-	keys, err = multimetro.DoKeys(ctx, cl, keys, func(ctx context.Context, mc *multimetro.MetroClient, keys multimetro.Keys) ([]multimetro.Key, []multimetro.Key, error) {
-		log.G(ctx).Trace().Msg("stopping instances for restart")
-		reqs := make([]platform.StopInstancesRequestItem, 0, len(keys))
-		for _, key := range keys {
-			reqs = append(reqs, cmd.toReq(key.NameOrUUID()))
-		}
-		resp, err := mc.StopInstances(ctx, reqs)
-		if err != nil && !platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
-			return nil, nil, err
-		}
-		var stopped []multimetro.Key
-		for _, instance := range resp.Data.Instances {
-			if instance.Status == nil || *instance.Status != platform.ResponseStatusSUCCESS {
-				continue
-			}
-			stopped = append(stopped, multimetro.Key{
-				Metro: mc.Metro.Name,
-				Name:  *instance.Name,
-				UUID:  *instance.Uuid,
-			})
-		}
-		return stopped, stopped, nil
-	})
+	stopped, err := stopInstances(ctx, cl, targetKeys, c.StopOpts)
 	if err != nil {
 		return err
 	}
-
-	// Then start the instances
-	_, err = multimetro.DoKeys(ctx, cl, keys, func(ctx context.Context, mc *multimetro.MetroClient, keys multimetro.Keys) ([]struct{}, []multimetro.Key, error) {
-		log.G(ctx).Trace().Msg("starting instances for restart")
-		resp, err := mc.StartInstances(ctx, keys.NamesOrUUIDs())
-		if err != nil && !platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
-			return nil, nil, err
-		}
-		var started []multimetro.Key
-		for _, instance := range resp.Data.Instances {
-			if instance.Status == nil || *instance.Status != platform.ResponseStatusSUCCESS {
-				continue
-			}
-			started = append(started, multimetro.Key{
-				Metro: mc.Metro.Name,
-				Name:  *instance.Name,
-				UUID:  *instance.Uuid,
-			})
-		}
-		return nil, started, nil
-	})
-
-	// FIXME: show diff view (start count will be different)
-
-	return err
+	started, err := startInstances(ctx, cl, stopped)
+	if err != nil {
+		return err
+	}
+	updated, err := Instance{}.Get(ctx, started.Strings())
+	if err != nil {
+		return err
+	}
+	return cmd.Diff(cfg.Stdout, before, updated)
 }
 
 type StopOpts struct {
@@ -810,4 +779,60 @@ func (args *StopOpts) toReq(nameOrUUID platform.NameOrUUID) platform.StopInstanc
 		req.DrainTimeoutMs = &timeout
 	}
 	return req
+}
+
+func startInstances(ctx context.Context, cl *multimetro.Client, keys multimetro.Keys) (multimetro.Keys, error) {
+	started, err := multimetro.DoKeys(ctx, cl, keys, func(ctx context.Context, mc *multimetro.MetroClient, keys multimetro.Keys) ([]multimetro.Key, []multimetro.Key, error) {
+		log.G(ctx).Trace().Msg("starting instances")
+		resp, err := mc.StartInstances(ctx, keys.NamesOrUUIDs())
+		if err != nil && !platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
+			return nil, nil, err
+		}
+		var started []multimetro.Key
+		for _, instance := range resp.Data.Instances {
+			if instance.Status == nil || *instance.Status != platform.ResponseStatusSUCCESS {
+				continue
+			}
+			started = append(started, multimetro.Key{
+				Metro: mc.Metro.Name,
+				Name:  *instance.Name,
+				UUID:  *instance.Uuid,
+			})
+		}
+		return started, started, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return multimetro.Keys(started), nil
+}
+
+func stopInstances(ctx context.Context, cl *multimetro.Client, keys multimetro.Keys, opts StopOpts) (multimetro.Keys, error) {
+	stopped, err := multimetro.DoKeys(ctx, cl, keys, func(ctx context.Context, mc *multimetro.MetroClient, keys multimetro.Keys) ([]multimetro.Key, []multimetro.Key, error) {
+		log.G(ctx).Trace().Msg("stopping instances")
+		reqs := make([]platform.StopInstancesRequestItem, 0, len(keys))
+		for _, key := range keys {
+			reqs = append(reqs, opts.toReq(key.NameOrUUID()))
+		}
+		resp, err := mc.StopInstances(ctx, reqs)
+		if err != nil && !platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
+			return nil, nil, err
+		}
+		var stopped []multimetro.Key
+		for _, instance := range resp.Data.Instances {
+			if instance.Status == nil || *instance.Status != platform.ResponseStatusSUCCESS {
+				continue
+			}
+			stopped = append(stopped, multimetro.Key{
+				Metro: mc.Metro.Name,
+				Name:  *instance.Name,
+				UUID:  *instance.Uuid,
+			})
+		}
+		return stopped, stopped, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return multimetro.Keys(stopped), nil
 }

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -17,13 +17,10 @@ import (
 
 	"github.com/containerd/containerd/v2/pkg/filters"
 	"github.com/lunixbochs/vtclean"
-	"github.com/sergi/go-diff/diffmatchpatch"
 	"unikraft.com/x/kingkong"
 	"unikraft.com/x/log"
 
 	"unikraft.com/cli/internal/config"
-	"unikraft.com/cli/internal/kvwriter"
-	"unikraft.com/cli/internal/prettydiff"
 	"unikraft.com/cli/internal/resource"
 	"unikraft.com/cli/internal/resource/patch"
 	"unikraft.com/cli/internal/tui/watcher"
@@ -480,31 +477,15 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, cfg *config.Config, sand
 		return PrintPatches(cfg.Stdout, patched, false)
 	}
 
-	start := &bytes.Buffer{}
-	err = printKV(start, nil, res)
-	if err != nil {
-		return err
-	}
+	updated := []resource.Resource{res}
 	if len(patched) > 0 {
-		res, err = r.Edit(ctx, res, patched)
+		result, err := r.Edit(ctx, res, patched)
 		if err != nil {
 			return err
 		}
+		updated = []resource.Resource{result}
 	}
-	end := &bytes.Buffer{}
-	err = printKV(end, nil, res)
-	if err != nil {
-		return err
-	}
-
-	dmp := diffmatchpatch.New()
-	diffs := dmp.DiffMain(start.String(), end.String(), false)
-	tw := kvwriter.KeyValueWriter(cfg.Stdout, kvwriter.WithIndent("  "))
-	_, err = io.Copy(tw, strings.NewReader(prettydiff.Render(diffs)))
-	if err != nil {
-		return err
-	}
-	return tw.Flush()
+	return Diff(cfg.Stdout, []resource.Resource{res}, updated)
 }
 
 type ResourceCreateCmd[R resource.CreatableResource] struct {

--- a/internal/resource/cmd/diff.go
+++ b/internal/resource/cmd/diff.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"strings"
+
+	"github.com/lunixbochs/vtclean"
+	"github.com/sergi/go-diff/diffmatchpatch"
+	"unikraft.com/cli/internal/kvwriter"
+	"unikraft.com/cli/internal/prettydiff"
+	"unikraft.com/cli/internal/resource"
+)
+
+// Diff produces a pretty diff between two sets of resources, writing the
+// output to the provided writer.
+func Diff(out io.Writer, before []resource.Resource, after []resource.Resource) error {
+	before, after = diffOrder(before, after)
+	start := &bytes.Buffer{}
+	if err := printKV(start, nil, before...); err != nil {
+		return err
+	}
+	end := &bytes.Buffer{}
+	if err := printKV(end, nil, after...); err != nil {
+		return err
+	}
+
+	dmp := diffmatchpatch.New()
+	diffs := dmp.DiffMain(
+		// clean all ANSI escape sequences from the output before diffing to avoid
+		// trying to diff them
+		// NOTE: it would be nice to preserve those in the output, but the diffing
+		// would have to be done differently
+		vtclean.Clean(start.String(), false),
+		vtclean.Clean(end.String(), false),
+		false,
+	)
+	tw := kvwriter.KeyValueWriter(out, kvwriter.WithIndent("  "))
+	if _, err := io.Copy(tw, strings.NewReader(prettydiff.Render(diffs))); err != nil {
+		return err
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// diffOrder reorders the after resources to match the order of the before
+// resources as much as possible. This should hopefully improve the diff
+// output.
+func diffOrder(before []resource.Resource, after []resource.Resource) ([]resource.Resource, []resource.Resource) {
+	afterMap := make(map[string]resource.Resource, len(after))
+	for _, r := range after {
+		key := r.Key().String()
+		afterMap[key] = r
+	}
+	afterFound := make(map[string]struct{}, len(after))
+
+	var orderedAfter []resource.Resource
+	for _, r := range before {
+		key := r.Key().String()
+		if afterR, ok := afterMap[key]; ok {
+			orderedAfter = append(orderedAfter, afterR)
+			afterFound[key] = struct{}{}
+		}
+	}
+	for _, r := range after {
+		key := r.Key().String()
+		if _, ok := afterFound[key]; !ok {
+			orderedAfter = append(orderedAfter, r)
+		}
+	}
+	return before, orderedAfter
+}


### PR DESCRIPTION
Before: no output.

After:

<img width="663" height="354" alt="image" src="https://github.com/user-attachments/assets/2d9ae633-312f-4df8-aacb-afa689e7f7a0" />

This creates a new `Differ` function, extracted from how we use `edit`, and apply it to `start`/`stop`/`restart` as well.
