### PR TITLE
fix: Common package for string-value manipulation

### DIFF
--- a/cmd/unikraft/testdata/TestGolden/auth
+++ b/cmd/unikraft/testdata/TestGolden/auth
@@ -7,7 +7,7 @@ $ unikraft profile list
 
 stdout:
 	NAME     ACTIVE  METROS
-	default  true    [test]
+	default  true    test
 
 $ unikraft metro list
 

--- a/cmd/unikraft/testdata/TestGolden/images
+++ b/cmd/unikraft/testdata/TestGolden/images
@@ -11,4 +11,4 @@ stdout:
 	digest:     sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
 	config:
 	  platform: kraftcloud/x86_64
-	  cmd:      [/usr/bin/nginx -c /etc/nginx/nginx.conf]
+	  cmd:      /usr/bin/nginx,-c,/etc/nginx/nginx.conf

--- a/cmd/unikraft/testdata/TestGolden/instances
+++ b/cmd/unikraft/testdata/TestGolden/instances
@@ -1,7 +1,7 @@
 $ unikraft instance list
 
 stdout:
-	METRO  NAME  STATE  IMAGE  ARGS  MEMORY  VCPUS  SERVICES  FQDN
+	METRO  NAME  STATE  IMAGE  ARGS  MEMORY  VCPUS  FQDN
 
 $ unikraft instance create --set name=test-$UNIQ_INST --set metro=test --set image=nginx:latest --set autostart=true --set resources.memory=128 --set resources.vcpus=1 --set service.services=443:8080/tls+http --set service.domains=name=$UNIQ_DOMAIN
 
@@ -28,8 +28,8 @@ stdout:
 $ unikraft instance list
 
 stdout:
-	METRO  NAME               STATE    IMAGE  ARGS  MEMORY  VCPUS  SERVICES  FQDN
-	test   test-<INST>  running  nginx  []    128     1                <DOMAIN>.unikraft.internal
+	METRO  NAME               STATE    IMAGE  ARGS  MEMORY  VCPUS  FQDN
+	test   test-<INST>  running  nginx        128     1      <DOMAIN>.unikraft.internal
 
 $ unikraft instance inspect test-$UNIQ_INST
 
@@ -156,4 +156,4 @@ $ unikraft instance delete test-$UNIQ_INST
 $ unikraft instance list
 
 stdout:
-	METRO  NAME  STATE  IMAGE  ARGS  MEMORY  VCPUS  SERVICES  FQDN
+	METRO  NAME  STATE  IMAGE  ARGS  MEMORY  VCPUS  FQDN

--- a/internal/cmd/certificates.go
+++ b/internal/cmd/certificates.go
@@ -34,6 +34,7 @@ type Certificate struct {
 	Name      string `mirror:"certificate.name" field:",short" create:"set"`
 	UUID      string `mirror:"certificate.uuid" field:",long"`
 
+	// create-only fields
 	CN         string `field:"cn,invisible" create:"set,required"`
 	Chain      string `field:"chain,invisible" create:"set,required"`
 	PrivateKey string `field:"pkey,invisible" create:"set,required"`

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -65,10 +65,12 @@ type Instance struct {
 	Volumes []*InstanceVolume `mirror:"instance.volumes" field:",embed" create:"set"`
 
 	Service struct {
-		UUID      string     `mirror:"uuid" field:",long" create:"set"`
-		Name      string     `mirror:"name" field:",long" create:"set"`
-		Services  []*Service `field:",long,embed" create:"set"`
-		Domains   []Domain   `mirror:"domains" field:",long,embed" create:"set"`
+		UUID    string   `mirror:"uuid" field:",long" create:"set"`
+		Name    string   `mirror:"name" field:",long" create:"set"`
+		Domains []Domain `mirror:"domains" field:",short,embed" create:"set"`
+
+		// create-only fields
+		Services  []*Service `field:",invisible,embed" create:"set"`
 		SoftLimit uint32     `field:",long" create:"set"`
 		HardLimit uint32     `field:",long" create:"set"`
 	} `mirror:"instance.service_group"`
@@ -124,7 +126,7 @@ type InstanceVolume struct {
 	Readonly bool   `mirror:"readonly" json:"readonly,omitempty" field:",long"`
 }
 
-func (v *InstanceVolume) String() string {
+func (v *InstanceVolume) MarshalText() ([]byte, error) {
 	parts := []string{cmp.Or(v.Name, v.UUID)}
 	if v.SizeMB > 0 {
 		parts = append(parts, strconv.FormatInt(v.SizeMB, 10)+"M")
@@ -133,10 +135,11 @@ func (v *InstanceVolume) String() string {
 	if v.Readonly {
 		parts = append(parts, "ro")
 	}
-	return strings.Join(parts, ":")
+	return []byte(strings.Join(parts, ":")), nil
 }
 
-func (v *InstanceVolume) Parse(str string) error {
+func (v *InstanceVolume) UnmarshalText(data []byte) error {
+	str := string(data)
 	parts := strings.Split(str, ":")
 	if len(parts) < 2 {
 		return fmt.Errorf("invalid volume format, expected NAME:AT[:ro] or UUID:AT[:ro] or NAME:SIZE:AT[:ro]")

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -15,7 +15,7 @@ import (
 	"unikraft.com/cli/internal/multimetro"
 	"unikraft.com/cli/internal/resource"
 	"unikraft.com/cli/internal/resource/cmd"
-	"unikraft.com/cli/internal/resource/patch"
+	"unikraft.com/cli/internal/resource/value"
 )
 
 type RunCmd struct {
@@ -54,23 +54,23 @@ func (c *RunCmd) Run(ctx context.Context, cfg *config.Config, sandbox *resource.
 		return fmt.Errorf("metro is required")
 	}
 
-	env, err := patch.ParseNewValue[map[string]string](c.Env)
+	env, err := value.Parse[map[string]string](c.Env)
 	if err != nil {
 		return err
 	}
-	volumes, err := patch.ParseNewValue[[]*InstanceVolume](c.Volume)
+	volumes, err := value.Parse[[]*InstanceVolume](c.Volume)
 	if err != nil {
 		return err
 	}
-	services, err := patch.ParseNewValue[[]*Service](c.Publish)
+	services, err := value.Parse[[]*Service](c.Publish)
 	if err != nil {
 		return err
 	}
-	domains, err := patch.ParseNewValue[[]Domain](c.Domain)
+	domains, err := value.Parse[[]Domain](c.Domain)
 	if err != nil {
 		return err
 	}
-	scaleToZero, err := patch.ParseNewValue[*InstanceScaleToZero](c.ScaleToZero)
+	scaleToZero, err := value.Parse[*InstanceScaleToZero](c.ScaleToZero)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/services.go
+++ b/internal/cmd/services.go
@@ -68,15 +68,20 @@ type Service struct {
 	Handlers    []platform.ServiceHandlers `mirror:"handlers" json:"handlers" field:",short"`
 }
 
-func (s *Service) String() string {
+func (s *Service) MarshalText() ([]byte, error) {
 	handlers := make([]string, len(s.Handlers))
 	for i, handler := range s.Handlers {
 		handlers[i] = string(handler)
 	}
-	return fmt.Sprintf("%d:%d/%s", s.Source, s.Destination, strings.Join(handlers, "+"))
+	return fmt.Appendf([]byte{}, "%d:%d/%s",
+		s.Source,
+		s.Destination,
+		strings.Join(handlers, "+"),
+	), nil
 }
 
-func (s *Service) Parse(str string) error {
+func (s *Service) UnmarshalText(text []byte) error {
+	str := string(text)
 	ports, handlers, _ := strings.Cut(str, "/")
 	src, dest, ok := strings.Cut(ports, ":")
 	if !ok {

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -301,7 +301,8 @@ func filterResources(resources []resource.Resource, filter filters.Filter) (filt
 				return "", false
 			}
 			// HACK: vtclean to remove any escape sequences from rendered output
-			return vtclean.Clean(fields[0].FormatString(), false), true
+			out, _ := fields[0].Render()
+			return vtclean.Clean(out, false), true
 		})) {
 			filtered = append(filtered, res)
 		}

--- a/internal/resource/cmd/printers.go
+++ b/internal/resource/cmd/printers.go
@@ -24,6 +24,7 @@ import (
 
 	"unikraft.com/cli/internal/kvwriter"
 	"unikraft.com/cli/internal/resource"
+	"unikraft.com/cli/internal/resource/value"
 	xslices "unikraft.com/cli/internal/x/slices"
 )
 
@@ -162,7 +163,11 @@ func printKVFields(out io.Writer, parent *resource.Field, fields []resource.Fiel
 			nextCurrent = indent
 			nextIndent = indent
 			if field.Value != nil {
-				line.WriteString(field.FormatString())
+				out, err := field.Render()
+				if err != nil {
+					return err
+				}
+				line.WriteString(out)
 				line.WriteString("\n")
 			}
 		} else {
@@ -174,7 +179,11 @@ func printKVFields(out io.Writer, parent *resource.Field, fields []resource.Fiel
 			line.WriteString(field.Name + ":")
 			if field.Value != nil {
 				line.WriteString(" ")
-				line.WriteString(field.FormatString())
+				out, err := field.Render()
+				if err != nil {
+					return err
+				}
+				line.WriteString(out)
 			}
 			line.WriteString("\n")
 		}
@@ -265,7 +274,10 @@ func printTable(out io.Writer, fieldSpecs []string, base resource.Resource, reso
 					continue
 				}
 
-				value := field.FormatString()
+				value, err := field.Render()
+				if err != nil {
+					return err
+				}
 				if field.Hyperlink != "" {
 					// TODO: use lipgloss styles when it supports hyperlinks
 					// https://github.com/charmbracelet/lipgloss/issues/220
@@ -450,17 +462,29 @@ func PrintPatches(out io.Writer, fields []resource.Field, create bool) error {
 			continue
 		}
 		if patch.Set != nil {
-			if _, err := fmt.Fprintf(tw, "%s := %s\n", path.String(), resource.FormatValue(patch.Set)); err != nil {
+			out, err := value.Format(patch.Set)
+			if err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintf(tw, "%s := %s\n", path.String(), out); err != nil {
 				return err
 			}
 		}
 		if patch.Add != nil {
-			if _, err := fmt.Fprintf(tw, "%s += %s\n", path.String(), resource.FormatValue(patch.Add)); err != nil {
+			out, err := value.Format(patch.Add)
+			if err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintf(tw, "%s += %s\n", path.String(), out); err != nil {
 				return err
 			}
 		}
 		if patch.Del != nil {
-			if _, err := fmt.Fprintf(tw, "%s -= %s\n", path.String(), resource.FormatValue(patch.Del)); err != nil {
+			out, err := value.Format(patch.Del)
+			if err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintf(tw, "%s -= %s\n", path.String(), out); err != nil {
 				return err
 			}
 		}

--- a/internal/resource/patch/patch.go
+++ b/internal/resource/patch/patch.go
@@ -10,12 +10,10 @@ import (
 	"fmt"
 	"iter"
 	"maps"
-	"reflect"
 	"slices"
-	"strconv"
-	"strings"
 
 	"unikraft.com/cli/internal/resource"
+	"unikraft.com/cli/internal/resource/value"
 )
 
 type PatchSpec struct {
@@ -77,10 +75,10 @@ func PatchedFields(fields []resource.Field, spec PatchSpec) ([]resource.Field, e
 		}
 
 		done := false
-		if value, ok := spec.Set[keyStr]; ok {
+		if vs, ok := spec.Set[keyStr]; ok {
 			done = true
 			if original.Set != nil {
-				set, err := parseNewValue(value, original.Set)
+				set, err := value.ParseNew(vs, original.Set)
 				if err != nil {
 					return nil, fmt.Errorf("failed to unpack set value for %s: %w", keyStr, err)
 				}
@@ -89,10 +87,10 @@ func PatchedFields(fields []resource.Field, spec PatchSpec) ([]resource.Field, e
 				setForbiddenFields[keyStr] = struct{}{}
 			}
 		}
-		if value, ok := spec.Add[keyStr]; ok {
+		if vs, ok := spec.Add[keyStr]; ok {
 			done = true
 			if original.Add != nil {
-				add, err := parseNewValue(value, original.Add)
+				add, err := value.ParseNew(vs, original.Add)
 				if err != nil {
 					return nil, fmt.Errorf("failed to unpack add value for %s: %w", keyStr, err)
 				}
@@ -101,10 +99,10 @@ func PatchedFields(fields []resource.Field, spec PatchSpec) ([]resource.Field, e
 				addForbiddenFields[keyStr] = struct{}{}
 			}
 		}
-		if value, ok := spec.Del[keyStr]; ok {
+		if vs, ok := spec.Del[keyStr]; ok {
 			done = true
 			if original.Del != nil {
-				del, err := parseNewValue(value, original.Del)
+				del, err := value.ParseNew(vs, original.Del)
 				if err != nil {
 					return nil, fmt.Errorf("failed to unpack del value for %s: %w", keyStr, err)
 				}
@@ -149,144 +147,4 @@ func PatchedFields(fields []resource.Field, spec PatchSpec) ([]resource.Field, e
 		return FilterCreatableFields(fields), nil
 	}
 	return FilterPatchableFields(fields), nil
-}
-
-func ParseNewValue[T any](input []string) (T, error) {
-	var t T
-	output, err := parseNewValue(input, t)
-	if err != nil {
-		return t, err
-	}
-	return output.(T), nil
-}
-
-func parseNewValue(input []string, output any) (any, error) {
-	parsedVal, err := parseNewReflect(input, reflect.ValueOf(output))
-	if err != nil {
-		return nil, err
-	}
-	return parsedVal.Interface(), nil
-}
-
-func parseNewReflect(input []string, output reflect.Value) (reflect.Value, error) {
-	newVal := reflect.New(output.Type())
-	err := parseReflect(input, newVal.Elem())
-	if err != nil {
-		return reflect.Value{}, err
-	}
-	return newVal.Elem(), nil
-}
-
-func parseReflect(input []string, value reflect.Value) error {
-	if input == nil {
-		return nil
-	}
-
-	output := value
-	for output.Kind() == reflect.Pointer {
-		if output.IsNil() {
-			output.Set(reflect.New(output.Type().Elem()))
-		}
-		output = output.Elem()
-	}
-
-	if len(input) == 0 {
-		output.Set(reflect.Zero(output.Type()))
-		return nil
-	}
-
-	switch output.Kind() {
-	case reflect.Pointer:
-		if output.IsNil() {
-			output.Set(reflect.New(output.Type().Elem()))
-		}
-		return parseReflect(input, output.Elem())
-	case reflect.String:
-		output.SetString(input[0])
-		return nil
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		v, err := strconv.ParseInt(input[0], 10, output.Type().Bits())
-		if err != nil {
-			return err
-		}
-		output.SetInt(v)
-		return nil
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		v, err := strconv.ParseUint(input[0], 10, output.Type().Bits())
-		if err != nil {
-			return err
-		}
-		output.SetUint(v)
-		return nil
-	case reflect.Float32, reflect.Float64:
-		v, err := strconv.ParseFloat(input[0], output.Type().Bits())
-		if err != nil {
-			return err
-		}
-		output.SetFloat(v)
-		return nil
-	case reflect.Bool:
-		v, err := strconv.ParseBool(input[0])
-		if err != nil {
-			return err
-		}
-		output.SetBool(v)
-		return nil
-	case reflect.Slice:
-		slice := reflect.MakeSlice(output.Type(), 0, 0)
-		for _, input := range input {
-			for item := range strings.SplitSeq(input, ",") {
-				val := reflect.New(output.Type().Elem()).Elem()
-				err := parseReflect([]string{item}, val)
-				if err != nil {
-					return err
-				}
-				slice = reflect.Append(slice, val)
-			}
-		}
-		output.Set(slice)
-		return nil
-	case reflect.Map:
-		mapp := reflect.MakeMap(output.Type())
-		for _, input := range input {
-			for item := range strings.SplitSeq(input, ",") {
-				if item == "" {
-					continue
-				}
-				k, v, _ := strings.Cut(item, "=")
-				key := reflect.New(output.Type().Key()).Elem()
-				err := parseReflect([]string{k}, key)
-				if err != nil {
-					return err
-				}
-				val := reflect.New(output.Type().Elem()).Elem()
-				err = parseReflect([]string{v}, val)
-				if err != nil {
-					return err
-				}
-				mapp.SetMapIndex(key, val)
-			}
-		}
-		output.Set(mapp)
-		return nil
-	case reflect.Struct:
-		valueField, ok := value.Interface().(resource.ValueField)
-		if ok {
-			return valueField.Parse(input[0])
-		}
-
-		kv := map[string]string{}
-		fields := strings.Split(input[0], ",")
-		for _, field := range fields {
-			field = strings.TrimSpace(field)
-			if field == "" {
-				continue
-			}
-			k, v, _ := strings.Cut(field, "=")
-			kv[k] = v
-		}
-		return resource.DecodeStruct(kv, value.Addr().Interface())
-	default:
-		return fmt.Errorf("unsupported type: %T", value.Interface())
-	}
 }

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -9,7 +9,8 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
+
+	"unikraft.com/cli/internal/resource/value"
 )
 
 type Type struct {
@@ -124,56 +125,15 @@ type Patch struct {
 	Required bool `json:"required,omitempty"`
 }
 
-func (f Field) FormatString() string {
-	return FormatValue(f.Value)
-}
-
-type Wrapped interface {
-	Unwrap() any
-}
-
-func FormatValue(value any) string {
-	for {
-		unwrapped, ok := value.(Wrapped)
-		if !ok {
-			break
-		}
-		value = unwrapped.Unwrap()
-	}
-	if value, ok := value.(fmt.Stringer); ok {
-		return value.String()
-	}
-
-	if value == nil {
-		return "<nil>"
-	}
-
-	v := reflect.ValueOf(value)
-	switch v.Kind() {
-	case reflect.String:
-		return v.String()
-	case reflect.Slice, reflect.Array:
-		var result []string
-		for i := range v.Len() {
-			result = append(result, FormatValue(v.Index(i).Interface()))
-		}
-		return "[" + strings.Join(result, " ") + "]"
-	case reflect.Map:
-		var result []string
-		for _, key := range v.MapKeys() {
-			val := v.MapIndex(key)
-			result = append(result, fmt.Sprintf("%s:%s", FormatValue(key.Interface()), FormatValue(val.Interface())))
-		}
-		return "{" + strings.Join(result, " ") + "}"
-	default:
-		return fmt.Sprintf("%v", value)
-	}
+func (f Field) Render() (string, error) {
+	return value.Format(f.Value)
 }
 
 type FieldVerbosity int
 
 const (
-	FieldVerbosityInvisible FieldVerbosity = iota
+	FieldVerbosityUnknown FieldVerbosity = iota
+	FieldVerbosityInvisible
 	FieldVerbosityHidden
 	FieldVerbosityLong
 	FieldVerbosityShort
@@ -184,6 +144,8 @@ func (v FieldVerbosity) String() string {
 		v = FieldVerbosityHidden
 	}
 	switch v {
+	case FieldVerbosityUnknown:
+		return "unknown"
 	case FieldVerbosityInvisible:
 		return "invisible"
 	case FieldVerbosityHidden:

--- a/internal/resource/struct.go
+++ b/internal/resource/struct.go
@@ -6,6 +6,8 @@
 package resource
 
 import (
+	"cmp"
+	"encoding"
 	"fmt"
 	"reflect"
 	"slices"
@@ -20,19 +22,14 @@ import (
 // FieldsFromStruct is a helper that converts a struct into a slice of Fields
 // based on the `field` tags defined on the struct's fields.
 func FieldsFromStruct(s any) (fields []Field, err error) {
-	field, err := fieldFromStruct(true, reflect.ValueOf(s))
+	field, err := fieldFromStruct(nil, reflect.ValueOf(s))
 	if err != nil {
 		return nil, err
 	}
 	return field.Subfields, nil
 }
 
-type ValueField interface {
-	String() string
-	Parse(s string) error
-}
-
-func fieldFromStruct(embed bool, v reflect.Value) (field *Field, err error) {
+func fieldFromStruct(pf *ParsedField, v reflect.Value) (field *Field, err error) {
 	s := v
 	if s.Kind() == reflect.Pointer {
 		if s.IsNil() {
@@ -46,7 +43,7 @@ func fieldFromStruct(embed bool, v reflect.Value) (field *Field, err error) {
 	}
 	t := s.Type()
 
-	if t.Name() != "" && !embed {
+	if t.Name() != "" && pf != nil && !pf.Embed {
 		return nil, nil
 	}
 
@@ -73,17 +70,17 @@ func fieldFromStruct(embed bool, v reflect.Value) (field *Field, err error) {
 			Edit:      parsedField.Edit,
 		}
 
-		newField, err := fieldFromStruct(parsedField.Embed, fieldVal)
+		newField, err := fieldFromStruct(parsedField, fieldVal)
 		if err != nil {
 			return nil, err
 		}
 		if newField != nil {
 			result.Value = newField.Value
 			result.Subfields = newField.Subfields
-			result.Verbosity = max(result.Verbosity, newField.Verbosity)
+			result.Verbosity = cmp.Or(result.Verbosity, newField.Verbosity, FieldVerbosityHidden)
 		}
 
-		newField, err = fieldFromSlice(parsedField.Embed, fieldVal)
+		newField, err = fieldFromSlice(parsedField, fieldVal)
 		if err != nil {
 			return nil, err
 		}
@@ -91,15 +88,18 @@ func fieldFromStruct(embed bool, v reflect.Value) (field *Field, err error) {
 			result.Value = newField.Value
 			result.Elem = newField.Elem
 			result.Subfields = newField.Subfields
-			result.Verbosity = max(result.Verbosity, newField.Verbosity)
+			result.Verbosity = cmp.Or(result.Verbosity, newField.Verbosity, FieldVerbosityHidden)
 		}
 
 		fields = append(fields, result)
 	}
 
 	var value any
-	if ValueField, ok := v.Interface().(ValueField); ok {
-		value = ValueField
+	if v, ok := v.Interface().(interface {
+		encoding.TextMarshaler
+		encoding.TextUnmarshaler
+	}); ok {
+		value = v
 	}
 
 	verbosity := FieldVerbosity(0)
@@ -113,7 +113,7 @@ func fieldFromStruct(embed bool, v reflect.Value) (field *Field, err error) {
 	}, nil
 }
 
-func fieldFromSlice(embed bool, v reflect.Value) (field *Field, err error) {
+func fieldFromSlice(pf *ParsedField, v reflect.Value) (field *Field, err error) {
 	if v.Kind() == reflect.Pointer {
 		if v.IsNil() {
 			v = reflect.New(v.Type().Elem())
@@ -127,7 +127,7 @@ func fieldFromSlice(embed bool, v reflect.Value) (field *Field, err error) {
 
 	elemType := v.Type().Elem()
 	elemVal := reflect.New(elemType).Elem()
-	elem, err := fieldFromStruct(embed, elemVal)
+	elem, err := fieldFromStruct(pf, elemVal)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func fieldFromSlice(embed bool, v reflect.Value) (field *Field, err error) {
 	var fields []Field
 	for i := range v.Len() {
 		vv := v.Index(i)
-		field, err := fieldFromStruct(embed, vv)
+		field, err := fieldFromStruct(pf, vv)
 		if err != nil {
 			return nil, err
 		}
@@ -193,8 +193,6 @@ func ParseField(field reflect.StructField) (*ParsedField, error) {
 		verbosity = FieldVerbosityShort
 	case slices.Contains(opts, "long"):
 		verbosity = FieldVerbosityLong
-	default:
-		verbosity = FieldVerbosityHidden
 	}
 
 	edit, err := parsePatch(field.Type, field.Tag.Get("edit"))

--- a/internal/resource/value/format.go
+++ b/internal/resource/value/format.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package value
+
+import (
+	"cmp"
+	"encoding"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type Wrapped interface {
+	Unwrap() any
+}
+
+func Format(value any) (string, error) {
+	for {
+		unwrapped, ok := value.(Wrapped)
+		if !ok {
+			break
+		}
+		value = unwrapped.Unwrap()
+	}
+	if value, ok := value.(fmt.Stringer); ok {
+		return value.String(), nil
+	}
+	if value, ok := value.(encoding.TextMarshaler); ok {
+		dt, err := value.MarshalText()
+		return string(dt), err
+	}
+
+	if value == nil {
+		return "<nil>", nil
+	}
+
+	v := reflect.ValueOf(value)
+	switch v.Kind() {
+	case reflect.Pointer:
+		if v.IsNil() {
+			return "<nil>", nil
+		}
+		return Format(v.Elem().Interface())
+	case reflect.String:
+		return v.String(), nil
+	case reflect.Slice, reflect.Array:
+		var result []string
+		for i := range v.Len() {
+			val := v.Index(i)
+			valStr, err := Format(val.Interface())
+			if err != nil {
+				return "", err
+			}
+			result = append(result, valStr)
+		}
+		return strings.Join(result, ","), nil
+	case reflect.Map:
+		var result []string
+		for _, key := range v.MapKeys() {
+			val := v.MapIndex(key)
+			keyStr, err := Format(key.Interface())
+			if err != nil {
+				return "", err
+			}
+			valStr, err := Format(val.Interface())
+			if err != nil {
+				return "", err
+			}
+			result = append(result, fmt.Sprintf("%s=%s", keyStr, valStr))
+		}
+		return strings.Join(result, ","), nil
+	case reflect.Struct:
+		var result []string
+		for i := range v.NumField() {
+			field := v.Type().Field(i)
+			if !field.IsExported() {
+				continue
+			}
+			val := v.Field(i)
+			valStr, err := Format(val.Interface())
+			if err != nil {
+				return "", err
+			}
+			if valStr == "" {
+				continue
+			}
+			name := cmp.Or(
+				strings.SplitN(field.Tag.Get("field"), ",", 2)[0],
+				strings.ToLower(field.Name),
+			)
+			result = append(result, fmt.Sprintf("%s=%s", name, valStr))
+		}
+		return strings.Join(result, ","), nil
+	default:
+		return fmt.Sprintf("%v", value), nil
+	}
+}

--- a/internal/resource/value/parse.go
+++ b/internal/resource/value/parse.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package value
+
+import (
+	"encoding"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+)
+
+func Parse[T any](input []string) (T, error) {
+	var t T
+	output, err := ParseNew(input, t)
+	if err != nil {
+		return t, err
+	}
+	return output.(T), nil
+}
+
+func ParseNew(input []string, output any) (any, error) {
+	parsedVal, err := parseNewReflect(input, reflect.ValueOf(output))
+	if err != nil {
+		return nil, err
+	}
+	return parsedVal.Interface(), nil
+}
+
+func parseNewReflect(input []string, output reflect.Value) (reflect.Value, error) {
+	newVal := reflect.New(output.Type()).Elem()
+	err := parseReflect(input, newVal)
+	if err != nil {
+		return reflect.Value{}, err
+	}
+	return newVal, nil
+}
+
+func parseReflect(input []string, value reflect.Value) error {
+	if input == nil {
+		return nil
+	}
+
+	output := value
+	for output.Kind() == reflect.Pointer {
+		if output.IsNil() {
+			output.Set(reflect.New(output.Type().Elem()))
+		}
+		output = output.Elem()
+	}
+
+	if len(input) == 0 {
+		output.Set(reflect.Zero(output.Type()))
+		return nil
+	}
+
+	text, ok := value.Interface().(encoding.TextUnmarshaler)
+	if ok {
+		return text.UnmarshalText([]byte(input[0]))
+	}
+
+	switch output.Kind() {
+	case reflect.String:
+		output.SetString(input[0])
+		return nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v, err := strconv.ParseInt(input[0], 10, output.Type().Bits())
+		if err != nil {
+			return err
+		}
+		output.SetInt(v)
+		return nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		v, err := strconv.ParseUint(input[0], 10, output.Type().Bits())
+		if err != nil {
+			return err
+		}
+		output.SetUint(v)
+		return nil
+	case reflect.Float32, reflect.Float64:
+		v, err := strconv.ParseFloat(input[0], output.Type().Bits())
+		if err != nil {
+			return err
+		}
+		output.SetFloat(v)
+		return nil
+	case reflect.Bool:
+		v, err := strconv.ParseBool(input[0])
+		if err != nil {
+			return err
+		}
+		output.SetBool(v)
+		return nil
+	case reflect.Slice:
+		slice := reflect.MakeSlice(output.Type(), 0, 0)
+		for _, input := range input {
+			for item := range strings.SplitSeq(input, ",") {
+				val := reflect.New(output.Type().Elem()).Elem()
+				err := parseReflect([]string{item}, val)
+				if err != nil {
+					return err
+				}
+				slice = reflect.Append(slice, val)
+			}
+		}
+		output.Set(slice)
+		return nil
+	case reflect.Map:
+		mapp := reflect.MakeMap(output.Type())
+		for _, input := range input {
+			for item := range strings.SplitSeq(input, ",") {
+				if item == "" {
+					continue
+				}
+				k, v, _ := strings.Cut(item, "=")
+				key := reflect.New(output.Type().Key()).Elem()
+				err := parseReflect([]string{k}, key)
+				if err != nil {
+					return err
+				}
+				val := reflect.New(output.Type().Elem()).Elem()
+				err = parseReflect([]string{v}, val)
+				if err != nil {
+					return err
+				}
+				mapp.SetMapIndex(key, val)
+			}
+		}
+		output.Set(mapp)
+		return nil
+	case reflect.Struct:
+		s := reflect.New(output.Type()).Elem()
+		for _, input := range input {
+			for item := range strings.SplitSeq(input, ",") {
+				item = strings.TrimSpace(item)
+				if item == "" {
+					continue
+				}
+				k, v, _ := strings.Cut(item, "=")
+
+				for i := range s.NumField() {
+					field := s.Type().Field(i)
+					if !field.IsExported() {
+						continue
+					}
+					if strings.SplitN(field.Tag.Get("field"), ",", 2)[0] == k || strings.EqualFold(field.Name, k) {
+						fieldVal := s.Field(i)
+						err := parseReflect([]string{v}, fieldVal)
+						if err != nil {
+							return err
+						}
+					}
+				}
+			}
+		}
+		output.Set(s)
+		return nil
+	default:
+		return fmt.Errorf("unsupported type: %T", value.Interface())
+	}
+}

--- a/tools/gencli/docs.go
+++ b/tools/gencli/docs.go
@@ -19,6 +19,7 @@ import (
 	"github.com/muesli/termenv"
 	"unikraft.com/cli/internal/resource"
 	"unikraft.com/cli/internal/resource/cmd"
+	"unikraft.com/cli/internal/resource/value"
 	"unikraft.com/cli/internal/tablewriter"
 	"unikraft.com/x/kingkong"
 	"unikraft.com/x/log"
@@ -188,7 +189,7 @@ func printDocsFields(buf *bytes.Buffer, fields []resource.Field) {
 func formatType(tp reflect.Type) string {
 	v := reflect.New(tp).Elem()
 	switch vv := v.Interface().(type) {
-	case resource.Wrapped:
+	case value.Wrapped:
 		return formatType(reflect.TypeOf(vv.Unwrap()))
 	}
 


### PR DESCRIPTION
This patch creates a common `value` package for string <-> value manipulation.
    
We use this functionality for:
- Converting `--set` patches into values
- Parsing the input values for `unikraft run`
- Displaying values in key-value + table output
- Formatting patches for output in `--dry-run`
    
This simplifies and standardizes the logic - the input format is now the same as the output format, and we can handle trickier values (like structs).

For example, before:

<img width="1357" height="132" alt="image" src="https://github.com/user-attachments/assets/d277a1c0-acd7-4ddf-89ff-2f512c0a7bbc" />

And, after:

<img width="1357" height="132" alt="image" src="https://github.com/user-attachments/assets/bf687023-ae1c-4b73-9df3-f2f6a85e7ca9" />
