### PR TITLE
fix: Allow --watch flag with no value

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -31,6 +31,7 @@ import (
 	"unikraft.com/cli/internal/resource"
 	"unikraft.com/cli/internal/resource/cmd"
 	"unikraft.com/cli/internal/version"
+	xkong "unikraft.com/cli/internal/x/kong"
 )
 
 type UnikraftCLI struct {
@@ -202,6 +203,7 @@ func NewParser(cli *UnikraftCLI) (*kong.Kong, error) {
 				Title: kingkong.Underline("Subcommand flags") + ":",
 			},
 		}),
+		kong.NamedMapper("optional", xkong.Optional()),
 	)
 	return parser, err
 }

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -7,6 +7,7 @@ package cmd
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -106,8 +107,8 @@ type FormatOpts struct {
 }
 
 type ResourceListCmd[R resource.GettableListableResource] struct {
-	Name  []string      `arg:"" optional:"" completion-predictor:"resource-key-${name}" help:"Names of the ${names} to list."`
-	Watch time.Duration `short:"w" help:"Watch for changes and refresh output."`
+	Name  []string       `arg:"" optional:"" completion-predictor:"resource-key-${name}" help:"Names of the ${names} to list."`
+	Watch *time.Duration `short:"w" help:"Watch for changes and refresh output." type:"optional"`
 
 	FormatOpts
 }
@@ -147,15 +148,16 @@ func (cmd *ResourceListCmd[R]) Run(ctx context.Context, cfg *config.Config, sand
 			Print(out, cmd.Field, empty, resources...)
 	}
 
-	if cmd.Watch > 0 {
-		return watcher.WatchOutput(ctx, cmd.Watch, cfg.Stdout, render)
+	if cmd.Watch != nil {
+		watch := cmp.Or(*cmd.Watch, 2*time.Second)
+		return watcher.WatchOutput(ctx, watch, cfg.Stdout, render)
 	}
 	return render(cfg.Stdout)
 }
 
 type ResourceInspectCmd[R resource.GettableResource] struct {
-	Name  []string      `arg:"" completion-predictor:"resource-key-${name}" help:"Names of the ${names} to inspect."`
-	Watch time.Duration `short:"w" help:"Watch for changes and refresh output."`
+	Name  []string       `arg:"" completion-predictor:"resource-key-${name}" help:"Names of the ${names} to inspect."`
+	Watch *time.Duration `short:"w" help:"Watch for changes and refresh output." type:"optional"`
 
 	FormatOpts
 }
@@ -188,8 +190,9 @@ func (cmd *ResourceInspectCmd[R]) Run(ctx context.Context, cfg *config.Config, s
 			Print(out, cmd.Field, empty, resources...)
 	}
 
-	if cmd.Watch > 0 {
-		return watcher.WatchOutput(ctx, cmd.Watch, cfg.Stdout, render)
+	if cmd.Watch != nil {
+		watch := cmp.Or(*cmd.Watch, 2*time.Second)
+		return watcher.WatchOutput(ctx, watch, cfg.Stdout, render)
 	}
 	return render(cfg.Stdout)
 }

--- a/internal/x/kong/mapper.go
+++ b/internal/x/kong/mapper.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package kong
+
+import (
+	"reflect"
+
+	"github.com/alecthomas/kong"
+)
+
+// Optional is a mapper function that makes a field optional.
+func Optional() kong.MapperFunc {
+	// NOTE: this works with:
+	// --optional
+	// --optional=value
+	// --optional value
+	// but not with:
+	// --optional notvalue
+	// because the latter is ambiguous with positional arguments.
+	return func(ctx *kong.DecodeContext, target reflect.Value) error {
+		if ctx.Scan.Peek().Type == kong.FlagValueToken || ctx.Scan.Peek().Type == kong.UntypedToken {
+			r := kong.NewRegistry().RegisterDefaults()
+			return r.ForValue(target).Decode(ctx, target)
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
We add a custom kong mapper for this.

Example usage:

    unikraft instance list # no watch applies
    unikraft instance list --watch=5s
    unikraft instance list --watch 5s
    unikraft instance list --watch # default of 2s applies

Fixes https://linear.app/unikraft/issue/CLI-60/be-able-to-watch-resources-without-supplying-duration-boolish-flag.