### PR TITLE
ci: Avoid cancelling in-progress workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,6 @@ permissions:
 # Automatically cancel in-progress actions on the same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
 
 jobs:
   release:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,6 @@ on:
 # Automatically cancel in-progress actions on the same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
-  cancel-in-progress: true
 
 jobs:
   go:


### PR DESCRIPTION
For release: we should *keep* running the already running release.
For test: we should tear down resources at the end of the test run.

I'm hoping this is the cause of https://linear.app/unikraft/issue/CLI-102/leaky-authenticated-cli-test-resources. But will keep an eye on it.