### PR TITLE
fix: Ensure tabwriter detects size of watched output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	unikraft.com/cloud/sdk v0.0.0-20260203165110-781485da6b76
 	unikraft.com/x/colors v0.0.0-20260116231133-1da0081544af
 	unikraft.com/x/fingerprint v0.0.0-20260126094137-ab6e717e5679
-	unikraft.com/x/guesstermwidth v0.0.0-20260116231133-1da0081544af
+	unikraft.com/x/guesstermwidth v0.0.0-20260205230841-e14b7e4a7c4c
 	unikraft.com/x/image-spec v0.0.0-20260126171022-af62c17fcdf7
 	unikraft.com/x/kingkong v0.0.0-20260203003720-5a31ab15ba4e
 	unikraft.com/x/log v0.0.0-20260126171022-af62c17fcdf7

--- a/go.sum
+++ b/go.sum
@@ -368,8 +368,8 @@ unikraft.com/x/colors v0.0.0-20260116231133-1da0081544af h1:hMhha9vksyprsG7cAoqv
 unikraft.com/x/colors v0.0.0-20260116231133-1da0081544af/go.mod h1:735uvuC2QXrt7MwEs1dnnQDmGxVMyDyVDf3GqfC0dmA=
 unikraft.com/x/fingerprint v0.0.0-20260126094137-ab6e717e5679 h1:zdvJjNkjsriS8RM46FcdgcRoCh4EYM66PGjqVgi/ups=
 unikraft.com/x/fingerprint v0.0.0-20260126094137-ab6e717e5679/go.mod h1:FP7uOxux/W5PKqSRQsR4tyjNuLq4Cfio7mc5QVH1kW8=
-unikraft.com/x/guesstermwidth v0.0.0-20260116231133-1da0081544af h1:cRrCU4yhPnWepQ44atbzITfHij0S/EIdLaZ7V2yqTYc=
-unikraft.com/x/guesstermwidth v0.0.0-20260116231133-1da0081544af/go.mod h1:q3EH6bLqLAJ1PqZgHlCJPpvvP6scnjJJspBMyGQtMt4=
+unikraft.com/x/guesstermwidth v0.0.0-20260205230841-e14b7e4a7c4c h1:DWRWh/lMGdraXL1uji3lG0aRcZvlzv9f8LZzWr7KyHw=
+unikraft.com/x/guesstermwidth v0.0.0-20260205230841-e14b7e4a7c4c/go.mod h1:q3EH6bLqLAJ1PqZgHlCJPpvvP6scnjJJspBMyGQtMt4=
 unikraft.com/x/image-spec v0.0.0-20260126171022-af62c17fcdf7 h1:J1Z1wZoh6yBAG9Y2UQa0q2XJAf1FHT+/pr9ly0kw/DI=
 unikraft.com/x/image-spec v0.0.0-20260126171022-af62c17fcdf7/go.mod h1:l0+tgd72OA6DzrX+V7z9XYjd80PrMJMCPnXNTODBjrc=
 unikraft.com/x/kingkong v0.0.0-20260203003720-5a31ab15ba4e h1:3Rhyq83l8uAuwDOfyt//a3cdU5XlznaphKu2UDKgDBY=

--- a/internal/tabwriter/tabwriter.go
+++ b/internal/tabwriter/tabwriter.go
@@ -10,7 +10,6 @@ import (
 	"io"
 
 	"github.com/charmbracelet/x/ansi"
-	"github.com/charmbracelet/x/term"
 	"unikraft.com/x/guesstermwidth"
 
 	xio "unikraft.com/cli/internal/x/io"
@@ -52,7 +51,7 @@ func WithMaxWidth(width int) TabWriterOpt {
 
 func WithMaxScreenWidth() TabWriterOpt {
 	return func(t *tabWriter) {
-		if !isTTY(t.w) {
+		if !guesstermwidth.IsTTY(t.w) {
 			return
 		}
 		t.maxwidth = max(0, guesstermwidth.GuessTermWidth(t.w))
@@ -242,12 +241,4 @@ func (t *tabWriter) Flush() error {
 		return tw.Flush()
 	}
 	return nil
-}
-
-func isTTY(out io.Writer) bool {
-	fdWriter, ok := out.(interface{ Fd() uintptr })
-	if !ok {
-		return false
-	}
-	return term.IsTerminal(fdWriter.Fd())
 }

--- a/internal/tui/watcher/model.go
+++ b/internal/tui/watcher/model.go
@@ -17,6 +17,7 @@ import (
 )
 
 type watchModel struct {
+	underlying  io.Writer
 	render      func(io.Writer) error
 	output      string
 	lastRefresh time.Time
@@ -84,7 +85,7 @@ func (model watchModel) View() string {
 func (model watchModel) watchRenderCmd() tea.Cmd {
 	return func() tea.Msg {
 		var buffer bytes.Buffer
-		err := model.render(&buffer)
+		err := model.render(wrapFdWriter(&buffer, model.underlying))
 		return watchRenderMsg{output: buffer.String(), err: err}
 	}
 }
@@ -93,4 +94,20 @@ func (model watchModel) watchStatusTickCmd() tea.Cmd {
 	return tea.Tick(50*time.Millisecond, func(time.Time) tea.Msg {
 		return watchStatusMsg{}
 	})
+}
+
+func wrapFdWriter(w io.Writer, fdw io.Writer) io.Writer {
+	if fdw, ok := fdw.(interface{ Fd() uintptr }); ok {
+		return fdWriter{Writer: w, fd: fdw.Fd()}
+	}
+	return w
+}
+
+type fdWriter struct {
+	io.Writer
+	fd uintptr
+}
+
+func (w fdWriter) Fd() uintptr {
+	return w.fd
 }

--- a/internal/tui/watcher/watcher.go
+++ b/internal/tui/watcher/watcher.go
@@ -25,7 +25,7 @@ func WatchOutput(ctx context.Context, interval time.Duration, out io.Writer, ren
 
 func watchOutputPretty(ctx context.Context, interval time.Duration, out io.Writer, render func(io.Writer) error) error {
 	program := tea.NewProgram(
-		watchModel{render: render, interval: interval},
+		watchModel{underlying: out, render: render, interval: interval},
 		tea.WithOutput(out),
 		tea.WithContext(ctx),
 	)

--- a/internal/x/io/flush.go
+++ b/internal/x/io/flush.go
@@ -3,7 +3,7 @@
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
 
-package kvwriter
+package io
 
 import "io"
 


### PR DESCRIPTION
Fixes https://linear.app/unikraft/issue/CLI-137/truncate-fields-in-wor-watch-mode.