### PR TITLE
fix: Many little fixes

### DIFF
--- a/cmd/unikraft/auth_test.go
+++ b/cmd/unikraft/auth_test.go
@@ -14,12 +14,10 @@ var authTestCases = []testCase{
 			{args: []string{unikraftCmd, "profile", "--help"}},
 			{args: []string{unikraftCmd, "profile", "get", "--help"}},
 			{args: []string{unikraftCmd, "profile", "list", "--help"}},
-			{args: []string{unikraftCmd, "profile", "wait", "--help"}},
 			{args: []string{unikraftCmd, "profile", "use", "--help"}},
 			{args: []string{unikraftCmd, "metro", "--help"}},
 			{args: []string{unikraftCmd, "metro", "get", "--help"}},
 			{args: []string{unikraftCmd, "metro", "list", "--help"}},
-			{args: []string{unikraftCmd, "metro", "wait", "--help"}},
 		},
 	},
 	{

--- a/cmd/unikraft/help_test.go
+++ b/cmd/unikraft/help_test.go
@@ -11,11 +11,36 @@ var helpTestCases = []testCase{
 		commands: []command{{args: []string{unikraftCmd}, allowErr: true}},
 	},
 	{
+		name:     "version",
+		commands: []command{{args: []string{unikraftCmd, "--version"}}},
+	},
+	{
 		name:     "help",
 		commands: []command{{args: []string{unikraftCmd, "--help"}}},
 	},
 	{
-		name:     "version",
-		commands: []command{{args: []string{unikraftCmd, "--version"}}},
+		// check we can detect an invalid arg
+		name:     "invalid/arg",
+		commands: []command{{args: []string{unikraftCmd, "invalid"}, allowErr: true}},
+	},
+	{
+		// check help args still work when we have an invalid cmdline
+		name: "invalid/help",
+		commands: []command{
+			{args: []string{unikraftCmd, "--help", "--bad-flag"}, allowErr: true},
+			{args: []string{unikraftCmd, "--help", "bad-arg"}, allowErr: true},
+			// NOTE: these aren't handled, since parsing exits *immediately* after
+			// finding an invalid flag/arg
+			// {args: []string{unikraftCmd, "--bad-flag", "--help"}, allowErr: true},
+			// {args: []string{unikraftCmd, "bad-arg", "--help"}, allowErr: true},
+		},
+	},
+	{
+		// check log args still work when we have an invalid cmdline
+		name: "invalid/logs",
+		commands: []command{
+			{args: []string{unikraftCmd, "--log-type=json", "invalid"}, allowErr: true},
+			{args: []string{unikraftCmd, "--log-level=fatal", "invalid"}, allowErr: true},
+		},
 	},
 }

--- a/cmd/unikraft/images_test.go
+++ b/cmd/unikraft/images_test.go
@@ -14,7 +14,6 @@ var imagesTestCases = []testCase{
 			{args: []string{unikraftCmd, "image", "--help"}},
 			{args: []string{unikraftCmd, "image", "get", "--help"}},
 			{args: []string{unikraftCmd, "image", "list", "--help"}},
-			{args: []string{unikraftCmd, "image", "wait", "--help"}},
 			{args: []string{unikraftCmd, "image", "copy", "--help"}},
 		},
 	},

--- a/cmd/unikraft/main.go
+++ b/cmd/unikraft/main.go
@@ -97,6 +97,9 @@ func getMethod(value reflect.Value, name string) reflect.Value {
 func run(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) (context.Context, error) {
 	cli, opts, cleanup, err := cmd.NewRootCmd(ctx, args, stdin, stdout, stderr)
 	if err != nil {
+		if opts != nil && opts.Context != nil {
+			return opts.Context, err
+		}
 		return ctx, err
 	}
 

--- a/cmd/unikraft/main_test.go
+++ b/cmd/unikraft/main_test.go
@@ -286,6 +286,11 @@ type cleaner struct {
 // so we get consistent golden files.
 var cleaners = []cleaner{
 	{
+		// datetimes like "2000-01-02T12:34:56+01:00" change between runs
+		pattern: regexp.MustCompile(`\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|(\+\d{2}:\d{2}))?\b`),
+		repl:    "YYYY-MM-DDTHH:MM:SSZ",
+	},
+	{
 		// times like "12:34:56" or "12:34:56PM" change between runs
 		pattern: regexp.MustCompile(`\b\d\d?:\d\d:\d\d([AP]M)?\b`),
 		repl:    "HH:MM:SS",

--- a/cmd/unikraft/testdata/TestGolden/auth/help
+++ b/cmd/unikraft/testdata/TestGolden/auth/help
@@ -89,8 +89,6 @@ stdout:
 	Commands:
 	  get, inspect, show
 	          Inspect a profile.
-	  wait
-	          Wait for profiles to match a filter.
 	  list, ls
 	          List profiles.
 	  use
@@ -230,60 +228,6 @@ stdout:
 	      --version
 	          Print version information.
 
-$ unikraft profile wait --help
-
-stdout:
-	Usage:
-	  unikraft profile wait --until=UNTIL <name> ... [flags]
-
-	Wait for profiles to match a filter.
-
-	Arguments:
-	  <name> ...
-	          Names of the profiles to wait for.
-
-	Fields:
-	  name
-	  active
-	  metros
-
-	Flags:
-	      --until, --filter ($UNIKRAFT_UNTIL)
-	          Filter expression to wait for (e.g. --until state==running).
-	      --interval ($UNIKRAFT_INTERVAL)
-	          Polling interval.
-	          [default: 2s]
-	      --timeout ($UNIKRAFT_TIMEOUT)
-	          Timeout before giving up.
-	          [default: 0]
-	  -f, --field ($UNIKRAFT_FIELD)
-	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
-	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
-
-	Global flags:
-	  -h, --help
-	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
-	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
-	          Enable or disable telemetry.
-	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
-	          Enable or disable emojis in the CLI output.
-	          [default: true]
-	      --log-level ($UNIKRAFT_LOG_LEVEL)
-	          Set the logging level.
-	          [default: info, choice: trace,debug,info,warn,error,fatal]
-	      --log-type ($UNIKRAFT_LOG_TYPE)
-	          Set the log type.
-	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
-	          Set the current profile.
-	          [default: default]
-	      --version
-	          Print version information.
-
 $ unikraft profile use --help
 
 stdout:
@@ -330,8 +274,6 @@ stdout:
 	Commands:
 	  get, inspect, show
 	          Inspect a metro.
-	  wait
-	          Wait for metros to match a filter.
 	  list, ls
 	          List metros.
 
@@ -441,60 +383,6 @@ stdout:
 	          Filter output based on a field value (e.g. --filter state==running).
 	  -w, --watch ($UNIKRAFT_WATCH)
 	          Watch for changes and refresh output.
-	  -f, --field ($UNIKRAFT_FIELD)
-	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
-	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
-
-	Global flags:
-	  -h, --help
-	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
-	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
-	          Enable or disable telemetry.
-	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
-	          Enable or disable emojis in the CLI output.
-	          [default: true]
-	      --log-level ($UNIKRAFT_LOG_LEVEL)
-	          Set the logging level.
-	          [default: info, choice: trace,debug,info,warn,error,fatal]
-	      --log-type ($UNIKRAFT_LOG_TYPE)
-	          Set the log type.
-	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
-	          Set the current profile.
-	          [default: default]
-	      --version
-	          Print version information.
-
-$ unikraft metro wait --help
-
-stdout:
-	Usage:
-	  unikraft metros wait --until=UNTIL <name> ... [flags]
-
-	Wait for metros to match a filter.
-
-	Arguments:
-	  <name> ...
-	          Names of the metros to wait for.
-
-	Fields:
-	  name
-	  country
-	  endpoint
-
-	Flags:
-	      --until, --filter ($UNIKRAFT_UNTIL)
-	          Filter expression to wait for (e.g. --until state==running).
-	      --interval ($UNIKRAFT_INTERVAL)
-	          Polling interval.
-	          [default: 2s]
-	      --timeout ($UNIKRAFT_TIMEOUT)
-	          Timeout before giving up.
-	          [default: 0]
 	  -f, --field ($UNIKRAFT_FIELD)
 	          Specify which fields to include in the output.
 	  -o, --output ($UNIKRAFT_OUTPUT)

--- a/cmd/unikraft/testdata/TestGolden/auth/help
+++ b/cmd/unikraft/testdata/TestGolden/auth/help
@@ -234,7 +234,7 @@ $ unikraft profile wait --help
 
 stdout:
 	Usage:
-	  unikraft profile wait <name> ... [flags]
+	  unikraft profile wait --until=UNTIL <name> ... [flags]
 
 	Wait for profiles to match a filter.
 
@@ -248,7 +248,7 @@ stdout:
 	  metros
 
 	Flags:
-	      --until ($UNIKRAFT_UNTIL)
+	      --until, --filter ($UNIKRAFT_UNTIL)
 	          Filter expression to wait for (e.g. --until state==running).
 	      --interval ($UNIKRAFT_INTERVAL)
 	          Polling interval.
@@ -473,7 +473,7 @@ $ unikraft metro wait --help
 
 stdout:
 	Usage:
-	  unikraft metros wait <name> ... [flags]
+	  unikraft metros wait --until=UNTIL <name> ... [flags]
 
 	Wait for metros to match a filter.
 
@@ -487,7 +487,7 @@ stdout:
 	  endpoint
 
 	Flags:
-	      --until ($UNIKRAFT_UNTIL)
+	      --until, --filter ($UNIKRAFT_UNTIL)
 	          Filter expression to wait for (e.g. --until state==running).
 	      --interval ($UNIKRAFT_INTERVAL)
 	          Polling interval.

--- a/cmd/unikraft/testdata/TestGolden/auth/help
+++ b/cmd/unikraft/testdata/TestGolden/auth/help
@@ -7,32 +7,32 @@ stdout:
 	Login to Unikraft Cloud.
 
 	Flags:
-	      --check ($UNIKRAFT_CHECK)
+	      --check
 	          Check if the user is already logged in.
-	  -t, --timeout ($UNIKRAFT_TIMEOUT)
+	  -t, --timeout
 	          Timeout for the login request.
 	          [default: 5m]
-	      --controlplane ($UNIKRAFT_CONTROLPLANE)
+	      --controlplane
 	          Control plane URL to use for login.
 	          [default: https://controlplane.unikraft.cloud]
-	  -k, --allow-insecure ($UNIKRAFT_ALLOW_INSECURE)
+	  -k, --allow-insecure
 	          Allow insecure server connections when using SSL.
-	      --no-browser ($UNIKRAFT_NO_BROWSER)
+	      --no-browser
 	          Do not open the browser automatically for login.
-	      --token ($UNIKRAFT_TOKEN)
+	      --token
 	          Path to a file containing the authentication token (or '-' for stdin).
-	      --organization ($UNIKRAFT_ORGANIZATION)
+	      --organization
 	          Organization to associate the login with.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -41,7 +41,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -58,12 +58,12 @@ stdout:
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -72,7 +72,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -102,12 +102,12 @@ stdout:
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -116,7 +116,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -144,22 +144,22 @@ stdout:
 	  metros
 
 	Flags:
-	  -w, --watch ($UNIKRAFT_WATCH)
+	  -w, --watch
 	          Watch for changes and refresh output.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -168,7 +168,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -196,24 +196,24 @@ stdout:
 	  metros
 
 	Flags:
-	      --filter ($UNIKRAFT_FILTER)
+	      --filter
 	          Filter output based on a field value (e.g. --filter state==running).
-	  -w, --watch ($UNIKRAFT_WATCH)
+	  -w, --watch
 	          Watch for changes and refresh output.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -222,7 +222,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -243,12 +243,12 @@ stdout:
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -257,7 +257,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -285,12 +285,12 @@ stdout:
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -299,7 +299,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -327,22 +327,22 @@ stdout:
 	  endpoint
 
 	Flags:
-	  -w, --watch ($UNIKRAFT_WATCH)
+	  -w, --watch
 	          Watch for changes and refresh output.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -351,7 +351,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -379,24 +379,24 @@ stdout:
 	  endpoint
 
 	Flags:
-	      --filter ($UNIKRAFT_FILTER)
+	      --filter
 	          Filter output based on a field value (e.g. --filter state==running).
-	  -w, --watch ($UNIKRAFT_WATCH)
+	  -w, --watch
 	          Watch for changes and refresh output.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -405,7 +405,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version

--- a/cmd/unikraft/testdata/TestGolden/certificates/create
+++ b/cmd/unikraft/testdata/TestGolden/certificates/create
@@ -70,5 +70,5 @@ stdout:
 $ unikraft certificate delete test-$UNIQ_CERT_A test-$UNIQ_CERT_B
 
 stdout:
-	test/12345678-1234-1234-1234-123456789abc
-	test/12345678-1234-1234-1234-123456789abc
+	test/test-<CERT_A>
+	test/test-<CERT_B>

--- a/cmd/unikraft/testdata/TestGolden/certificates/help
+++ b/cmd/unikraft/testdata/TestGolden/certificates/help
@@ -183,7 +183,7 @@ $ unikraft certificate wait --help
 
 stdout:
 	Usage:
-	  unikraft certificates wait <name> ... [flags]
+	  unikraft certificates wait --until=UNTIL <name> ... [flags]
 
 	Wait for certificates to match a filter.
 
@@ -206,7 +206,7 @@ stdout:
 	  timestamps, timestamps.created-at, timestamps.not-before, timestamps.not-after
 
 	Flags:
-	      --until ($UNIKRAFT_UNTIL)
+	      --until, --filter ($UNIKRAFT_UNTIL)
 	          Filter expression to wait for (e.g. --until state==running).
 	      --interval ($UNIKRAFT_INTERVAL)
 	          Polling interval.

--- a/cmd/unikraft/testdata/TestGolden/certificates/help
+++ b/cmd/unikraft/testdata/TestGolden/certificates/help
@@ -35,12 +35,12 @@ stdout:
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -49,7 +49,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -86,22 +86,22 @@ stdout:
 	  timestamps, timestamps.created-at, timestamps.not-before, timestamps.not-after
 
 	Flags:
-	  -w, --watch ($UNIKRAFT_WATCH)
+	  -w, --watch
 	          Watch for changes and refresh output.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -110,7 +110,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -147,24 +147,24 @@ stdout:
 	  timestamps, timestamps.created-at, timestamps.not-before, timestamps.not-after
 
 	Flags:
-	      --filter ($UNIKRAFT_FILTER)
+	      --filter
 	          Filter output based on a field value (e.g. --filter state==running).
-	  -w, --watch ($UNIKRAFT_WATCH)
+	  -w, --watch
 	          Watch for changes and refresh output.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -173,7 +173,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -206,28 +206,28 @@ stdout:
 	  timestamps, timestamps.created-at, timestamps.not-before, timestamps.not-after
 
 	Flags:
-	      --until, --filter ($UNIKRAFT_UNTIL)
+	      --until, --filter
 	          Filter expression to wait for (e.g. --until state==running).
-	      --interval ($UNIKRAFT_INTERVAL)
+	      --interval
 	          Polling interval.
 	          [default: 2s]
-	      --timeout ($UNIKRAFT_TIMEOUT)
+	      --timeout
 	          Timeout before giving up.
 	          [default: 0]
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -236,7 +236,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -278,28 +278,28 @@ stdout:
 	  timestamps, timestamps.created-at, timestamps.not-before, timestamps.not-after
 
 	Flags:
-	      --set ($UNIKRAFT_SET)
+	      --set
 	          Key-value pairs for creating the certificate.
-	      --set-file ($UNIKRAFT_SET_FILE)
+	      --set-file
 	          Files containing key-value pairs for creating the certificate.
-	  -e, --visual ($UNIKRAFT_VISUAL)
+	  -e, --visual
 	          Open an editor to set fields visually.
-	      --dry-run ($UNIKRAFT_DRY_RUN)
+	      --dry-run
 	          Print patches without applying them.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -308,7 +308,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -345,20 +345,20 @@ stdout:
 	  timestamps, timestamps.created-at, timestamps.not-before, timestamps.not-after
 
 	Flags:
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -367,7 +367,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version

--- a/cmd/unikraft/testdata/TestGolden/empty
+++ b/cmd/unikraft/testdata/TestGolden/empty
@@ -48,12 +48,12 @@ stdout:
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -62,7 +62,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version

--- a/cmd/unikraft/testdata/TestGolden/empty
+++ b/cmd/unikraft/testdata/TestGolden/empty
@@ -20,15 +20,15 @@ stdout:
 	          Run an image as an instance.
 	  metros, metro
 	          Manage Unikraft Cloud metros.
-	  instances, instance
+	  instances, instance, vm, vms
 	          Manage Unikraft Cloud instances.
-	  volumes, volume
+	  volumes, volume, vol, vols
 	          Manage Unikraft Cloud volumes.
-	  services, service
+	  services, service, svc, svcs
 	          Manage Unikraft Cloud services.
-	  certificates, certificate
+	  certificates, certificate, crt, crts, cert, certs
 	          Manage Unikraft Cloud certificates.
-	  images, image
+	  images, image, img, imgs
 	          Manage Unikraft Cloud images.
 
 	Examples:

--- a/cmd/unikraft/testdata/TestGolden/help
+++ b/cmd/unikraft/testdata/TestGolden/help
@@ -48,12 +48,12 @@ stdout:
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -62,7 +62,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version

--- a/cmd/unikraft/testdata/TestGolden/help
+++ b/cmd/unikraft/testdata/TestGolden/help
@@ -20,15 +20,15 @@ stdout:
 	          Run an image as an instance.
 	  metros, metro
 	          Manage Unikraft Cloud metros.
-	  instances, instance
+	  instances, instance, vm, vms
 	          Manage Unikraft Cloud instances.
-	  volumes, volume
+	  volumes, volume, vol, vols
 	          Manage Unikraft Cloud volumes.
-	  services, service
+	  services, service, svc, svcs
 	          Manage Unikraft Cloud services.
-	  certificates, certificate
+	  certificates, certificate, crt, crts, cert, certs
 	          Manage Unikraft Cloud certificates.
-	  images, image
+	  images, image, img, imgs
 	          Manage Unikraft Cloud images.
 
 	Examples:

--- a/cmd/unikraft/testdata/TestGolden/images/help
+++ b/cmd/unikraft/testdata/TestGolden/images/help
@@ -9,8 +9,6 @@ stdout:
 	Commands:
 	  get, inspect, show
 	          Inspect a image.
-	  wait
-	          Wait for images to match a filter.
 	  list, ls
 	          List images.
 	  copy
@@ -132,61 +130,6 @@ stdout:
 	          Filter output based on a field value (e.g. --filter state==running).
 	  -w, --watch ($UNIKRAFT_WATCH)
 	          Watch for changes and refresh output.
-	  -f, --field ($UNIKRAFT_FIELD)
-	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
-	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
-
-	Global flags:
-	  -h, --help
-	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
-	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
-	          Enable or disable telemetry.
-	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
-	          Enable or disable emojis in the CLI output.
-	          [default: true]
-	      --log-level ($UNIKRAFT_LOG_LEVEL)
-	          Set the logging level.
-	          [default: info, choice: trace,debug,info,warn,error,fatal]
-	      --log-type ($UNIKRAFT_LOG_TYPE)
-	          Set the log type.
-	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
-	          Set the current profile.
-	          [default: default]
-	      --version
-	          Print version information.
-
-$ unikraft image wait --help
-
-stdout:
-	Usage:
-	  unikraft images wait --until=UNTIL <name> ... [flags]
-
-	Wait for images to match a filter.
-
-	Arguments:
-	  <name> ...
-	          Names of the images to wait for.
-
-	Fields:
-	  ref
-	  digest
-	  config, config.platform, config.entrypoint, config.cmd, config.env,
-	  config.exposed-ports, config.volumes
-
-	Flags:
-	      --until, --filter ($UNIKRAFT_UNTIL)
-	          Filter expression to wait for (e.g. --until state==running).
-	      --interval ($UNIKRAFT_INTERVAL)
-	          Polling interval.
-	          [default: 2s]
-	      --timeout ($UNIKRAFT_TIMEOUT)
-	          Timeout before giving up.
-	          [default: 0]
 	  -f, --field ($UNIKRAFT_FIELD)
 	          Specify which fields to include in the output.
 	  -o, --output ($UNIKRAFT_OUTPUT)

--- a/cmd/unikraft/testdata/TestGolden/images/help
+++ b/cmd/unikraft/testdata/TestGolden/images/help
@@ -25,12 +25,12 @@ stdout:
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -39,7 +39,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -68,22 +68,22 @@ stdout:
 	  config.exposed-ports, config.volumes
 
 	Flags:
-	  -w, --watch ($UNIKRAFT_WATCH)
+	  -w, --watch
 	          Watch for changes and refresh output.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -92,7 +92,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -126,24 +126,24 @@ stdout:
 	  dangling
 
 	Flags:
-	      --filter ($UNIKRAFT_FILTER)
+	      --filter
 	          Filter output based on a field value (e.g. --filter state==running).
-	  -w, --watch ($UNIKRAFT_WATCH)
+	  -w, --watch
 	          Watch for changes and refresh output.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -152,7 +152,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -188,12 +188,12 @@ stdout:
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -202,7 +202,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version

--- a/cmd/unikraft/testdata/TestGolden/images/help
+++ b/cmd/unikraft/testdata/TestGolden/images/help
@@ -164,7 +164,7 @@ $ unikraft image wait --help
 
 stdout:
 	Usage:
-	  unikraft images wait <name> ... [flags]
+	  unikraft images wait --until=UNTIL <name> ... [flags]
 
 	Wait for images to match a filter.
 
@@ -179,7 +179,7 @@ stdout:
 	  config.exposed-ports, config.volumes
 
 	Flags:
-	      --until ($UNIKRAFT_UNTIL)
+	      --until, --filter ($UNIKRAFT_UNTIL)
 	          Filter expression to wait for (e.g. --until state==running).
 	      --interval ($UNIKRAFT_INTERVAL)
 	          Polling interval.

--- a/cmd/unikraft/testdata/TestGolden/instances/connect
+++ b/cmd/unikraft/testdata/TestGolden/instances/connect
@@ -35,4 +35,4 @@ stdout:
 $ unikraft instance delete test-$UNIQ_INST
 
 stdout:
-	test/12345678-1234-1234-1234-123456789abc
+	test/test-<INST>

--- a/cmd/unikraft/testdata/TestGolden/instances/create
+++ b/cmd/unikraft/testdata/TestGolden/instances/create
@@ -54,7 +54,7 @@ stdout:
 $ unikraft instance delete test-$UNIQ_INST
 
 stdout:
-	test/12345678-1234-1234-1234-123456789abc
+	test/test-<INST>
 
 $ unikraft instance list
 

--- a/cmd/unikraft/testdata/TestGolden/instances/edit
+++ b/cmd/unikraft/testdata/TestGolden/instances/edit
@@ -1,12 +1,12 @@
 $ unikraft instance create --output quiet --set name=test-$UNIQ_INST --set metro=test --set image=nginx:latest --set runtime.args=before,first --set runtime.env=A=1,B=2 --set autostart=false --set resources.memory=128 --set resources.vcpus=1
 
 stdout:
-	test/12345678-1234-1234-1234-123456789abc
+	test/test-<INST>
 
 $ unikraft instance edit test-$UNIQ_INST --output quiet --set image=redis:latest --set runtime.args=after,second --set runtime.env=A=3,B=4 --set resources.memory=256
 
 stdout:
-	test/12345678-1234-1234-1234-123456789abc
+	test/test-<INST>
 
 $ unikraft instance inspect test-$UNIQ_INST
 
@@ -32,4 +32,4 @@ stdout:
 $ unikraft instance delete test-$UNIQ_INST
 
 stdout:
-	test/12345678-1234-1234-1234-123456789abc
+	test/test-<INST>

--- a/cmd/unikraft/testdata/TestGolden/instances/help
+++ b/cmd/unikraft/testdata/TestGolden/instances/help
@@ -232,7 +232,7 @@ $ unikraft instance wait --help
 
 stdout:
 	Usage:
-	  unikraft instances wait <name> ... [flags]
+	  unikraft instances wait --until=UNTIL <name> ... [flags]
 
 	Wait for instances to match a filter.
 
@@ -268,7 +268,7 @@ stdout:
 	  features
 
 	Flags:
-	      --until ($UNIKRAFT_UNTIL)
+	      --until, --filter ($UNIKRAFT_UNTIL)
 	          Filter expression to wait for (e.g. --until state==running).
 	      --interval ($UNIKRAFT_INTERVAL)
 	          Polling interval.

--- a/cmd/unikraft/testdata/TestGolden/instances/help
+++ b/cmd/unikraft/testdata/TestGolden/instances/help
@@ -58,12 +58,12 @@ stdout:
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -72,7 +72,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -122,22 +122,22 @@ stdout:
 	  features
 
 	Flags:
-	  -w, --watch ($UNIKRAFT_WATCH)
+	  -w, --watch
 	          Watch for changes and refresh output.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -146,7 +146,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -196,24 +196,24 @@ stdout:
 	  features
 
 	Flags:
-	      --filter ($UNIKRAFT_FILTER)
+	      --filter
 	          Filter output based on a field value (e.g. --filter state==running).
-	  -w, --watch ($UNIKRAFT_WATCH)
+	  -w, --watch
 	          Watch for changes and refresh output.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -222,7 +222,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -268,28 +268,28 @@ stdout:
 	  features
 
 	Flags:
-	      --until, --filter ($UNIKRAFT_UNTIL)
+	      --until, --filter
 	          Filter expression to wait for (e.g. --until state==running).
-	      --interval ($UNIKRAFT_INTERVAL)
+	      --interval
 	          Polling interval.
 	          [default: 2s]
-	      --timeout ($UNIKRAFT_TIMEOUT)
+	      --timeout
 	          Timeout before giving up.
 	          [default: 0]
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -298,7 +298,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -350,28 +350,28 @@ stdout:
 	  features
 
 	Flags:
-	      --set ($UNIKRAFT_SET)
+	      --set
 	          Key-value pairs for creating the instance.
-	      --set-file ($UNIKRAFT_SET_FILE)
+	      --set-file
 	          Files containing key-value pairs for creating the instance.
-	  -e, --visual ($UNIKRAFT_VISUAL)
+	  -e, --visual
 	          Open an editor to set fields visually.
-	      --dry-run ($UNIKRAFT_DRY_RUN)
+	      --dry-run
 	          Print patches without applying them.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -380,7 +380,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -430,36 +430,36 @@ stdout:
 	  features
 
 	Flags:
-	      --set ($UNIKRAFT_SET)
+	      --set
 	          Key-value pairs to update the instance with.
-	      --add ($UNIKRAFT_ADD)
+	      --add
 	          Key-value pairs to add to the instance.
-	      --del ($UNIKRAFT_DEL)
+	      --del
 	          Keys to delete from the instance.
-	      --set-file ($UNIKRAFT_SET_FILE)
+	      --set-file
 	          Files containing key-value pairs to update the instance with.
-	      --add-file ($UNIKRAFT_ADD_FILE)
+	      --add-file
 	          Files containing key-value pairs to add to the instance.
-	      --del-file ($UNIKRAFT_DEL_FILE)
+	      --del-file
 	          Files containing keys to delete from the instance.
-	  -e, --visual ($UNIKRAFT_VISUAL)
+	  -e, --visual
 	          Open an editor to modify fields visually.
-	      --dry-run ($UNIKRAFT_DRY_RUN)
+	      --dry-run
 	          Print patches without applying them.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -468,7 +468,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -518,20 +518,20 @@ stdout:
 	  features
 
 	Flags:
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -540,7 +540,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -569,20 +569,20 @@ stdout:
 	  unikraft instance logs my-instance --follow
 
 	Flags:
-	      --tail ($UNIKRAFT_TAIL)
+	      --tail
 	          Number of lines to show from the end of the logs.
-	  -f, --follow ($UNIKRAFT_FOLLOW)
+	  -f, --follow
 	          Follow log output.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -591,7 +591,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -614,20 +614,20 @@ stdout:
 	  unikraft instance start demo-instance
 
 	Flags:
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -636,7 +636,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -665,25 +665,25 @@ stdout:
 	  unikraft instance stop demo-instance --force
 
 	Flags:
-	      --force ($UNIKRAFT_FORCE)
+	      --force
 	          Force stop the instance immediately.
-	      --drain-timeout ($UNIKRAFT_DRAIN_TIMEOUT)
+	      --drain-timeout
 	          Timeout in milliseconds for draining connections before stopping.
 	          [default: -1]
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -692,7 +692,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -718,25 +718,25 @@ stdout:
 	  unikraft instance restart demo-instance --force
 
 	Flags:
-	      --force ($UNIKRAFT_FORCE)
+	      --force
 	          Force stop the instance immediately.
-	      --drain-timeout ($UNIKRAFT_DRAIN_TIMEOUT)
+	      --drain-timeout
 	          Timeout in milliseconds for draining connections before stopping.
 	          [default: -1]
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -745,7 +745,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version

--- a/cmd/unikraft/testdata/TestGolden/instances/start-stop
+++ b/cmd/unikraft/testdata/TestGolden/instances/start-stop
@@ -108,4 +108,4 @@ stdout:
 $ unikraft instance delete test-$UNIQ_INST
 
 stdout:
-	test/12345678-1234-1234-1234-123456789abc
+	test/test-<INST>

--- a/cmd/unikraft/testdata/TestGolden/invalid/arg
+++ b/cmd/unikraft/testdata/TestGolden/invalid/arg
@@ -1,0 +1,11 @@
+$ unikraft invalid
+
+stderr:
+	│  
+	│ error:
+	│   unexpected argument invalid
+	│   unikraft.com/cli/internal/cmd.NewRootCmd:148: parsing arguments
+	│  
+	exit status 1
+
+exit code: 1

--- a/cmd/unikraft/testdata/TestGolden/invalid/help
+++ b/cmd/unikraft/testdata/TestGolden/invalid/help
@@ -1,0 +1,161 @@
+$ unikraft --help --bad-flag
+
+stdout:
+	Usage:
+	  unikraft <command> [flags]
+
+	Version:
+	  dev (GOOS/GOARCH)
+
+	Commands:
+	  completion
+	          Outputs shell code for initialising tab completions.
+	  login
+	          Login to Unikraft Cloud.
+	  logout
+	          Logout from Unikraft Cloud.
+	  profile, profiles
+	          Manage Unikraft Cloud profiles.
+	  run
+	          Run an image as an instance.
+	  metros, metro
+	          Manage Unikraft Cloud metros.
+	  instances, instance, vm, vms
+	          Manage Unikraft Cloud instances.
+	  volumes, volume, vol, vols
+	          Manage Unikraft Cloud volumes.
+	  services, service, svc, svcs
+	          Manage Unikraft Cloud services.
+	  certificates, certificate, crt, crts, cert, certs
+	          Manage Unikraft Cloud certificates.
+	  images, image, img, imgs
+	          Manage Unikraft Cloud images.
+
+	Examples:
+	  # Login to Unikraft Cloud
+	  unikraft login
+
+	  # List instances across metros
+	  unikraft instances list
+
+	  # Deploy a new instance from an image
+	  unikraft run --metro=sfo --autostart -p 443:8080/http+tls --scale-to-zero
+	  policy=on nginx:latest
+
+	  # Switch to a different profile
+	  unikraft profile use my-other-profile
+
+	  -h, --help
+	          Show context-sensitive help.
+	      --config ($UNIKRAFT_CONFIG)
+	          Set the configuration file.
+	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	          Enable or disable telemetry.
+	          [default: true]
+	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	          Enable or disable emojis in the CLI output.
+	          [default: true]
+	      --log-level ($UNIKRAFT_LOG_LEVEL)
+	          Set the logging level.
+	          [default: info, choice: trace,debug,info,warn,error,fatal]
+	      --log-type ($UNIKRAFT_LOG_TYPE)
+	          Set the log type.
+	          [default: text, choice: text,json]
+	      --profile ($UNIKRAFT_PROFILE)
+	          Set the current profile.
+	          [default: default]
+	      --version
+	          Print version information.
+
+	Run "unikraft <command> --help" for more information on a command.
+
+stderr:
+	│  
+	│ error:
+	│   unknown flag --bad-flag
+	│   unikraft.com/cli/internal/cmd.NewRootCmd:148: parsing arguments
+	│  
+	exit status 1
+
+exit code: 1
+
+$ unikraft --help bad-arg
+
+stdout:
+	Usage:
+	  unikraft <command> [flags]
+
+	Version:
+	  dev (GOOS/GOARCH)
+
+	Commands:
+	  completion
+	          Outputs shell code for initialising tab completions.
+	  login
+	          Login to Unikraft Cloud.
+	  logout
+	          Logout from Unikraft Cloud.
+	  profile, profiles
+	          Manage Unikraft Cloud profiles.
+	  run
+	          Run an image as an instance.
+	  metros, metro
+	          Manage Unikraft Cloud metros.
+	  instances, instance, vm, vms
+	          Manage Unikraft Cloud instances.
+	  volumes, volume, vol, vols
+	          Manage Unikraft Cloud volumes.
+	  services, service, svc, svcs
+	          Manage Unikraft Cloud services.
+	  certificates, certificate, crt, crts, cert, certs
+	          Manage Unikraft Cloud certificates.
+	  images, image, img, imgs
+	          Manage Unikraft Cloud images.
+
+	Examples:
+	  # Login to Unikraft Cloud
+	  unikraft login
+
+	  # List instances across metros
+	  unikraft instances list
+
+	  # Deploy a new instance from an image
+	  unikraft run --metro=sfo --autostart -p 443:8080/http+tls --scale-to-zero
+	  policy=on nginx:latest
+
+	  # Switch to a different profile
+	  unikraft profile use my-other-profile
+
+	  -h, --help
+	          Show context-sensitive help.
+	      --config ($UNIKRAFT_CONFIG)
+	          Set the configuration file.
+	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	          Enable or disable telemetry.
+	          [default: true]
+	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	          Enable or disable emojis in the CLI output.
+	          [default: true]
+	      --log-level ($UNIKRAFT_LOG_LEVEL)
+	          Set the logging level.
+	          [default: info, choice: trace,debug,info,warn,error,fatal]
+	      --log-type ($UNIKRAFT_LOG_TYPE)
+	          Set the log type.
+	          [default: text, choice: text,json]
+	      --profile ($UNIKRAFT_PROFILE)
+	          Set the current profile.
+	          [default: default]
+	      --version
+	          Print version information.
+
+	Run "unikraft <command> --help" for more information on a command.
+
+stderr:
+	│  
+	│ error:
+	│   unexpected argument bad-arg
+	│   unikraft.com/cli/internal/cmd.NewRootCmd:148: parsing arguments
+	│  
+	exit status 1
+
+exit code: 1

--- a/cmd/unikraft/testdata/TestGolden/invalid/help
+++ b/cmd/unikraft/testdata/TestGolden/invalid/help
@@ -47,12 +47,12 @@ stdout:
 
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -61,7 +61,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -128,12 +128,12 @@ stdout:
 
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -142,7 +142,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version

--- a/cmd/unikraft/testdata/TestGolden/invalid/logs
+++ b/cmd/unikraft/testdata/TestGolden/invalid/logs
@@ -1,0 +1,15 @@
+$ unikraft --log-type=json invalid
+
+stderr:
+	{"level":"error","time":"YYYY-MM-DDTHH:MM:SSZ","message":"unexpected argument invalid"}
+	{"level":"error","time":"YYYY-MM-DDTHH:MM:SSZ","message":"unikraft.com/cli/internal/cmd.NewRootCmd:148: parsing arguments"}
+	exit status 1
+
+exit code: 1
+
+$ unikraft --log-level=fatal invalid
+
+stderr:
+	exit status 1
+
+exit code: 1

--- a/cmd/unikraft/testdata/TestGolden/services/create
+++ b/cmd/unikraft/testdata/TestGolden/services/create
@@ -86,5 +86,5 @@ stdout:
 $ unikraft service delete test-$UNIQ_SVC_A test-$UNIQ_SVC_B
 
 stdout:
-	test/12345678-1234-1234-1234-123456789abc
-	test/12345678-1234-1234-1234-123456789abc
+	test/test-<SVC_A>
+	test/test-<SVC_B>

--- a/cmd/unikraft/testdata/TestGolden/services/edit
+++ b/cmd/unikraft/testdata/TestGolden/services/edit
@@ -1,12 +1,12 @@
 $ unikraft service create --output quiet --set name=test-$UNIQ_SVC --set metro=test --set domains=fqdn=$UNIQ_DOMAIN.unikraft.example --set services=443:8080/tls+http
 
 stdout:
-	test/12345678-1234-1234-1234-123456789abc
+	test/test-<SVC>
 
 $ unikraft service edit test-$UNIQ_SVC --output quiet --set limits.soft=2 --set limits.hard=10 --set domains=fqdn=$UNIQ_DOMAIN_EDIT.unikraft.example --set services=1000:2000/tls
 
 stdout:
-	test/12345678-1234-1234-1234-123456789abc
+	test/test-<SVC>
 
 $ unikraft service inspect test-$UNIQ_SVC
 
@@ -29,4 +29,4 @@ stdout:
 $ unikraft service delete test-$UNIQ_SVC
 
 stdout:
-	test/12345678-1234-1234-1234-123456789abc
+	test/test-<SVC>

--- a/cmd/unikraft/testdata/TestGolden/services/help
+++ b/cmd/unikraft/testdata/TestGolden/services/help
@@ -182,7 +182,7 @@ $ unikraft service wait --help
 
 stdout:
 	Usage:
-	  unikraft services wait <name> ... [flags]
+	  unikraft services wait --until=UNTIL <name> ... [flags]
 
 	Wait for services to match a filter.
 
@@ -204,7 +204,7 @@ stdout:
 	  services, services.*
 
 	Flags:
-	      --until ($UNIKRAFT_UNTIL)
+	      --until, --filter ($UNIKRAFT_UNTIL)
 	          Filter expression to wait for (e.g. --until state==running).
 	      --interval ($UNIKRAFT_INTERVAL)
 	          Polling interval.

--- a/cmd/unikraft/testdata/TestGolden/services/help
+++ b/cmd/unikraft/testdata/TestGolden/services/help
@@ -36,12 +36,12 @@ stdout:
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -50,7 +50,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -86,22 +86,22 @@ stdout:
 	  services, services.*
 
 	Flags:
-	  -w, --watch ($UNIKRAFT_WATCH)
+	  -w, --watch
 	          Watch for changes and refresh output.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -110,7 +110,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -146,24 +146,24 @@ stdout:
 	  services, services.*
 
 	Flags:
-	      --filter ($UNIKRAFT_FILTER)
+	      --filter
 	          Filter output based on a field value (e.g. --filter state==running).
-	  -w, --watch ($UNIKRAFT_WATCH)
+	  -w, --watch
 	          Watch for changes and refresh output.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -172,7 +172,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -204,28 +204,28 @@ stdout:
 	  services, services.*
 
 	Flags:
-	      --until, --filter ($UNIKRAFT_UNTIL)
+	      --until, --filter
 	          Filter expression to wait for (e.g. --until state==running).
-	      --interval ($UNIKRAFT_INTERVAL)
+	      --interval
 	          Polling interval.
 	          [default: 2s]
-	      --timeout ($UNIKRAFT_TIMEOUT)
+	      --timeout
 	          Timeout before giving up.
 	          [default: 0]
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -234,7 +234,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -270,28 +270,28 @@ stdout:
 	  services, services.*
 
 	Flags:
-	      --set ($UNIKRAFT_SET)
+	      --set
 	          Key-value pairs for creating the service.
-	      --set-file ($UNIKRAFT_SET_FILE)
+	      --set-file
 	          Files containing key-value pairs for creating the service.
-	  -e, --visual ($UNIKRAFT_VISUAL)
+	  -e, --visual
 	          Open an editor to set fields visually.
-	      --dry-run ($UNIKRAFT_DRY_RUN)
+	      --dry-run
 	          Print patches without applying them.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -300,7 +300,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -336,36 +336,36 @@ stdout:
 	  services, services.*
 
 	Flags:
-	      --set ($UNIKRAFT_SET)
+	      --set
 	          Key-value pairs to update the service with.
-	      --add ($UNIKRAFT_ADD)
+	      --add
 	          Key-value pairs to add to the service.
-	      --del ($UNIKRAFT_DEL)
+	      --del
 	          Keys to delete from the service.
-	      --set-file ($UNIKRAFT_SET_FILE)
+	      --set-file
 	          Files containing key-value pairs to update the service with.
-	      --add-file ($UNIKRAFT_ADD_FILE)
+	      --add-file
 	          Files containing key-value pairs to add to the service.
-	      --del-file ($UNIKRAFT_DEL_FILE)
+	      --del-file
 	          Files containing keys to delete from the service.
-	  -e, --visual ($UNIKRAFT_VISUAL)
+	  -e, --visual
 	          Open an editor to modify fields visually.
-	      --dry-run ($UNIKRAFT_DRY_RUN)
+	      --dry-run
 	          Print patches without applying them.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -374,7 +374,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -410,20 +410,20 @@ stdout:
 	  services, services.*
 
 	Flags:
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -432,7 +432,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version

--- a/cmd/unikraft/testdata/TestGolden/volumes/create
+++ b/cmd/unikraft/testdata/TestGolden/volumes/create
@@ -32,4 +32,4 @@ stdout:
 $ unikraft volume delete test-$UNIQ_VOLUME
 
 stdout:
-	test/12345678-1234-1234-1234-123456789abc
+	test/test-<VOLUME>

--- a/cmd/unikraft/testdata/TestGolden/volumes/edit
+++ b/cmd/unikraft/testdata/TestGolden/volumes/edit
@@ -1,12 +1,12 @@
 $ unikraft volume create --output quiet --set name=test-$UNIQ_VOLUME --set size=10 --set metro=test
 
 stdout:
-	test/12345678-1234-1234-1234-123456789abc
+	test/test-<VOLUME>
 
 $ unikraft volume edit test-$UNIQ_VOLUME --output quiet --set size=20
 
 stdout:
-	test/12345678-1234-1234-1234-123456789abc
+	test/test-<VOLUME>
 
 $ unikraft volume inspect test-$UNIQ_VOLUME
 
@@ -21,4 +21,4 @@ stdout:
 $ unikraft volume delete test-$UNIQ_VOLUME
 
 stdout:
-	test/12345678-1234-1234-1234-123456789abc
+	test/test-<VOLUME>

--- a/cmd/unikraft/testdata/TestGolden/volumes/help
+++ b/cmd/unikraft/testdata/TestGolden/volumes/help
@@ -182,7 +182,7 @@ $ unikraft volume wait --help
 
 stdout:
 	Usage:
-	  unikraft volumes wait <name> ... [flags]
+	  unikraft volumes wait --until=UNTIL <name> ... [flags]
 
 	Wait for volumes to match a filter.
 
@@ -204,7 +204,7 @@ stdout:
 	  by.*.read-only
 
 	Flags:
-	      --until ($UNIKRAFT_UNTIL)
+	      --until, --filter ($UNIKRAFT_UNTIL)
 	          Filter expression to wait for (e.g. --until state==running).
 	      --interval ($UNIKRAFT_INTERVAL)
 	          Polling interval.

--- a/cmd/unikraft/testdata/TestGolden/volumes/help
+++ b/cmd/unikraft/testdata/TestGolden/volumes/help
@@ -36,12 +36,12 @@ stdout:
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -50,7 +50,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -86,22 +86,22 @@ stdout:
 	  by.*.read-only
 
 	Flags:
-	  -w, --watch ($UNIKRAFT_WATCH)
+	  -w, --watch
 	          Watch for changes and refresh output.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -110,7 +110,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -146,24 +146,24 @@ stdout:
 	  by.*.read-only
 
 	Flags:
-	      --filter ($UNIKRAFT_FILTER)
+	      --filter
 	          Filter output based on a field value (e.g. --filter state==running).
-	  -w, --watch ($UNIKRAFT_WATCH)
+	  -w, --watch
 	          Watch for changes and refresh output.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -172,7 +172,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -204,28 +204,28 @@ stdout:
 	  by.*.read-only
 
 	Flags:
-	      --until, --filter ($UNIKRAFT_UNTIL)
+	      --until, --filter
 	          Filter expression to wait for (e.g. --until state==running).
-	      --interval ($UNIKRAFT_INTERVAL)
+	      --interval
 	          Polling interval.
 	          [default: 2s]
-	      --timeout ($UNIKRAFT_TIMEOUT)
+	      --timeout
 	          Timeout before giving up.
 	          [default: 0]
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -234,7 +234,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -269,28 +269,28 @@ stdout:
 	  by.*.read-only
 
 	Flags:
-	      --set ($UNIKRAFT_SET)
+	      --set
 	          Key-value pairs for creating the volume.
-	      --set-file ($UNIKRAFT_SET_FILE)
+	      --set-file
 	          Files containing key-value pairs for creating the volume.
-	  -e, --visual ($UNIKRAFT_VISUAL)
+	  -e, --visual
 	          Open an editor to set fields visually.
-	      --dry-run ($UNIKRAFT_DRY_RUN)
+	      --dry-run
 	          Print patches without applying them.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -299,7 +299,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -335,36 +335,36 @@ stdout:
 	  by.*.read-only
 
 	Flags:
-	      --set ($UNIKRAFT_SET)
+	      --set
 	          Key-value pairs to update the volume with.
-	      --add ($UNIKRAFT_ADD)
+	      --add
 	          Key-value pairs to add to the volume.
-	      --del ($UNIKRAFT_DEL)
+	      --del
 	          Keys to delete from the volume.
-	      --set-file ($UNIKRAFT_SET_FILE)
+	      --set-file
 	          Files containing key-value pairs to update the volume with.
-	      --add-file ($UNIKRAFT_ADD_FILE)
+	      --add-file
 	          Files containing key-value pairs to add to the volume.
-	      --del-file ($UNIKRAFT_DEL_FILE)
+	      --del-file
 	          Files containing keys to delete from the volume.
-	  -e, --visual ($UNIKRAFT_VISUAL)
+	  -e, --visual
 	          Open an editor to modify fields visually.
-	      --dry-run ($UNIKRAFT_DRY_RUN)
+	      --dry-run
 	          Print patches without applying them.
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -373,7 +373,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version
@@ -409,20 +409,20 @@ stdout:
 	  by.*.read-only
 
 	Flags:
-	  -f, --field ($UNIKRAFT_FIELD)
+	  -f, --field
 	          Specify which fields to include in the output.
-	  -o, --output ($UNIKRAFT_OUTPUT)
+	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
 
 	Global flags:
 	  -h, --help
 	          Show context-sensitive help.
-	      --config ($UNIKRAFT_CONFIG)
+	      --config
 	          Set the configuration file.
-	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	      --[no-]telemetry
 	          Enable or disable telemetry.
 	          [default: true]
-	      --[no-]emojis ($UNIKRAFT_EMOJIS)
+	      --[no-]emojis
 	          Enable or disable emojis in the CLI output.
 	          [default: true]
 	      --log-level ($UNIKRAFT_LOG_LEVEL)
@@ -431,7 +431,7 @@ stdout:
 	      --log-type ($UNIKRAFT_LOG_TYPE)
 	          Set the log type.
 	          [default: text, choice: text,json]
-	      --profile ($UNIKRAFT_PROFILE)
+	      --profile
 	          Set the current profile.
 	          [default: default]
 	      --version

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	unikraft.com/x/fingerprint v0.0.0-20260126094137-ab6e717e5679
 	unikraft.com/x/guesstermwidth v0.0.0-20260116231133-1da0081544af
 	unikraft.com/x/image-spec v0.0.0-20260126171022-af62c17fcdf7
-	unikraft.com/x/kingkong v0.0.0-20260126171022-af62c17fcdf7
+	unikraft.com/x/kingkong v0.0.0-20260203003720-5a31ab15ba4e
 	unikraft.com/x/log v0.0.0-20260126171022-af62c17fcdf7
 	unikraft.com/x/ptr v0.0.0-20260116231133-1da0081544af
 )

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require (
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/Masterminds/sprig/v3 v3.3.0
-	github.com/alecthomas/kong v1.13.0
+	github.com/alecthomas/kong v1.13.1-0.20260203032815-becd4f3a2c57
 	github.com/alecthomas/kong-yaml v0.2.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/Microsoft/hcsshim v0.14.0-rc.1 h1:qAPXKwGOkVn8LlqgBN8GS0bxZ83hOJpcjxz
 github.com/Microsoft/hcsshim v0.14.0-rc.1/go.mod h1:hTKFGbnDtQb1wHiOWv4v0eN+7boSWAHyK/tNAaYZL0c=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
-github.com/alecthomas/kong v1.13.0 h1:5e/7XC3ugvhP1DQBmTS+WuHtCbcv44hsohMgcvVxSrA=
-github.com/alecthomas/kong v1.13.0/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
+github.com/alecthomas/kong v1.13.1-0.20260203032815-becd4f3a2c57 h1:jcHvDxl46EtaGHxfBWPpBsMmmfW5vMFhpYSeCsvwlx4=
+github.com/alecthomas/kong v1.13.1-0.20260203032815-becd4f3a2c57/go.mod h1:wrlbXem1CWqUV5Vbmss5ISYhsVPkBb1Yo7YKJghju2I=
 github.com/alecthomas/kong-yaml v0.2.0 h1:iiVVqVttmOsHKawlaW/TljPsjaEv1O4ODx6dloSA58Y=
 github.com/alecthomas/kong-yaml v0.2.0/go.mod h1:vMvOIy+wpB49MCZ0TA3KMts38Mu9YfRP03Q1StN69/g=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=

--- a/go.sum
+++ b/go.sum
@@ -372,8 +372,8 @@ unikraft.com/x/guesstermwidth v0.0.0-20260116231133-1da0081544af h1:cRrCU4yhPnWe
 unikraft.com/x/guesstermwidth v0.0.0-20260116231133-1da0081544af/go.mod h1:q3EH6bLqLAJ1PqZgHlCJPpvvP6scnjJJspBMyGQtMt4=
 unikraft.com/x/image-spec v0.0.0-20260126171022-af62c17fcdf7 h1:J1Z1wZoh6yBAG9Y2UQa0q2XJAf1FHT+/pr9ly0kw/DI=
 unikraft.com/x/image-spec v0.0.0-20260126171022-af62c17fcdf7/go.mod h1:l0+tgd72OA6DzrX+V7z9XYjd80PrMJMCPnXNTODBjrc=
-unikraft.com/x/kingkong v0.0.0-20260126171022-af62c17fcdf7 h1:Ms4XMa6KNCE5Qi2RkHN8Y71tbianDEF6EooPCPsG13E=
-unikraft.com/x/kingkong v0.0.0-20260126171022-af62c17fcdf7/go.mod h1:qADEVxmns2gEIJwMHGj/bV2/beKl5L1mlYOGv48W7ig=
+unikraft.com/x/kingkong v0.0.0-20260203003720-5a31ab15ba4e h1:3Rhyq83l8uAuwDOfyt//a3cdU5XlznaphKu2UDKgDBY=
+unikraft.com/x/kingkong v0.0.0-20260203003720-5a31ab15ba4e/go.mod h1:qADEVxmns2gEIJwMHGj/bV2/beKl5L1mlYOGv48W7ig=
 unikraft.com/x/log v0.0.0-20260126171022-af62c17fcdf7 h1:kFOE7rmK33PiJ2GbWFd3v0WrE8DeAaQsPjrUQ+15CIU=
 unikraft.com/x/log v0.0.0-20260126171022-af62c17fcdf7/go.mod h1:f/+5628rnWTnRaRrCDD9mOMf7OV5QmkGIgARlTu4XGE=
 unikraft.com/x/ptr v0.0.0-20260116231133-1da0081544af h1:qEEtHdfIKn1p4OGrekAxbPe+Kbd1Gi1g5S3iJgTRcWM=

--- a/internal/cmd/certificates.go
+++ b/internal/cmd/certificates.go
@@ -27,6 +27,7 @@ import (
 type CertificatesCmd struct {
 	cmd.ResourceCmd[Certificate]
 	cmd.GettableResourceCmd[Certificate]  `set:"name=certificate" set:"names=certificates"`
+	cmd.WaitableResourceCmd[Certificate]  `set:"name=certificate" set:"names=certificates"`
 	cmd.ListableResourceCmd[Certificate]  `set:"name=certificate" set:"names=certificates"`
 	cmd.DeletableResourceCmd[Certificate] `set:"name=certificate" set:"names=certificates"`
 	cmd.CreatableResourceCmd[Certificate] `set:"name=certificate" set:"names=certificates"`

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -36,6 +36,7 @@ import (
 type InstancesCmd struct {
 	cmd.ResourceCmd[Instance]
 	cmd.GettableResourceCmd[Instance]  `set:"name=instance" set:"names=instances"`
+	cmd.WaitableResourceCmd[Instance]  `set:"name=instance" set:"names=instances"`
 	cmd.ListableResourceCmd[Instance]  `set:"name=instance" set:"names=instances"`
 	cmd.DeletableResourceCmd[Instance] `set:"name=instance" set:"names=instances"`
 	cmd.EditableResourceCmd[Instance]  `set:"name=instance" set:"names=instances"`

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -48,11 +48,11 @@ type UnikraftCLI struct {
 	Run     RunCmd          `cmd:"" help:"Run an image as an instance."`
 
 	Metros       MetrosCmd       `cmd:"" help:"Manage Unikraft Cloud metros." aliases:"metro,metros"`
-	Instances    InstancesCmd    `cmd:"" help:"Manage Unikraft Cloud instances." aliases:"instance,instances"`
-	Volumes      VolumesCmd      `cmd:"" help:"Manage Unikraft Cloud volumes." aliases:"volume,volumes"`
-	Services     ServicesCmd     `cmd:"" help:"Manage Unikraft Cloud services." aliases:"service,services"`
-	Certificates CertificatesCmd `cmd:"" help:"Manage Unikraft Cloud certificates." aliases:"certificate,certificates"`
-	Images       ImagesCmd       `cmd:"" help:"Manage Unikraft Cloud images." aliases:"image,images"`
+	Instances    InstancesCmd    `cmd:"" help:"Manage Unikraft Cloud instances." aliases:"instance,instances,vm,vms"`
+	Volumes      VolumesCmd      `cmd:"" help:"Manage Unikraft Cloud volumes." aliases:"volume,volumes,vol,vols"`
+	Services     ServicesCmd     `cmd:"" help:"Manage Unikraft Cloud services." aliases:"service,services,svc,svcs"`
+	Certificates CertificatesCmd `cmd:"" help:"Manage Unikraft Cloud certificates." aliases:"certificate,certificates,crt,crts,cert,certs"`
+	Images       ImagesCmd       `cmd:"" help:"Manage Unikraft Cloud images." aliases:"image,images,img,imgs"`
 }
 
 func (cli UnikraftCLI) Examples() []kingkong.Example {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -38,7 +38,7 @@ import (
 type UnikraftCLI struct {
 	config.Config
 
-	Version version.VersionFlag `group:"flag-global" name:"version" help:"Print version information." env:"-"`
+	Version version.VersionFlag `group:"flag-global" name:"version" help:"Print version information."`
 
 	Completion kongcompletion.Completion `cmd:"" completion-shell-default:"false" help:"Outputs shell code for initialising tab completions."`
 
@@ -237,7 +237,6 @@ func NewParser(cli *UnikraftCLI) (*kong.Kong, error) {
 
 	parser, err := kong.New(cli,
 		kong.Name("unikraft"),
-		kong.DefaultEnvars("UNIKRAFT"),
 		kong.UsageOnError(),
 		kong.ConfigureHelp(helpOptions),
 		kong.Configuration(kongyaml.Loader, configFile),

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -87,9 +87,10 @@ func (cli UnikraftCLI) Examples() []kingkong.Example {
 func NewRootCmd(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io.Writer) (*kong.Context, *UnikraftCLI, func() error, error) {
 	cli := UnikraftCLI{
 		Config: config.Config{
-			Stdin:  stdin,
-			Stdout: stdout,
-			Stderr: stderr,
+			Context: ctx,
+			Stdin:   stdin,
+			Stdout:  stdout,
+			Stderr:  stderr,
 		},
 	}
 
@@ -114,47 +115,40 @@ func NewRootCmd(ctx context.Context, args []string, stdin io.Reader, stdout, std
 	kctx, err := parser.Parse(args)
 
 	var parseErr *kong.ParseError
+	printHelp := false
 	if errors.As(err, &parseErr) {
+		// we couldn't parse everything, but still try and manually load these
+		// flags, since they're used for help + logging
+		for _, flag := range parseErr.Context.Flags() {
+			switch flag.Name {
+			case "help":
+				printHelp = flag.Set
+			case "log-type":
+				cli.LogType = parseErr.Context.FlagValue(flag).(log.Type)
+			case "log-level":
+				cli.LogLevel = parseErr.Context.FlagValue(flag).(log.Level)
+			}
+		}
+
 		// HACK: kong provides UsageOnError, but this shows help for *all* parse
 		// errors - we only want to show it only for parent commands.
 		// See https://github.com/alecthomas/kong/issues/33
 		if strings.HasPrefix(parseErr.Error(), "expected one of") {
-			_ = parseErr.Context.PrintUsage(false)
-			fmt.Fprintln(os.Stdout)
+			printHelp = true
 		}
 	}
 
 	if err != nil {
-		return nil, nil, nil, jujuerrors.Annotate(err, "parsing arguments")
+		cli.Context = ctxWithLogger(cli.Context, stderr, cli.LogType, cli.LogLevel)
+		cli.Context = config.WithConfig(cli.Context, &cli.Config)
+		if printHelp {
+			_ = parseErr.Context.PrintUsage(false)
+			fmt.Fprintln(os.Stdout)
+		}
+		return nil, &cli, nil, jujuerrors.Annotate(err, "parsing arguments")
 	}
 
-	cli.Context = ctx
-
-	var level log.Level
-	switch cli.LogLevel.String() {
-	case "trace":
-		level = log.TraceLevel
-	case "debug":
-		level = log.DebugLevel
-	case "info":
-		level = log.InfoLevel
-	case "warn":
-		level = log.WarnLevel
-	case "error":
-		level = log.ErrorLevel
-	case "fatal":
-		level = log.FatalLevel
-	case "panic":
-		level = log.PanicLevel
-	default:
-		level = log.InfoLevel
-	}
-	cli.Context = log.WithLogger(cli.Context, logfmt.New(stderr, cli.LogType, level))
-	cli.Context = ctrdlog.WithLogger(cli.Context, logrus.NewEntry(log.ToLogrus(
-		log.G(cli.Context),
-		log.WithLogrusLevelCap(logrus.DebugLevel),
-	)))
-
+	cli.Context = ctxWithLogger(cli.Context, stderr, cli.LogType, cli.LogLevel)
 	cli.Context = config.WithConfig(cli.Context, &cli.Config)
 	kctx.BindTo(cli.Context, (*context.Context)(nil))
 
@@ -189,6 +183,33 @@ func NewRootCmd(ctx context.Context, args []string, stdin io.Reader, stdout, std
 		Msg("unikraft CLI")
 
 	return kctx, &cli, cleanup, nil
+}
+
+func ctxWithLogger(ctx context.Context, out io.Writer, type_ log.Type, level log.Level) context.Context {
+	switch level.String() {
+	case "trace":
+		level = log.TraceLevel
+	case "debug":
+		level = log.DebugLevel
+	case "info":
+		level = log.InfoLevel
+	case "warn":
+		level = log.WarnLevel
+	case "error":
+		level = log.ErrorLevel
+	case "fatal":
+		level = log.FatalLevel
+	case "panic":
+		level = log.PanicLevel
+	default:
+		level = log.InfoLevel
+	}
+	ctx = log.WithLogger(ctx, logfmt.New(out, type_, level))
+	ctx = ctrdlog.WithLogger(ctx, logrus.NewEntry(log.ToLogrus(
+		log.G(ctx),
+		log.WithLogrusLevelCap(logrus.DebugLevel),
+	)))
+	return ctx
 }
 
 func NewParser(cli *UnikraftCLI) (*kong.Kong, error) {

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -51,7 +51,9 @@ type RunCmd struct {
 
 	DryRun bool `help:"Show the create preview without executing."`
 
-	Follow bool `short:"f" help:"Follow instance logs after creation."`
+	Follow bool `help:"Follow instance logs after creation."`
+
+	cmd.FormatOpts
 }
 
 func (RunCmd) Examples() []kingkong.Example {
@@ -71,7 +73,7 @@ func (RunCmd) Examples() []kingkong.Example {
 		{
 			Description: "Deploy and tail logs from a new instance",
 			Commands: []string{
-				"unikraft run --metro=fra -f nginx:latest",
+				"unikraft run --metro=fra --follow nginx:latest",
 			},
 		},
 		{
@@ -171,8 +173,11 @@ func (c *RunCmd) Run(ctx context.Context, cfg *config.Config, sandbox *resource.
 	if len(created) == 0 {
 		return fmt.Errorf("no instances created")
 	}
-	for _, res := range created {
-		fmt.Fprintln(cfg.Stdout, res.Key())
+	err = c.Output.
+		WithDefault(cmd.PrinterTypeKeyValue).
+		Print(cfg.Stdout, c.Field, Instance{}, created...)
+	if err != nil {
+		return err
 	}
 
 	if c.Follow {

--- a/internal/cmd/services.go
+++ b/internal/cmd/services.go
@@ -28,6 +28,7 @@ import (
 type ServicesCmd struct {
 	cmd.ResourceCmd[ServiceGroup]
 	cmd.GettableResourceCmd[ServiceGroup]  `set:"name=service" set:"names=services"`
+	cmd.WaitableResourceCmd[ServiceGroup]  `set:"name=service" set:"names=services"`
 	cmd.ListableResourceCmd[ServiceGroup]  `set:"name=service" set:"names=services"`
 	cmd.DeletableResourceCmd[ServiceGroup] `set:"name=service" set:"names=services"`
 	cmd.EditableResourceCmd[ServiceGroup]  `set:"name=service" set:"names=services"`

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -27,6 +27,7 @@ import (
 type VolumesCmd struct {
 	cmd.ResourceCmd[Volume]
 	cmd.GettableResourceCmd[Volume]  `set:"name=volume" set:"names=volumes"`
+	cmd.WaitableResourceCmd[Volume]  `set:"name=volume" set:"names=volumes"`
 	cmd.ListableResourceCmd[Volume]  `set:"name=volume" set:"names=volumes"`
 	cmd.DeletableResourceCmd[Volume] `set:"name=volume" set:"names=volumes"`
 	cmd.EditableResourceCmd[Volume]  `set:"name=volume" set:"names=volumes"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,8 +35,8 @@ type Config struct {
 	Emojis    bool   `group:"flag-global" name:"emojis" help:"Enable or disable emojis in the CLI output." default:"true" negatable:"" yaml:"emojis" json:"emojis"`
 
 	// Logging configuration.
-	LogLevel log.Level `group:"flag-global" name:"log-level" help:"Set the logging level." enum:"trace,debug,info,warn,error,fatal" placeholder:"level" default:"info" yaml:"-" json:"-"`
-	LogType  log.Type  `group:"flag-global" name:"log-type" help:"Set the log type." enum:"text,json" placeholder:"type" default:"text" yaml:"-" json:"-"`
+	LogLevel log.Level `group:"flag-global" name:"log-level" env:"UNIKRAFT_LOG_LEVEL" help:"Set the logging level." enum:"trace,debug,info,warn,error,fatal" placeholder:"level" default:"info" yaml:"-" json:"-"`
+	LogType  log.Type  `group:"flag-global" name:"log-type" env:"UNIKRAFT_LOG_TYPE" help:"Set the log type." enum:"text,json" placeholder:"type" default:"text" yaml:"-" json:"-"`
 
 	// Profile configuration.
 	Profile  string             `group:"flag-global" name:"profile" help:"Set the current profile." placeholder:"name" default:"default"`

--- a/internal/multimetro/key.go
+++ b/internal/multimetro/key.go
@@ -75,16 +75,18 @@ func (k Key) String() string {
 	if k.Metro != "" {
 		s += k.Metro + MetroKeySeparator
 	}
-	if k.UUID != "" {
-		if requiresIDPrefix(k.UUID) {
-			s += KeyUUIDPrefix
-		}
-		s += k.UUID
-	} else if k.Name != "" {
+	// FIXME: ideally format using the same as we parsed, even if we have both
+	// this is a bit tricky, since we construct keys in a few places
+	if k.Name != "" {
 		if requiresNamePrefix(k.Name) {
 			s += KeyNamePrefix
 		}
 		s += k.Name
+	} else if k.UUID != "" {
+		if requiresIDPrefix(k.UUID) {
+			s += KeyUUIDPrefix
+		}
+		s += k.UUID
 	}
 	return s
 }

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -212,7 +212,7 @@ func (cmd *ResourceGetCmd[R]) Run(ctx context.Context, cfg *config.Config, sandb
 
 type ResourceWaitCmd[R resource.GettableResource] struct {
 	Name  []string `arg:"" completion-predictor:"resource-key-${name}" help:"Names of the ${names} to wait for."`
-	Until []string `help:"Filter expression to wait for (e.g. --until state==running)." sep:"none"`
+	Until []string `help:"Filter expression to wait for (e.g. --until state==running)." sep:"none" required:"" aliases:"filter"`
 
 	Interval time.Duration `long:"interval" default:"2s" help:"Polling interval."`
 	Timeout  time.Duration `long:"timeout" default:"0" help:"Timeout before giving up."`

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -40,7 +40,9 @@ func (cmd ResourceCmd[R]) Underlying() resource.Resource {
 }
 
 type GettableResourceCmd[R resource.GettableResource] struct {
-	Get  ResourceGetCmd[R]  `cmd:"" help:"Inspect a ${name}." aliases:"inspect,show"`
+	Get ResourceGetCmd[R] `cmd:"" help:"Inspect a ${name}." aliases:"inspect,show"`
+}
+type WaitableResourceCmd[R resource.GettableResource] struct {
 	Wait ResourceWaitCmd[R] `cmd:"" help:"Wait for ${names} to match a filter."`
 }
 type ListableResourceCmd[R resource.GettableListableResource] struct {

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -538,6 +538,10 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, cfg *config.Config, sand
 			return err
 		}
 		updated = []resource.Resource{result}
+	} else {
+		log.G(ctx).Warn().
+			Str("resource", res.Key().String()).
+			Msg("no edits made")
 	}
 	return Diff(cfg.Stdout, cmd.FormatOpts, empty, []resource.Resource{res}, updated)
 }

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -520,7 +520,7 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, cfg *config.Config, sand
 		return err
 	}
 	if cmd.Visual {
-		patched, err = patch.VisualEdit(ctx, cfg, fields, patched)
+		patched, err = patch.VisualEdit(ctx, cfg, res, fields, patched)
 		if err != nil {
 			return err
 		}
@@ -615,7 +615,7 @@ func (cmd *ResourceCreateCmd[R]) Run(ctx context.Context, cfg *config.Config, sa
 
 	if cmd.Visual {
 		// FIXME: should allow required fields
-		patched, err = patch.VisualCreate(ctx, cfg, fields, patched)
+		patched, err = patch.VisualCreate(ctx, cfg, empty, fields, patched)
 		if err != nil {
 			return err
 		}

--- a/internal/resource/cmd/cmd_test.go
+++ b/internal/resource/cmd/cmd_test.go
@@ -142,13 +142,11 @@ func TestListOutput(t *testing.T) {
 	require.NoError(t, err)
 	resourcet.TestStore = cloned.(map[string]resourcet.TestResource)
 
-	runList := func(t *testing.T, printer Printer) string {
+	runList := func(t *testing.T, opts FormatOpts) string {
 		t.Helper()
 		var out bytes.Buffer
 		cmd := &ResourceListCmd[resourcet.TestResource]{
-			FormatOpts: FormatOpts{
-				Output: printer,
-			},
+			FormatOpts: opts,
 		}
 		err = cmd.Run(ctx, testConfig(&out), sandbox)
 		require.NoError(t, err)
@@ -156,7 +154,7 @@ func TestListOutput(t *testing.T) {
 	}
 
 	t.Run("table", func(t *testing.T) {
-		output := runList(t, Printer{Type: PrinterTypeTable})
+		output := runList(t, FormatOpts{Output: Printer{Type: PrinterTypeTable}})
 		cleaned := vtclean.Clean(output, false)
 		assert.Contains(t, cleaned, "test1")
 		assert.Contains(t, cleaned, "test2")
@@ -164,7 +162,7 @@ func TestListOutput(t *testing.T) {
 	})
 
 	t.Run("kv", func(t *testing.T) {
-		output := runList(t, Printer{Type: PrinterTypeKeyValue})
+		output := runList(t, FormatOpts{Output: Printer{Type: PrinterTypeKeyValue}})
 		assert.Contains(t, output, "name:")
 		assert.Contains(t, output, "id:")
 		assert.Contains(t, output, "test1")
@@ -173,7 +171,7 @@ func TestListOutput(t *testing.T) {
 	})
 
 	t.Run("json", func(t *testing.T) {
-		output := runList(t, Printer{Type: PrinterTypeJSON})
+		output := runList(t, FormatOpts{Output: Printer{Type: PrinterTypeJSON}})
 		var resources []map[string]any
 		err := json.Unmarshal([]byte(output), &resources)
 		require.NoError(t, err)
@@ -190,7 +188,7 @@ func TestListOutput(t *testing.T) {
 	})
 
 	t.Run("yaml", func(t *testing.T) {
-		output := runList(t, Printer{Type: PrinterTypeYAML})
+		output := runList(t, FormatOpts{Output: Printer{Type: PrinterTypeYAML}})
 		var resources []map[string]any
 		err := yaml.Unmarshal([]byte(output), &resources)
 		require.NoError(t, err)
@@ -207,7 +205,7 @@ func TestListOutput(t *testing.T) {
 	})
 
 	t.Run("raw", func(t *testing.T) {
-		output := runList(t, Printer{Type: PrinterTypeRaw})
+		output := runList(t, FormatOpts{Output: Printer{Type: PrinterTypeRaw}})
 		var resources []resourcet.TestResource
 		err := json.Unmarshal([]byte(output), &resources)
 		require.NoError(t, err)
@@ -222,12 +220,17 @@ func TestListOutput(t *testing.T) {
 	})
 
 	t.Run("quiet", func(t *testing.T) {
-		output := runList(t, Printer{Type: PrinterTypeQuiet})
+		output := runList(t, FormatOpts{Output: Printer{Type: PrinterTypeQuiet}})
 		assert.Equal(t, "test1\ntest2\n", output)
 	})
 
+	t.Run("quiet field", func(t *testing.T) {
+		output := runList(t, FormatOpts{Output: Printer{Type: PrinterTypeQuiet}, Field: []string{"id", "url"}})
+		assert.Equal(t, "id-test1 https://example.com\nid-test2 https://example.org\n", output)
+	})
+
 	t.Run("template", func(t *testing.T) {
-		output := runList(t, Printer{Type: PrinterTypeTemplate, Value: "{{.name}}-{{.id}}"})
+		output := runList(t, FormatOpts{Output: Printer{Type: PrinterTypeTemplate, Value: "{{.name}}-{{.id}}"}})
 		assert.Equal(t, "test1-id-test1\ntest2-id-test2\n", output)
 	})
 }

--- a/internal/resource/cmd/cmd_test.go
+++ b/internal/resource/cmd/cmd_test.go
@@ -235,6 +235,30 @@ func TestListOutput(t *testing.T) {
 	})
 }
 
+func TestTableNestedFieldSelection(t *testing.T) {
+	ctx := context.Background()
+	sandbox := &resource.Sandbox{}
+
+	cloned, err := copystructure.Copy(baseTestStore)
+	require.NoError(t, err)
+	resourcet.TestStore = cloned.(map[string]resourcet.TestResource)
+
+	var out bytes.Buffer
+	cmd := &ResourceGetCmd[resourcet.TestResource]{
+		Name: []string{"test1"},
+		FormatOpts: FormatOpts{
+			Output: Printer{Type: PrinterTypeTable},
+			Field:  []string{"name", "authors"},
+		},
+	}
+	err = cmd.Run(ctx, testConfig(&out), sandbox)
+	require.NoError(t, err)
+
+	cleaned := vtclean.Clean(out.String(), false)
+	assert.Contains(t, cleaned, "Alice")
+	assert.Contains(t, cleaned, "alice@example.com")
+}
+
 func TestGet(t *testing.T) {
 	ctx := context.Background()
 	sandbox := &resource.Sandbox{}

--- a/internal/resource/cmd/printers.go
+++ b/internal/resource/cmd/printers.go
@@ -132,7 +132,7 @@ func (p Printer) Print(out io.Writer, fieldSpecs []string, base resource.Resourc
 	case PrinterTypeRaw:
 		return printRaw(out, resources...)
 	case PrinterTypeQuiet:
-		return printQuiet(out, resources...)
+		return printQuiet(out, fieldSpecs, resources...)
 	case PrinterTypeTemplate:
 		return printTemplate(out, p.Value, resources...)
 	case PrintTypeDebug:
@@ -350,12 +350,40 @@ func headerName(path resource.FieldPath) string {
 	return ""
 }
 
-func printQuiet(out io.Writer, resources ...resource.Resource) error {
+func printQuiet(out io.Writer, specs []string, resources ...resource.Resource) error {
 	for _, res := range resources {
-		_, err := fmt.Fprintln(out, res.Key())
+		if specs == nil {
+			_, err := fmt.Fprintln(out, res.Key())
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		fields, err := res.Fields()
 		if err != nil {
 			return err
 		}
+		fields, err = resourceFields(fields, false, resource.FieldVerbosityNone, specs)
+		if err != nil {
+			return err
+		}
+		i := 0
+		for _, field := range resource.IterFields(fields) {
+			if field.HasChildren() && field.Value == nil {
+				continue
+			}
+			s, err := field.Render()
+			if err != nil {
+				return err
+			}
+			if i > 0 {
+				fmt.Fprint(out, " ")
+			}
+			fmt.Fprint(out, s)
+			i++
+		}
+		fmt.Fprintln(out)
 	}
 	return nil
 }

--- a/internal/resource/patch/visual.go
+++ b/internal/resource/patch/visual.go
@@ -21,20 +21,20 @@ import (
 	"unikraft.com/cli/internal/resource"
 )
 
-func VisualEdit(ctx context.Context, cfg *config.Config, fields []resource.Field, patches []resource.Field) ([]resource.Field, error) {
-	return visualEdit(ctx, cfg, fields, patches, false)
+func VisualEdit(ctx context.Context, cfg *config.Config, res resource.Resource, fields []resource.Field, patches []resource.Field) ([]resource.Field, error) {
+	return visualEdit(ctx, cfg, res, fields, patches, false)
 }
 
-func VisualCreate(ctx context.Context, cfg *config.Config, fields []resource.Field, creates []resource.Field) ([]resource.Field, error) {
-	return visualEdit(ctx, cfg, fields, creates, true)
+func VisualCreate(ctx context.Context, cfg *config.Config, res resource.Resource, fields []resource.Field, creates []resource.Field) ([]resource.Field, error) {
+	return visualEdit(ctx, cfg, res, fields, creates, true)
 }
 
 // visualEdit opens an editor for the user to modify fields visually.
 //
 // It takes all the fields and already existing patched fields as input, and
 // returns all patched fields after editing.
-func visualEdit(ctx context.Context, cfg *config.Config, fields []resource.Field, patches []resource.Field, create bool) ([]resource.Field, error) {
-	data, err := saveFields(fields, patches, create)
+func visualEdit(ctx context.Context, cfg *config.Config, res resource.Resource, fields []resource.Field, patches []resource.Field, create bool) ([]resource.Field, error) {
+	data, err := saveFields(res, fields, patches, create)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize fields: %w", err)
 	}
@@ -82,7 +82,7 @@ func visualEdit(ctx context.Context, cfg *config.Config, fields []resource.Field
 	return fields, nil
 }
 
-func saveFields(fields []resource.Field, patches []resource.Field, create bool) ([]byte, error) {
+func saveFields(res resource.Resource, fields []resource.Field, patches []resource.Field, create bool) ([]byte, error) {
 	fields = resource.CloneFields(fields)
 
 	patchMap := make(map[string]resource.Field)
@@ -154,17 +154,7 @@ func saveFields(fields []resource.Field, patches []resource.Field, create bool) 
 		return nil, fmt.Errorf("failed to marshal fields to YAML: %w", err)
 	}
 
-	result = append(result, []byte("\n# Edit the fields above. Lines starting with '#' will be ignored.\n#")...)
-	result = append(result, []byte("\n# Original:\n")...)
-
-	rest, err := yaml.Marshal(resource.FieldsToMap(fields))
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal fields to YAML: %w", err)
-	}
-	for line := range bytes.Lines(rest) {
-		result = append(result, []byte("#\t")...)
-		result = append(result, line...)
-	}
+	result = append(fmt.Appendf(nil, "# %s %s\n", res.Type().Name, res.Key()), result...)
 
 	return result, nil
 }

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -137,6 +137,7 @@ const (
 	FieldVerbosityHidden
 	FieldVerbosityLong
 	FieldVerbosityShort
+	FieldVerbosityNone // do not show anything
 )
 
 func (v FieldVerbosity) String() string {

--- a/internal/resource/resource_path.go
+++ b/internal/resource/resource_path.go
@@ -135,6 +135,7 @@ func filterFieldsByPath(field Field, specs []FieldPath, strict bool) (result Fie
 				// if we don't, then recursively include all subfields
 				if !strict && field.Elem != nil {
 					elem := *field.Elem
+					elem.Name = "*"
 					elem = mergeElem(elem)
 					elem = pruneFields(elem)
 					result.Subfields = append(result.Subfields, elem)


### PR DESCRIPTION
This is a first pass at fixing lots of issues discovered during the testing session. See each commit for more details. None of this is an attempt to get to a final state - it's just meant to fix and correct for the feedback, so we can clear some of the tickets from triage.

Fixes https://linear.app/unikraft/issue/CLI-141/comment-in-edit-is-confusing.
Fixes https://linear.app/unikraft/issue/CLI-139/bare-edit-command-does-nothing.
Fixes https://linear.app/unikraft/issue/CLI-129/h-help-should-work-even-if-rest-of-args-are-invalid.
Fixes https://linear.app/unikraft/issue/CLI-121/log-type-isnt-applied-if-command-line-parsing-fails.
Fixes https://linear.app/unikraft/issue/CLI-120/unikraft-run-should-support-format-opts
Fixes https://linear.app/unikraft/issue/CLI-117/o-quiet-should-support-field-selection
Fixes https://linear.app/unikraft/issue/CLI-116/unikraft-metro-wait-shouldnt-exist
Fixes https://linear.app/unikraft/issue/CLI-114/missing-filter-args-cause-weird-unprintable-characters
Fixes https://linear.app/unikraft/issue/CLI-113/make-wait-until-required
Fixes https://linear.app/unikraft/issue/CLI-103/more-command-aliases
Fixes https://linear.app/unikraft/issue/CLI-118/variable-names-in-help-screen (more fixes incoming in #72).