### PR TITLE
fix: Options for run

### DIFF
--- a/cmd/unikraft/testdata/TestGolden/instances/create
+++ b/cmd/unikraft/testdata/TestGolden/instances/create
@@ -6,29 +6,28 @@ stdout:
 $ unikraft instance create --set name=test-$UNIQ_INST --set metro=test --set image=nginx:latest --set runtime.env=A=1,B=2,C=3 --set autostart=true --set resources.memory=128 --set resources.vcpus=1 --set service.services=443:8080/tls+http --set service.domains=name=$UNIQ_DOMAIN
 
 stdout:
-	metro:         test
-	name:          test-<INST>
-	uuid:          12345678-1234-1234-1234-123456789abc
-	state:         running
-	image:         nginx
+	metro:        test
+	name:         test-<INST>
+	uuid:         12345678-1234-1234-1234-123456789abc
+	state:        running
+	image:        nginx
 	runtime:
 	  env:
-	    A:         1
-	    B:         2
-	    C:         3
+	    A:        1
+	    B:        2
+	    C:        3
 	resources:
-	  memory:      128MiB
-	  vcpus:       1
+	  memory:     128MiB
+	  vcpus:      1
 	service:
-	  uuid:        12345678-1234-1234-1234-123456789abc
-	  name:        <SERVICE_NAME>
+	  uuid:       12345678-1234-1234-1234-123456789abc
+	  name:       <SERVICE_NAME>
 	  domains:
-	  - fqdn:      <DOMAIN>.unikraft.internal
+	  - fqdn:     <DOMAIN>.unikraft.internal
 	networks:
-	- uuid:        12345678-1234-1234-1234-123456789abc
-	  private-ip:  10.X.X.X
-	  mac:         aa:bb:cc:dd:ee:ff
-	scale-to-zero:
+	- uuid:       12345678-1234-1234-1234-123456789abc
+	  private-ip: 10.X.X.X
+	  mac:        aa:bb:cc:dd:ee:ff
 
 $ unikraft instance list
 
@@ -39,139 +38,134 @@ stdout:
 $ unikraft instance inspect test-$UNIQ_INST
 
 stdout:
-	metro:         test
-	name:          test-<INST>
-	uuid:          12345678-1234-1234-1234-123456789abc
-	state:         running
-	image:         nginx
+	metro:        test
+	name:         test-<INST>
+	uuid:         12345678-1234-1234-1234-123456789abc
+	state:        running
+	image:        nginx
 	runtime:
 	  env:
-	    A:         1
-	    B:         2
-	    C:         3
+	    A:        1
+	    B:        2
+	    C:        3
 	resources:
-	  memory:      128MiB
-	  vcpus:       1
+	  memory:     128MiB
+	  vcpus:      1
 	service:
-	  uuid:        12345678-1234-1234-1234-123456789abc
-	  name:        <SERVICE_NAME>
+	  uuid:       12345678-1234-1234-1234-123456789abc
+	  name:       <SERVICE_NAME>
 	  domains:
-	  - fqdn:      <DOMAIN>.unikraft.internal
+	  - fqdn:     <DOMAIN>.unikraft.internal
 	networks:
-	- uuid:        12345678-1234-1234-1234-123456789abc
-	  private-ip:  10.X.X.X
-	  mac:         aa:bb:cc:dd:ee:ff
-	scale-to-zero:
+	- uuid:       12345678-1234-1234-1234-123456789abc
+	  private-ip: 10.X.X.X
+	  mac:        aa:bb:cc:dd:ee:ff
 
 $ unikraft instance stop test-$UNIQ_INST
 
 stdout:
-	  metro:         test
-	  name:          test-<INST>
-	  uuid:          12345678-1234-1234-1234-123456789abc
-	- state:         running
-	+ state:         stopped
-	  image:         nginx
+	  metro:        test
+	  name:         test-<INST>
+	  uuid:         12345678-1234-1234-1234-123456789abc
+	- state:        running
+	+ state:        stopped
+	  image:        nginx
 	  runtime:
 	    env:
-	      A:         1
-	      B:         2
-	      C:         3
+	      A:        1
+	      B:        2
+	      C:        3
 	  resources:
-	    memory:      128MiB
-	    vcpus:       1
+	    memory:     128MiB
+	    vcpus:      1
 	  service:
-	    uuid:        12345678-1234-1234-1234-123456789abc
-	    name:        <SERVICE_NAME>
+	    uuid:       12345678-1234-1234-1234-123456789abc
+	    name:       <SERVICE_NAME>
 	    domains:
-	    - fqdn:      <DOMAIN>.unikraft.internal
+	    - fqdn:     <DOMAIN>.unikraft.internal
 	  networks:
-	  - uuid:        12345678-1234-1234-1234-123456789abc
-	    private-ip:  10.X.X.X
-	    mac:         aa:bb:cc:dd:ee:ff
-	  scale-to-zero:
+	  - uuid:       12345678-1234-1234-1234-123456789abc
+	    private-ip: 10.X.X.X
+	    mac:        aa:bb:cc:dd:ee:ff
 
 $ unikraft instance inspect test-$UNIQ_INST
 
 stdout:
-	metro:         test
-	name:          test-<INST>
-	uuid:          12345678-1234-1234-1234-123456789abc
-	state:         stopped
-	image:         nginx
+	metro:        test
+	name:         test-<INST>
+	uuid:         12345678-1234-1234-1234-123456789abc
+	state:        stopped
+	image:        nginx
 	runtime:
 	  env:
-	    A:         1
-	    B:         2
-	    C:         3
+	    A:        1
+	    B:        2
+	    C:        3
 	resources:
-	  memory:      128MiB
-	  vcpus:       1
+	  memory:     128MiB
+	  vcpus:      1
 	service:
-	  uuid:        12345678-1234-1234-1234-123456789abc
-	  name:        <SERVICE_NAME>
+	  uuid:       12345678-1234-1234-1234-123456789abc
+	  name:       <SERVICE_NAME>
 	  domains:
-	  - fqdn:      <DOMAIN>.unikraft.internal
+	  - fqdn:     <DOMAIN>.unikraft.internal
 	networks:
-	- uuid:        12345678-1234-1234-1234-123456789abc
-	  private-ip:  10.X.X.X
-	  mac:         aa:bb:cc:dd:ee:ff
-	scale-to-zero:
+	- uuid:       12345678-1234-1234-1234-123456789abc
+	  private-ip: 10.X.X.X
+	  mac:        aa:bb:cc:dd:ee:ff
 
 $ unikraft instance start test-$UNIQ_INST
 
 stdout:
-	  metro:         test
-	  name:          test-<INST>
-	  uuid:          12345678-1234-1234-1234-123456789abc
-	- state:         stopped
-	+ state:         running
-	  image:         nginx
+	  metro:        test
+	  name:         test-<INST>
+	  uuid:         12345678-1234-1234-1234-123456789abc
+	- state:        stopped
+	+ state:        running
+	  image:        nginx
 	  runtime:
 	    env:
-	      A:         1
-	      B:         2
-	      C:         3
+	      A:        1
+	      B:        2
+	      C:        3
 	  resources:
-	    memory:      128MiB
-	    vcpus:       1
+	    memory:     128MiB
+	    vcpus:      1
 	  service:
-	    uuid:        12345678-1234-1234-1234-123456789abc
-	    name:        <SERVICE_NAME>
+	    uuid:       12345678-1234-1234-1234-123456789abc
+	    name:       <SERVICE_NAME>
 	    domains:
-	    - fqdn:      <DOMAIN>.unikraft.internal
+	    - fqdn:     <DOMAIN>.unikraft.internal
 	  networks:
-	  - uuid:        12345678-1234-1234-1234-123456789abc
-	    private-ip:  10.X.X.X
-	    mac:         aa:bb:cc:dd:ee:ff
-	  scale-to-zero:
+	  - uuid:       12345678-1234-1234-1234-123456789abc
+	    private-ip: 10.X.X.X
+	    mac:        aa:bb:cc:dd:ee:ff
 
 $ unikraft instance inspect test-$UNIQ_INST
 
 stdout:
-	metro:         test
-	name:          test-<INST>
-	uuid:          12345678-1234-1234-1234-123456789abc
-	state:         running
-	image:         nginx
+	metro:        test
+	name:         test-<INST>
+	uuid:         12345678-1234-1234-1234-123456789abc
+	state:        running
+	image:        nginx
 	runtime:
 	  env:
-	    A:         1
-	    B:         2
-	    C:         3
+	    A:        1
+	    B:        2
+	    C:        3
 	resources:
-	  memory:      128MiB
-	  vcpus:       1
+	  memory:     128MiB
+	  vcpus:      1
 	service:
-	  uuid:        12345678-1234-1234-1234-123456789abc
-	  name:        <SERVICE_NAME>
+	  uuid:       12345678-1234-1234-1234-123456789abc
+	  name:       <SERVICE_NAME>
 	  domains:
-	  - fqdn:      <DOMAIN>.unikraft.internal
+	  - fqdn:     <DOMAIN>.unikraft.internal
 	networks:
-	- uuid:        12345678-1234-1234-1234-123456789abc
-	  private-ip:  10.X.X.X
-	  mac:         aa:bb:cc:dd:ee:ff
-	scale-to-zero:
+	- uuid:       12345678-1234-1234-1234-123456789abc
+	  private-ip: 10.X.X.X
+	  mac:        aa:bb:cc:dd:ee:ff
 
 $ FQDN=$(unikraft instance inspect test-$UNIQ_INST --output 'template={{ (index (index (index (index . 0) "service") "domains") 0).fqdn }}')
 

--- a/cmd/unikraft/testdata/TestGolden/instances/help
+++ b/cmd/unikraft/testdata/TestGolden/instances/help
@@ -43,7 +43,8 @@ stdout:
 	  service.soft-limit, service.hard-limit
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps
-	  scale-to-zero
+	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
+	  zero.stateful, scale-to-zero.cooldown-time
 	  timing
 	  restart
 	  stop
@@ -106,7 +107,8 @@ stdout:
 	  service.soft-limit, service.hard-limit
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps
-	  scale-to-zero
+	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
+	  zero.stateful, scale-to-zero.cooldown-time
 	  timing
 	  restart
 	  stop
@@ -177,7 +179,8 @@ stdout:
 	  service.soft-limit, service.hard-limit
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps
-	  scale-to-zero
+	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
+	  zero.stateful, scale-to-zero.cooldown-time
 	  timing
 	  restart
 	  stop
@@ -246,7 +249,8 @@ stdout:
 	  service.soft-limit, service.hard-limit
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps
-	  scale-to-zero
+	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
+	  zero.stateful, scale-to-zero.cooldown-time
 	  timing
 	  restart
 	  stop
@@ -325,7 +329,8 @@ stdout:
 	  service.soft-limit, service.hard-limit
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps
-	  scale-to-zero
+	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
+	  zero.stateful, scale-to-zero.cooldown-time
 	  timing
 	  restart
 	  stop
@@ -402,7 +407,8 @@ stdout:
 	  service.soft-limit, service.hard-limit
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps
-	  scale-to-zero
+	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
+	  zero.stateful, scale-to-zero.cooldown-time
 	  timing
 	  restart
 	  stop
@@ -487,7 +493,8 @@ stdout:
 	  service.soft-limit, service.hard-limit
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps
-	  scale-to-zero
+	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
+	  zero.stateful, scale-to-zero.cooldown-time
 	  timing
 	  restart
 	  stop

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/x/kingkong"
@@ -27,6 +28,7 @@ import (
 	"unikraft.com/cli/internal/multimetro"
 	"unikraft.com/cli/internal/resource"
 	"unikraft.com/cli/internal/resource/cmd"
+	"unikraft.com/cli/internal/resource/value"
 	"unikraft.com/cli/internal/types"
 	xslices "unikraft.com/cli/internal/x/slices"
 )
@@ -124,19 +126,27 @@ type Instance struct {
 type InstanceVolume struct {
 	UUID     string `mirror:"uuid" json:"uuid,omitempty" field:",long"`
 	Name     string `mirror:"name" json:"name,omitempty" field:",long"`
-	SizeMB   int64  `json:"size_mb,omitempty"`
 	At       string `mirror:"at" json:"at" field:",long"`
 	Readonly bool   `mirror:"readonly" json:"readonly,omitempty" field:",long"`
+
+	// create-only field
+	Size types.SizeMebibytes `field:",invisible,embed" create:"set"`
 }
 
 func (v *InstanceVolume) MarshalText() ([]byte, error) {
-	parts := []string{cmp.Or(v.Name, v.UUID)}
-	if v.SizeMB > 0 {
-		parts = append(parts, strconv.FormatInt(v.SizeMB, 10)+"M")
+	parts := []string{
+		cmp.Or(v.Name, v.UUID),
+		v.At,
 	}
-	parts = append(parts, v.At)
 	if v.Readonly {
 		parts = append(parts, "ro")
+	}
+	if v.Size > 0 {
+		s, err := value.Format(v.Size)
+		if err != nil {
+			return nil, err
+		}
+		parts = append(parts, fmt.Sprintf("size=%s", s))
 	}
 	return []byte(strings.Join(parts, ":")), nil
 }
@@ -145,33 +155,45 @@ func (v *InstanceVolume) UnmarshalText(data []byte) error {
 	str := string(data)
 	parts := strings.Split(str, ":")
 	if len(parts) < 2 {
-		return fmt.Errorf("invalid volume format, expected NAME:AT[:ro] or UUID:AT[:ro] or NAME:SIZE:AT[:ro]")
+		return fmt.Errorf("invalid volume format, expected NAME:AT, got %q", str)
 	}
 
-	// Check if last part is "ro"
-	if len(parts) > 0 && parts[len(parts)-1] == "ro" {
-		v.Readonly = true
-		parts = parts[:len(parts)-1]
-	}
+	name, at, parts := parts[0], parts[1], parts[2:]
+	readonly := false
+	size := types.SizeMebibytes(0)
 
-	if len(parts) == 2 {
-		// Could be NAME:AT or UUID:AT
-		v.Name = parts[0]
-		v.UUID = parts[0]
-		v.At = parts[1]
-	} else if len(parts) == 3 {
-		// NAME:SIZE:AT
-		v.Name = parts[0]
-		sizeStr := strings.TrimSuffix(parts[1], "M")
-		size, err := strconv.ParseInt(sizeStr, 10, 64)
-		if err != nil {
-			return fmt.Errorf("invalid size: %w", err)
+	var err error
+	for _, part := range parts {
+		k, v, ok := strings.Cut(part, "=")
+		switch k {
+		case "ro":
+			if ok {
+				readonly, err = strconv.ParseBool(v)
+				if err != nil {
+					return err
+				}
+			} else {
+				readonly = true
+			}
+		case "size":
+			size, err = value.Parse[types.SizeMebibytes]([]string{v})
+			if err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("invalid volume option: %q", k)
 		}
-		v.SizeMB = size
-		v.At = parts[2]
-	} else {
-		return fmt.Errorf("invalid volume format")
 	}
+
+	if name == "" {
+		v.Size = size
+	} else if uuid.Validate(name) == nil {
+		v.UUID = name
+	} else {
+		v.Name = name
+	}
+	v.At = at
+	v.Readonly = readonly
 
 	return nil
 }
@@ -488,8 +510,8 @@ func (Instance) Create(ctx context.Context, fields []resource.Field) ([]resource
 				if vol.Name != "" {
 					reqVol.Name = &vol.Name
 				}
-				if vol.SizeMB > 0 {
-					reqVol.SizeMb = &vol.SizeMB
+				if vol.Size > 0 {
+					reqVol.SizeMb = ptr.ToPtr(int64(vol.Size))
 				}
 				if vol.Readonly {
 					reqVol.Readonly = &vol.Readonly

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -90,7 +90,7 @@ type Instance struct {
 		StoppedAt time.Time `mirror:"instance.stopped_at"`
 	}
 
-	ScaleToZero InstanceScaleToZero `field:",long,embed" mirror:"instance.scale_to_zero"`
+	ScaleToZero InstanceScaleToZero `field:",embed" mirror:"instance.scale_to_zero"`
 
 	Timing struct {
 		Uptime   types.DurationMS `mirror:"instance.uptime_ms"`
@@ -177,10 +177,10 @@ func (v *InstanceVolume) UnmarshalText(data []byte) error {
 }
 
 type InstanceScaleToZero struct {
-	Enabled      *bool  `mirror:"enabled" create:"set"`
-	Policy       string `mirror:"policy" create:"set"`
-	Stateful     bool   `mirror:"stateful" create:"set"`
-	CooldownTime int64  `mirror:"cooldown_time_ms" create:"set"`
+	Enabled      bool   `mirror:"enabled" field:",long"`
+	Policy       string `mirror:"policy" field:",long" create:"set"`
+	Stateful     bool   `mirror:"stateful" field:",long" create:"set"`
+	CooldownTime int64  `mirror:"cooldown_time_ms" field:",long" create:"set"`
 }
 
 func (Instance) Type() resource.Type {
@@ -459,12 +459,6 @@ func (Instance) Create(ctx context.Context, fields []resource.Field) ([]resource
 		case "restart.policy":
 			policy := platform.CreateInstanceRequestRestartPolicy(field.Create.Set.(string))
 			req.RestartPolicy = &policy
-		case "scale-to-zero.enabled":
-			if req.ScaleToZero == nil {
-				req.ScaleToZero = &platform.CreateInstanceRequestScaleToZero{}
-			}
-			enabled := field.Create.Set.(bool)
-			req.ScaleToZero.Enabled = &enabled
 		case "scale-to-zero.policy":
 			if req.ScaleToZero == nil {
 				req.ScaleToZero = &platform.CreateInstanceRequestScaleToZero{}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -19,6 +19,7 @@ import (
 	"unikraft.com/cli/internal/resource/cmd"
 	"unikraft.com/cli/internal/resource/value"
 	"unikraft.com/cli/internal/types"
+	"unikraft.com/cloud/sdk/platform"
 )
 
 type RunCmd struct {
@@ -186,11 +187,7 @@ func (c *RunCmd) runCreatePatches(env map[string]string, volumes []*InstanceVolu
 		patches["restart.policy"] = c.Restart
 	}
 	if scaleToZero != nil {
-		if scaleToZero.Enabled != nil {
-			patches["scale-to-zero.enabled"] = *scaleToZero.Enabled
-		} else {
-			patches["scale-to-zero.enabled"] = true
-		}
+		patches["scale-to-zero.policy"] = string(platform.InstanceScaleToZeroPolicyOn)
 		if scaleToZero.Policy != "" {
 			patches["scale-to-zero.policy"] = scaleToZero.Policy
 		}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -19,6 +19,7 @@ import (
 	"unikraft.com/cli/internal/resource/cmd"
 	"unikraft.com/cli/internal/resource/value"
 	"unikraft.com/cli/internal/types"
+	xmaps "unikraft.com/cli/internal/x/maps"
 	"unikraft.com/cloud/sdk/platform"
 )
 
@@ -156,7 +157,11 @@ func (c *RunCmd) applyCreatePatches(fields []resource.Field, env map[string]stri
 		field.Create = nil
 		if value, ok := patches[path.String()]; ok {
 			field.Create = &resource.Patch{Set: value}
+			delete(patches, path.String())
 		}
+	}
+	if len(patches) > 0 {
+		return fmt.Errorf("unknown create patches: %v", xmaps.OrderedKeys(patches))
 	}
 
 	return nil

--- a/internal/resource/value/parse.go
+++ b/internal/resource/value/parse.go
@@ -11,6 +11,8 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+
+	xmaps "unikraft.com/cli/internal/x/maps"
 )
 
 func Parse[T any](input []string) (T, error) {
@@ -139,7 +141,10 @@ func parseReflect(input []string, value reflect.Value) error {
 		return nil
 	case reflect.Struct:
 		s := reflect.New(output.Type()).Elem()
+
+		notFound := make(map[string]struct{})
 		for _, input := range input {
+		process:
 			for item := range strings.SplitSeq(input, ",") {
 				item = strings.TrimSpace(item)
 				if item == "" {
@@ -158,9 +163,14 @@ func parseReflect(input []string, value reflect.Value) error {
 						if err != nil {
 							return err
 						}
+						continue process
 					}
 				}
+				notFound[k] = struct{}{}
 			}
+		}
+		if len(notFound) > 0 {
+			return fmt.Errorf("unknown fields: %v", xmaps.OrderedKeys(notFound))
 		}
 		output.Set(s)
 		return nil


### PR DESCRIPTION
`--volume` and `--scale-to-zero` both had issues.

`--volume` was just almost entirely broken, the prior implementation was not right.

`--scale-to-zero` took an `enabled` parameter, this actually doesn't exist in the platform, so we shouldn't set it. The correct syntax is `--scale-to-zero policy=on`.

This *also* finally fixes the `scale-to-zero` extra field appearing.
