### PR TITLE
fix: Cap containerd logs to debug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	unikraft.com/x/colors v0.0.0-20260116231133-1da0081544af
 	unikraft.com/x/image-spec v0.0.0-20260122232605-1672b2b1f81e
 	unikraft.com/x/kingkong v0.0.0-20260116231133-1da0081544af
-	unikraft.com/x/log v0.0.0-20260121151350-0debc2b75f29
+	unikraft.com/x/log v0.0.0-20260123171130-d7f7471d74c0
 	unikraft.com/x/ptr v0.0.0-20260116231133-1da0081544af
 )
 

--- a/go.sum
+++ b/go.sum
@@ -351,7 +351,7 @@ unikraft.com/x/image-spec v0.0.0-20260122232605-1672b2b1f81e h1:zk6sff0WXp8sDGNs
 unikraft.com/x/image-spec v0.0.0-20260122232605-1672b2b1f81e/go.mod h1:knuzG5cFGbvrfuBi7lrdDs2F+Y+58EFbDUDIpeOHpvY=
 unikraft.com/x/kingkong v0.0.0-20260116231133-1da0081544af h1:3BAUegqUkOw7/J9bd50mvehjs1ojpf78QpOX/KGhsQY=
 unikraft.com/x/kingkong v0.0.0-20260116231133-1da0081544af/go.mod h1:SdVWaa62x8E4wlnQo0BirnGxk/Ev3sN6uoOHwblOFPY=
-unikraft.com/x/log v0.0.0-20260121151350-0debc2b75f29 h1:r1hrpQ2EErsX3qlp7uSduMbOb4ax9QQQhsYtiTxXwjo=
-unikraft.com/x/log v0.0.0-20260121151350-0debc2b75f29/go.mod h1:02/yNlrGz5ZwgL6gpwWnKf+Xq0o3hsc8WDWFgWAzaIo=
+unikraft.com/x/log v0.0.0-20260123171130-d7f7471d74c0 h1:e0hA163wbp2qkPKFEPU66wpXkmM2bCYIb0ql9jimNf8=
+unikraft.com/x/log v0.0.0-20260123171130-d7f7471d74c0/go.mod h1:f/+5628rnWTnRaRrCDD9mOMf7OV5QmkGIgARlTu4XGE=
 unikraft.com/x/ptr v0.0.0-20260116231133-1da0081544af h1:qEEtHdfIKn1p4OGrekAxbPe+Kbd1Gi1g5S3iJgTRcWM=
 unikraft.com/x/ptr v0.0.0-20260116231133-1da0081544af/go.mod h1:une+KauhLNYkBFnT0R4bzVvD8bJ54xACjXMBPMnc5ig=

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -115,7 +115,10 @@ func NewRootCmd(ctx context.Context, args []string, stdin io.Reader, stdout, std
 		level = log.InfoLevel
 	}
 	cli.Context = log.WithLogger(cli.Context, log.New(stderr, cli.LogType, level))
-	cli.Context = ctrdlog.WithLogger(cli.Context, logrus.NewEntry(log.ToLogrus(log.G(cli.Context))))
+	cli.Context = ctrdlog.WithLogger(cli.Context, logrus.NewEntry(log.ToLogrus(
+		log.G(cli.Context),
+		log.WithLogrusLevelCap(logrus.DebugLevel),
+	)))
 
 	cli.Context = config.WithConfig(cli.Context, &cli.Config)
 	kctx.BindTo(cli.Context, (*context.Context)(nil))


### PR DESCRIPTION
Fixes https://linear.app/unikraft/issue/CLI-85/downgrade-containerd-logs-to-cli-debug-level.