### PR TITLE
feat: Add log wrapping

### DIFF
--- a/internal/logfmt/logfmt.go
+++ b/internal/logfmt/logfmt.go
@@ -29,14 +29,14 @@ func New(sink io.Writer, typ log.Type, level log.Level) *log.Logger {
 		fallthrough
 	default:
 		logger = zerolog.New(zerolog.ConsoleWriter{
-			Out: sink,
+			Out: newScreenWrappedWriter(sink),
 			FormatLevel: func(i any) string {
+				if i == nil {
+					return LogLevelSymbol
+				}
 				if ll, ok := i.(string); ok {
 					level, _ := zerolog.ParseLevel(ll)
 					return levelColors[level](LogLevelSymbol)
-				}
-				if i == nil {
-					return "?"
 				}
 				return fmt.Sprintf("%s", i)
 			},

--- a/internal/logfmt/wrapper.go
+++ b/internal/logfmt/wrapper.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package logfmt
+
+import (
+	"bytes"
+	"io"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/charmbracelet/x/term"
+	"unikraft.com/x/guesstermwidth"
+)
+
+type wrappedWriter struct {
+	out     io.Writer
+	width   int
+	pending []byte
+}
+
+func newWrappedWriter(out io.Writer, width int) io.Writer {
+	return &wrappedWriter{out: out, width: width}
+}
+
+func newScreenWrappedWriter(out io.Writer) io.Writer {
+	if !isTTY(out) {
+		return out
+	}
+	return newWrappedWriter(out, guesstermwidth.GuessTermWidth(out))
+}
+
+func (w *wrappedWriter) Write(p []byte) (int, error) {
+	if w.width < 1 {
+		return w.out.Write(p)
+	}
+
+	w.pending = append(w.pending, p...)
+	for {
+		newline := bytes.IndexByte(w.pending, '\n')
+		if newline == -1 {
+			break
+		}
+		line := string(w.pending[:newline+1])
+		if newline+1 >= len(w.pending) {
+			w.pending = w.pending[:0]
+		} else {
+			w.pending = w.pending[newline+1:]
+		}
+
+		if err := w.writeWrappedLine(line); err != nil {
+			return 0, err
+		}
+	}
+
+	return len(p), nil
+}
+
+func (w *wrappedWriter) writeWrappedLine(line string) error {
+	prefix, content := splitLogPrefix(line)
+	wrapWidth := w.width
+	if prefix != "" {
+		wrapWidth = max(w.width-ansi.StringWidth(prefix), 1)
+	}
+
+	wrapped := ansi.Wrap(content, wrapWidth, " ")
+	for line := range strings.Lines(wrapped) {
+		if prefix != "" {
+			line = prefix + line
+		}
+		if _, err := io.WriteString(w.out, line); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func splitLogPrefix(line string) (string, string) {
+	ss := strings.SplitAfterN(line, " ", 2)
+	if len(ss) < 2 {
+		return "", line
+	}
+	if !strings.Contains(ss[0], LogLevelSymbol) {
+		// this *shouldn't* happen, the log writer should always be prefixed by a
+		// level but just in case, we avoid accidentally repeating the first word
+		// of the line as a prefix
+		return "", line
+	}
+	return ss[0], ss[1]
+}
+
+func isTTY(out io.Writer) bool {
+	fdWriter, ok := out.(interface{ Fd() uintptr })
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(fdWriter.Fd())
+}

--- a/internal/logfmt/wrapper_test.go
+++ b/internal/logfmt/wrapper_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package logfmt
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrappedWriterWrapsPlainLine(t *testing.T) {
+	buffer := &bytes.Buffer{}
+	writer := newWrappedWriter(buffer, 6)
+
+	_, err := writer.Write([]byte("hello world\n"))
+	require.NoError(t, err)
+
+	require.Equal(t, "hello\nworld\n", buffer.String())
+}
+
+func TestWrappedWriterWrapsLongWord(t *testing.T) {
+	buffer := &bytes.Buffer{}
+	writer := newWrappedWriter(buffer, 4)
+
+	_, err := writer.Write([]byte("abcdefgh\n"))
+	require.NoError(t, err)
+
+	require.Equal(t, "abcd\nefgh\n", buffer.String())
+}
+
+func TestWrappedWriterWrapsLogLine(t *testing.T) {
+	buffer := &bytes.Buffer{}
+	writer := newWrappedWriter(buffer, 10)
+
+	_, err := writer.Write([]byte(LogLevelSymbol + " hello world from unikraft\n"))
+	require.NoError(t, err)
+
+	expected := "" +
+		LogLevelSymbol + " hello\n" +
+		LogLevelSymbol + " world\n" +
+		LogLevelSymbol + " from\n" +
+		LogLevelSymbol + " unikraft\n"
+	require.Equal(t, expected, buffer.String())
+}
+
+func TestWrappedWriterRepeatsLogPrefix(t *testing.T) {
+	buffer := &bytes.Buffer{}
+	writer := newWrappedWriter(buffer, 8)
+
+	prefix := "\x1b[31m" + LogLevelSymbol + "\x1b[0m "
+	_, err := writer.Write([]byte(prefix + "hello world\n"))
+	require.NoError(t, err)
+
+	expected := prefix + "hello\n" + prefix + "world\n"
+	require.Equal(t, expected, buffer.String())
+}


### PR DESCRIPTION
Wraps logs to the screen size.

Note. Like the table formatting, this will still look bad when resizing after the command has run (either by resizing the terminal window), or when copy-pasting output. However, for the happy path logs just look better on smaller screen sizes.

Before:

```
│ unikraft CLI arch=amd64 built=unknown commit=uns
et plat=linux version=dev
│ initializing platform clients metros=["ukp-stabl
e","ukp-staging"]
│ getting instances keys=["http-go121-q8yf8"] metr
o=ukp-staging
│ getting instances keys=["http-go121-q8yf8"] metr
o=ukp-stable
│  
│ error:
│   keys not found: [http-go121-q8yf8]
│  
```

After:

```
❯ unikraft instance logs http-go121-q8yf8 --log-level=trace
│ unikraft CLI arch=amd64 built=unknown commit=unset
│ plat=linux version=dev
│ initializing platform clients metros=["ukp-
│ stable","ukp-staging"]
│ getting instances keys=["http-go121-q8yf8"] 
│ metro=ukp-staging
│ getting instances keys=["http-go121-q8yf8"] 
│ metro=ukp-stable
│  
│ error:
│   keys not found: [http-go121-q8yf8]
│  
```