### PR TITLE
ci(release): Add `trixie` to list of debian distributions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,6 +106,7 @@ jobs:
         # Debian
         DISTROS+=("bullseye")
         DISTROS+=("bookworm")
+        DISTROS+=("trixie")
         # Ubuntu
         DISTROS+=("jammy")
         DISTROS+=("lunar")


### PR DESCRIPTION
Signed-off-by: Alexander Jung <alex@unikraft.com>
