### PR TITLE
fix: Gracefully handle multiple Create

### DIFF
--- a/internal/cmd/certificates.go
+++ b/internal/cmd/certificates.go
@@ -12,6 +12,7 @@ import (
 
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/x/log"
+	"unikraft.com/x/ptr"
 
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/mirror"
@@ -184,7 +185,7 @@ func (Certificate) Delete(ctx context.Context, targets []resource.Resource) erro
 	return err
 }
 
-func (Certificate) Create(ctx context.Context, fields []resource.Field) (resource.Resource, error) {
+func (Certificate) Create(ctx context.Context, fields []resource.Field) ([]resource.Resource, error) {
 	var req platform.CreateCertificateRequest
 	var metro string
 	for key, field := range resource.IterFields(fields) {
@@ -209,25 +210,32 @@ func (Certificate) Create(ctx context.Context, fields []resource.Field) (resourc
 	if err != nil {
 		return nil, err
 	}
-	uuid, err := multimetro.DoMetro(ctx, cl, metro, func(ctx context.Context, mc *multimetro.MetroClient) (string, error) {
+	keys, err := multimetro.DoMetro(ctx, cl, metro, func(ctx context.Context, mc *multimetro.MetroClient) (multimetro.Keys, error) {
 		log.G(ctx).Trace().Msg("creating certificate")
 		resp, err := mc.CreateCertificate(ctx, req)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
-		return *resp.Data.Certificates[0].Uuid, nil
+		if len(resp.Data.Certificates) == 0 {
+			return nil, fmt.Errorf("no certificates created")
+		}
+		created := make(multimetro.Keys, 0, len(resp.Data.Certificates))
+		for _, certificate := range resp.Data.Certificates {
+			key := multimetro.Key{
+				Metro: mc.Metro.Name,
+				UUID:  ptr.ZeroIfNil(certificate.Uuid),
+				Name:  ptr.ZeroIfNil(certificate.Name),
+			}
+			created = append(created, key)
+		}
+		return created, nil
 	})
 	if err != nil {
 		return nil, err
 	}
-
-	key := multimetro.Key{
-		Metro: metro,
-		UUID:  uuid,
-	}
-	results, err := Certificate{}.Get(ctx, []string{key.String()})
+	results, err := Certificate{}.Get(ctx, keys.Strings())
 	if err != nil {
 		return nil, err
 	}
-	return results[0], nil
+	return results, nil
 }

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/x/log"
+	"unikraft.com/x/ptr"
 
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/logs"
@@ -425,7 +426,7 @@ func (Instance) getPatchRequest(uuid string, key resource.FieldPath, value any, 
 	}
 }
 
-func (Instance) Create(ctx context.Context, fields []resource.Field) (resource.Resource, error) {
+func (Instance) Create(ctx context.Context, fields []resource.Field) ([]resource.Resource, error) {
 	var req platform.CreateInstanceRequest
 	var metro string
 	for key, field := range resource.IterFields(fields) {
@@ -579,27 +580,34 @@ func (Instance) Create(ctx context.Context, fields []resource.Field) (resource.R
 	if err != nil {
 		return nil, err
 	}
-	uuid, err := multimetro.DoMetro(ctx, cl, metro, func(ctx context.Context, mc *multimetro.MetroClient) (string, error) {
+	keys, err := multimetro.DoMetro(ctx, cl, metro, func(ctx context.Context, mc *multimetro.MetroClient) (multimetro.Keys, error) {
 		log.G(ctx).Trace().Msg("creating instance")
 		resp, err := mc.CreateInstance(ctx, req)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
-		return *resp.Data.Instances[0].Uuid, nil
+		if len(resp.Data.Instances) == 0 {
+			return nil, fmt.Errorf("no instances created")
+		}
+		created := make(multimetro.Keys, 0, len(resp.Data.Instances))
+		for _, instance := range resp.Data.Instances {
+			key := multimetro.Key{
+				Metro: mc.Metro.Name,
+				UUID:  ptr.ZeroIfNil(instance.Uuid),
+				Name:  ptr.ZeroIfNil(instance.Name),
+			}
+			created = append(created, key)
+		}
+		return created, nil
 	})
 	if err != nil {
 		return nil, err
 	}
-
-	key := multimetro.Key{
-		Metro: metro,
-		UUID:  uuid,
-	}
-	results, err := Instance{}.Get(ctx, []string{key.String()})
+	results, err := Instance{}.Get(ctx, keys.Strings())
 	if err != nil {
 		return nil, err
 	}
-	return results[0], nil
+	return results, nil
 }
 
 type InstancesLogsCmd struct {

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -7,9 +7,11 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 
+	"golang.org/x/sync/errgroup"
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/logs"
 	"unikraft.com/cli/internal/multimetro"
@@ -95,25 +97,48 @@ func (c *RunCmd) Run(ctx context.Context, cfg *config.Config, sandbox *resource.
 	if err != nil {
 		return err
 	}
-	instance := created.(Instance)
-	fmt.Fprintln(cfg.Stdout, created.Key())
+	if len(created) == 0 {
+		return fmt.Errorf("no instances created")
+	}
+	for _, res := range created {
+		fmt.Fprintln(cfg.Stdout, res.Key())
+	}
 
 	if c.Follow {
+		keys := make(multimetro.Keys, 0, len(created))
+		for _, res := range created {
+			instance, ok := res.(Instance)
+			if !ok {
+				return fmt.Errorf("unexpected resource type %T", res)
+			}
+			keys = append(keys, instance.key())
+		}
 		cl, err := multimetro.NewClient(ctx)
 		if err != nil {
 			return err
 		}
-		_, err = multimetro.DoKeyExact(ctx, cl, instance.key(), func(ctx context.Context, mc *multimetro.MetroClient) (any, error) {
-			r, err := logs.InstanceLogs(ctx, mc).Reader(instance.key().NameOrUUID(), 0, true)
-			if err != nil {
-				return nil, err
+		eg, ctx := errgroup.WithContext(ctx)
+		_, err = multimetro.DoKeys(ctx, cl, keys, func(_ context.Context, mc *multimetro.MetroClient, keys multimetro.Keys) ([]struct{}, []multimetro.Key, error) {
+			for _, key := range keys {
+				eg.Go(func() error {
+					r, err := logs.InstanceLogs(ctx, mc).Reader(key.NameOrUUID(), 0, true)
+					if err != nil {
+						return err
+					}
+					_, err = io.Copy(cfg.Stdout, r)
+					return err
+				})
 			}
-			_, err = io.Copy(cfg.Stdout, r)
-			return nil, err
+			return nil, keys, nil
 		})
 		if err != nil {
 			return err
 		}
+		err = eg.Wait()
+		if errors.Is(err, context.Canceled) {
+			return nil
+		}
+		return err
 	}
 
 	return nil

--- a/internal/cmd/services.go
+++ b/internal/cmd/services.go
@@ -14,6 +14,7 @@ import (
 
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/x/log"
+	"unikraft.com/x/ptr"
 
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/mirror"
@@ -260,7 +261,7 @@ func (ServiceGroup) Delete(ctx context.Context, targets []resource.Resource) err
 	return err
 }
 
-func (ServiceGroup) Create(ctx context.Context, fields []resource.Field) (resource.Resource, error) {
+func (ServiceGroup) Create(ctx context.Context, fields []resource.Field) ([]resource.Resource, error) {
 	var req platform.CreateServiceGroupRequest
 	var metro string
 	for key, field := range resource.IterFields(fields) {
@@ -303,27 +304,34 @@ func (ServiceGroup) Create(ctx context.Context, fields []resource.Field) (resour
 	if err != nil {
 		return nil, err
 	}
-	uuid, err := multimetro.DoMetro(ctx, cl, metro, func(ctx context.Context, mc *multimetro.MetroClient) (string, error) {
+	keys, err := multimetro.DoMetro(ctx, cl, metro, func(ctx context.Context, mc *multimetro.MetroClient) (multimetro.Keys, error) {
 		log.G(ctx).Trace().Msg("creating service group")
 		resp, err := mc.CreateServiceGroup(ctx, req)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
-		return *resp.Data.ServiceGroups[0].Uuid, nil
+		if len(resp.Data.ServiceGroups) == 0 {
+			return nil, fmt.Errorf("no service groups created")
+		}
+		created := make(multimetro.Keys, 0, len(resp.Data.ServiceGroups))
+		for _, group := range resp.Data.ServiceGroups {
+			key := multimetro.Key{
+				Metro: mc.Metro.Name,
+				UUID:  ptr.ZeroIfNil(group.Uuid),
+				Name:  ptr.ZeroIfNil(group.Name),
+			}
+			created = append(created, key)
+		}
+		return created, nil
 	})
 	if err != nil {
 		return nil, err
 	}
-
-	key := multimetro.Key{
-		Metro: metro,
-		UUID:  uuid,
-	}
-	results, err := ServiceGroup{}.Get(ctx, []string{key.String()})
+	results, err := ServiceGroup{}.Get(ctx, keys.Strings())
 	if err != nil {
 		return nil, err
 	}
-	return results[0], nil
+	return results, nil
 }
 
 func (ServiceGroup) Edit(ctx context.Context, target resource.Resource, fields []resource.Field) (resource.Resource, error) {

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -12,6 +12,7 @@ import (
 
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/x/log"
+	"unikraft.com/x/ptr"
 
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/mirror"
@@ -189,7 +190,7 @@ func (Volume) Delete(ctx context.Context, targets []resource.Resource) error {
 	return err
 }
 
-func (Volume) Create(ctx context.Context, fields []resource.Field) (resource.Resource, error) {
+func (Volume) Create(ctx context.Context, fields []resource.Field) ([]resource.Resource, error) {
 	var req platform.CreateVolumeRequest
 	var metro string
 	for key, field := range resource.IterFields(fields) {
@@ -211,27 +212,34 @@ func (Volume) Create(ctx context.Context, fields []resource.Field) (resource.Res
 	if err != nil {
 		return nil, err
 	}
-	uuid, err := multimetro.DoMetro(ctx, cl, metro, func(ctx context.Context, mc *multimetro.MetroClient) (string, error) {
+	keys, err := multimetro.DoMetro(ctx, cl, metro, func(ctx context.Context, mc *multimetro.MetroClient) (multimetro.Keys, error) {
 		log.G(ctx).Trace().Msg("creating volume")
 		resp, err := mc.CreateVolume(ctx, req)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
-		return *resp.Data.Volumes[0].Uuid, nil
+		if len(resp.Data.Volumes) == 0 {
+			return nil, fmt.Errorf("no volumes created")
+		}
+		created := make(multimetro.Keys, 0, len(resp.Data.Volumes))
+		for _, volume := range resp.Data.Volumes {
+			key := multimetro.Key{
+				Metro: mc.Metro.Name,
+				UUID:  ptr.ZeroIfNil(volume.Uuid),
+				Name:  ptr.ZeroIfNil(volume.Name),
+			}
+			created = append(created, key)
+		}
+		return created, nil
 	})
 	if err != nil {
 		return nil, err
 	}
-
-	key := multimetro.Key{
-		Metro: metro,
-		UUID:  uuid,
-	}
-	results, err := Volume{}.Get(ctx, []string{key.String()})
+	results, err := Volume{}.Get(ctx, keys.Strings())
 	if err != nil {
 		return nil, err
 	}
-	return results[0], nil
+	return results, nil
 }
 
 func (Volume) Edit(ctx context.Context, target resource.Resource, fields []resource.Field) (resource.Resource, error) {

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -565,9 +565,9 @@ func (cmd *ResourceCreateCmd[R]) Run(ctx context.Context, cfg *config.Config, sa
 		return PrintPatches(cfg.Stdout, fields, true)
 	}
 
-	res, err := r.Create(ctx, fields)
+	resources, err := r.Create(ctx, fields)
 	if err != nil {
 		return err
 	}
-	return printKVFormatted(cfg.Stdout, nil, res)
+	return printKVFormatted(cfg.Stdout, nil, resources...)
 }

--- a/internal/resource/cmd/cmd_test.go
+++ b/internal/resource/cmd/cmd_test.go
@@ -410,8 +410,9 @@ func TestCreate(t *testing.T) {
 
 	res, err := empty.Create(ctx, templateFields)
 	require.NoError(t, err)
+	require.Len(t, res, 1)
 
-	created := res.(resourcet.TestResource)
+	created := res[0].(resourcet.TestResource)
 	assert.Equal(t, "test-new", created.Name)
 	assert.Equal(t, 100, created.Settings.X)
 	assert.Equal(t, "created", created.Settings.Y)

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -50,7 +50,7 @@ type EditableResource interface {
 
 type CreatableResource interface {
 	GettableResource
-	Create(ctx context.Context, fields []Field) (Resource, error)
+	Create(ctx context.Context, fields []Field) ([]Resource, error)
 }
 
 type DeletableResource interface {

--- a/internal/resource/sandbox.go
+++ b/internal/resource/sandbox.go
@@ -330,12 +330,17 @@ func (r sandboxedCreatableResource) Get(ctx context.Context, keys []string) ([]R
 	}.Get(ctx, keys)
 }
 
-func (r sandboxedCreatableResource) Create(ctx context.Context, fields []Field) (Resource, error) {
-	res, err := r.CreatableResource.Create(ctx, fields)
+func (r sandboxedCreatableResource) Create(ctx context.Context, fields []Field) ([]Resource, error) {
+	resources, err := r.CreatableResource.Create(ctx, fields)
 	if err != nil {
 		return nil, err
 	}
-	return res, r.sandbox.Add(ctx, res)
+	for _, res := range resources {
+		if err := r.sandbox.Add(ctx, res); err != nil {
+			return nil, err
+		}
+	}
+	return resources, nil
 }
 
 type sandboxedDeletableResource struct {

--- a/internal/resource/testing/resource.go
+++ b/internal/resource/testing/resource.go
@@ -189,7 +189,7 @@ func (TestResource) Get(ctx context.Context, keys []string) ([]resource.Resource
 	return resources, nil
 }
 
-func (TestResource) Create(ctx context.Context, fields []resource.Field) (resource.Resource, error) {
+func (TestResource) Create(ctx context.Context, fields []resource.Field) ([]resource.Resource, error) {
 	t := TestResource{
 		Settings: TestSettings{},
 	}
@@ -209,7 +209,7 @@ func (TestResource) Create(ctx context.Context, fields []resource.Field) (resour
 	}
 
 	TestStore[t.Name] = t
-	return t, nil
+	return []resource.Resource{t}, nil
 }
 
 func (TestResource) Edit(ctx context.Context, target resource.Resource, fields []resource.Field) (resource.Resource, error) {


### PR DESCRIPTION
This is not a regular scenario! But can occur, for example, when starting replicas of a single instance.

Resolves https://linear.app/unikraft/issue/CLI-66/update-creatableresource-to-return-multiple-values.