### PR TITLE
fix: Ensure prettydiff handles diffs containing newlines

### DIFF
--- a/cmd/unikraft/testdata/TestGolden/services
+++ b/cmd/unikraft/testdata/TestGolden/services
@@ -122,7 +122,6 @@ stdout:
 	- - 443:8080/tls+http
 	- - 80:443/http+redirect
 	+ - 1000:2000/tls
-	+
 
 $ unikraft service inspect test-$UNIQ_SVC_A test-$UNIQ_SVC_B
 

--- a/internal/prettydiff/diff.go
+++ b/internal/prettydiff/diff.go
@@ -23,36 +23,7 @@ import (
 // The diffs are broken down into a line-by-line format, grouped into hunks,
 // and rendered with appropriate ANSI color codes for the terminal display.
 func Render(diffs []diffmatchpatch.Diff) string {
-	var lines []line
-	var current []diffmatchpatch.Diff
-
-	for _, diff := range diffs {
-		text := diff.Text
-
-		for len(text) > 0 {
-			idx := strings.IndexByte(text, '\n')
-
-			if idx == -1 {
-				current = append(current, diffmatchpatch.Diff{
-					Type: diff.Type,
-					Text: text,
-				})
-				break
-			}
-			current = append(current, diffmatchpatch.Diff{
-				Type: diff.Type,
-				Text: text[:idx], // cut the newline character
-			})
-
-			lines = append(lines, parseLine(current)...)
-
-			current = nil
-			text = text[idx+1:]
-		}
-	}
-	if len(current) > 0 {
-		lines = append(lines, parseLine(current)...)
-	}
+	lines := splitLines(diffs)
 
 	color := lipgloss.ColorProfile() != termenv.Ascii
 
@@ -96,86 +67,101 @@ type line struct {
 	diffs []diffmatchpatch.Diff
 }
 
-func parseLine(lineDiffs []diffmatchpatch.Diff) []line {
-	hasInsert, hasDelete := getLineType(lineDiffs)
-	if !hasInsert && !hasDelete {
-		return []line{{
-			op:    diffmatchpatch.DiffEqual,
-			diffs: lineDiffs,
-		}}
-	}
-
+func splitLines(diffs []diffmatchpatch.Diff) []line {
 	var lines []line
+	var oldLine []diffmatchpatch.Diff
+	var newLine []diffmatchpatch.Diff
 
-	// deletions
-	if hasInsert && !hasDelete {
-		var equalDiffs []diffmatchpatch.Diff
-		for _, d := range lineDiffs {
-			if d.Type == diffmatchpatch.DiffEqual {
-				equalDiffs = append(equalDiffs, d)
+	for _, diff := range diffs {
+		text := diff.Text
+
+		for len(text) > 0 {
+			idx := strings.IndexByte(text, '\n')
+			segment := text
+			ended := idx != -1
+			if ended {
+				segment = text[:idx]
 			}
-		}
-		if len(equalDiffs) > 0 {
-			lines = append(lines, line{
-				op:    diffmatchpatch.DiffDelete,
-				diffs: equalDiffs,
-			})
-		}
-	}
-	if hasDelete {
-		var delDiffs []diffmatchpatch.Diff
-		for _, d := range lineDiffs {
-			if d.Type == diffmatchpatch.DiffDelete || d.Type == diffmatchpatch.DiffEqual {
-				delDiffs = append(delDiffs, d)
+			part := diffmatchpatch.Diff{Type: diff.Type, Text: segment}
+			if diff.Type != diffmatchpatch.DiffInsert {
+				oldLine = append(oldLine, part)
 			}
+			if diff.Type != diffmatchpatch.DiffDelete {
+				newLine = append(newLine, part)
+			}
+			if !ended {
+				break
+			}
+
+			// determine where the newline occurred - this affects what gets flushed.
+			oldEnded, newEnded := false, false
+			switch diff.Type {
+			case diffmatchpatch.DiffEqual:
+				oldEnded = true
+				newEnded = true
+			case diffmatchpatch.DiffDelete:
+				oldEnded = true
+			case diffmatchpatch.DiffInsert:
+				newEnded = true
+			}
+			lines = flushLines(lines, &oldLine, &newLine, oldEnded, newEnded)
+			text = text[idx+1:]
 		}
-		lines = append(lines, line{
-			op:    diffmatchpatch.DiffDelete,
-			diffs: delDiffs,
-		})
 	}
 
-	// additions
-	if hasDelete && !hasInsert {
-		var equalDiffs []diffmatchpatch.Diff
-		for _, d := range lineDiffs {
-			if d.Type == diffmatchpatch.DiffEqual {
-				equalDiffs = append(equalDiffs, d)
-			}
-		}
-		if len(equalDiffs) > 0 {
-			lines = append(lines, line{
-				op:    diffmatchpatch.DiffInsert,
-				diffs: equalDiffs,
-			})
-		}
-	}
-	if hasInsert {
-		var insDiffs []diffmatchpatch.Diff
-		for _, d := range lineDiffs {
-			if d.Type == diffmatchpatch.DiffInsert || d.Type == diffmatchpatch.DiffEqual {
-				insDiffs = append(insDiffs, d)
-			}
-		}
-		lines = append(lines, line{
-			op:    diffmatchpatch.DiffInsert,
-			diffs: insDiffs,
-		})
+	if len(oldLine) > 0 || len(newLine) > 0 {
+		lines = flushLines(lines, &oldLine, &newLine, len(oldLine) > 0, len(newLine) > 0)
 	}
 
 	return lines
 }
 
-func getLineType(lineDiffs []diffmatchpatch.Diff) (hasInsert bool, hasDelete bool) {
-	for _, d := range lineDiffs {
-		switch d.Type {
-		case diffmatchpatch.DiffInsert:
-			hasInsert = true
-		case diffmatchpatch.DiffDelete:
-			hasDelete = true
+func flushLines(lines []line, oldLine, newLine *[]diffmatchpatch.Diff, oldEnded, newEnded bool) []line {
+	if !oldEnded && !newEnded {
+		return lines
+	}
+	if oldEnded && newEnded {
+		oldText := lineText(*oldLine)
+		newText := lineText(*newLine)
+		if oldText == newText {
+			// diff segments can still be mixed even when the visible line text
+			// matches (e.g. insertions splitting shared prefixes), so we've had to
+			// compare text
+			if oldText != "" {
+				lines = append(lines, line{
+					op: diffmatchpatch.DiffEqual,
+					diffs: []diffmatchpatch.Diff{{
+						Type: diffmatchpatch.DiffEqual,
+						Text: oldText,
+					}},
+				})
+			}
+			*oldLine = nil
+			*newLine = nil
+			return lines
 		}
 	}
-	return hasInsert, hasDelete
+	if oldEnded {
+		if len(*oldLine) > 0 {
+			lines = append(lines, line{op: diffmatchpatch.DiffDelete, diffs: *oldLine})
+		}
+		*oldLine = nil
+	}
+	if newEnded {
+		if len(*newLine) > 0 {
+			lines = append(lines, line{op: diffmatchpatch.DiffInsert, diffs: *newLine})
+		}
+		*newLine = nil
+	}
+	return lines
+}
+
+func lineText(lineDiffs []diffmatchpatch.Diff) string {
+	var buff strings.Builder
+	for _, diff := range lineDiffs {
+		buff.WriteString(diff.Text)
+	}
+	return buff.String()
 }
 
 // ANSI color codes for backgrounds

--- a/internal/prettydiff/diff_test.go
+++ b/internal/prettydiff/diff_test.go
@@ -111,3 +111,35 @@ func TestDiffPrettyText_EmptyStrings(t *testing.T) {
 	clean = vtclean.Clean(result, false)
 	require.Equal(t, "- old line\n", clean)
 }
+
+func TestDiffPrettyText_InsertBlockBeforeSimilarPrefix(t *testing.T) {
+	dmp := diffmatchpatch.New()
+	before := strings.Join([]string{
+		"image:        nginx",
+		"resources:",
+		"  memory:     128",
+		"  vcpus:      1",
+		"",
+	}, "\n")
+	after := strings.Join([]string{
+		"image:        nginx",
+		"runtime:",
+		"  env:        {A:1 B:2}",
+		"resources:",
+		"  memory:     128",
+		"  vcpus:      1",
+		"",
+	}, "\n")
+
+	diffs := dmp.DiffMain(before, after, false)
+	result := Render(diffs)
+	clean := vtclean.Clean(result, false)
+	require.Equal(t, []string{
+		"  image:        nginx",
+		"+ runtime:",
+		"+   env:        {A:1 B:2}",
+		"  resources:",
+		"    memory:     128",
+		"    vcpus:      1",
+	}, strings.Split(strings.TrimSuffix(clean, "\n"), "\n"))
+}


### PR DESCRIPTION
This is needed so we don't weirdly end up splitting multiline diffs in super odd places.

Fixes https://linear.app/unikraft/issue/CLI-54/weird-diff-newline-in-wrong-place.