### PR TITLE
ci: Skip build on staging branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,14 +1,6 @@
 name: build
 
 on:
-  push:
-    branches:
-    - staging
-    paths:
-    - '**'
-    - '!.github/**'
-    - '.github/workflows/build.yaml'
-    - '!README.md'
   pull_request:
     types:
     - opened


### PR DESCRIPTION
The auto-release pipeline will do this for us. Hopefully this should reduce our usage.