### PR TITLE
feat: Allow virtually patching the instance state

### DIFF
--- a/cmd/unikraft/instances_test.go
+++ b/cmd/unikraft/instances_test.go
@@ -115,6 +115,12 @@ var instancesTestCases = []testCase{
 			{args: []string{unikraftCmd, "instance", "start", "test-$UNIQ_INST"}},
 			{args: []string{unikraftCmd, "instance", "inspect", "test-$UNIQ_INST"}},
 
+			{args: []string{unikraftCmd, "instance", "edit", "test-$UNIQ_INST", "--set", "state=stopped"}},
+			{args: []string{unikraftCmd, "instance", "inspect", "test-$UNIQ_INST"}},
+
+			{args: []string{unikraftCmd, "instance", "edit", "test-$UNIQ_INST", "--set", "state=running"}},
+			{args: []string{unikraftCmd, "instance", "inspect", "test-$UNIQ_INST"}},
+
 			// {args: []string{unikraftCmd, "instance", "restart", "test-$UNIQ_INST"}},
 			// {args: []string{unikraftCmd, "instance", "inspect", "test-$UNIQ_INST"}},
 

--- a/cmd/unikraft/testdata/TestGolden/instances/start-stop
+++ b/cmd/unikraft/testdata/TestGolden/instances/start-stop
@@ -105,6 +105,92 @@ stdout:
 	  private-ip: 10.X.X.X
 	  mac:        aa:bb:cc:dd:ee:ff
 
+$ unikraft instance edit test-$UNIQ_INST --set state=stopped
+
+stdout:
+	  metro:        test
+	  name:         test-<INST>
+	  uuid:         12345678-1234-1234-1234-123456789abc
+	- state:        running
+	+ state:        stopped
+	  image:        nginx
+	  runtime:
+	    env:
+	      A:        1
+	      B:        2
+	      C:        3
+	  resources:
+	    memory:     128MiB
+	    vcpus:      1
+	  networks:
+	  - uuid:       12345678-1234-1234-1234-123456789abc
+	    private-ip: 10.X.X.X
+	    mac:        aa:bb:cc:dd:ee:ff
+
+$ unikraft instance inspect test-$UNIQ_INST
+
+stdout:
+	metro:        test
+	name:         test-<INST>
+	uuid:         12345678-1234-1234-1234-123456789abc
+	state:        stopped
+	image:        nginx
+	runtime:
+	  env:
+	    A:        1
+	    B:        2
+	    C:        3
+	resources:
+	  memory:     128MiB
+	  vcpus:      1
+	networks:
+	- uuid:       12345678-1234-1234-1234-123456789abc
+	  private-ip: 10.X.X.X
+	  mac:        aa:bb:cc:dd:ee:ff
+
+$ unikraft instance edit test-$UNIQ_INST --set state=running
+
+stdout:
+	  metro:        test
+	  name:         test-<INST>
+	  uuid:         12345678-1234-1234-1234-123456789abc
+	- state:        stopped
+	+ state:        running
+	  image:        nginx
+	  runtime:
+	    env:
+	      A:        1
+	      B:        2
+	      C:        3
+	  resources:
+	    memory:     128MiB
+	    vcpus:      1
+	  networks:
+	  - uuid:       12345678-1234-1234-1234-123456789abc
+	    private-ip: 10.X.X.X
+	    mac:        aa:bb:cc:dd:ee:ff
+
+$ unikraft instance inspect test-$UNIQ_INST
+
+stdout:
+	metro:        test
+	name:         test-<INST>
+	uuid:         12345678-1234-1234-1234-123456789abc
+	state:        running
+	image:        nginx
+	runtime:
+	  env:
+	    A:        1
+	    B:        2
+	    C:        3
+	resources:
+	  memory:     128MiB
+	  vcpus:      1
+	networks:
+	- uuid:       12345678-1234-1234-1234-123456789abc
+	  private-ip: 10.X.X.X
+	  mac:        aa:bb:cc:dd:ee:ff
+
 $ unikraft instance delete test-$UNIQ_INST
 
 stdout:

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -55,7 +55,7 @@ type Instance struct {
 
 	Tags []string `mirror:"instance.tags"`
 
-	State types.InstanceState `mirror:"instance.state" field:",short"`
+	State types.InstanceState `mirror:"instance.state" field:",short" edit:"set"`
 	Image string              `mirror:"instance.image" field:",short" create:"set,required" edit:"set"`
 
 	Runtime struct {
@@ -382,6 +382,14 @@ func (Instance) Delete(ctx context.Context, targets []resource.Resource) error {
 
 func (Instance) Edit(ctx context.Context, target resource.Resource, fields []resource.Field) (resource.Resource, error) {
 	instance := target.(Instance)
+
+	targetState := instance.State
+	if fields := resource.GetFieldByPath(fields, resource.FieldPath{"state"}); len(fields) > 0 {
+		field := fields[0]
+		targetState = field.Edit.Set.(types.InstanceState)
+		field.Edit = nil
+	}
+
 	patches := patchRequests(fields, instancePatchSpec)
 	reqs := make([]platform.UpdateInstancesRequestItem, 0, len(patches))
 	for _, patch := range patches {
@@ -397,13 +405,27 @@ func (Instance) Edit(ctx context.Context, target resource.Resource, fields []res
 	if err != nil {
 		return nil, err
 	}
-	err = group.DoMetro(ctx, g, instance.key().Metro, func(ctx context.Context, c multimetro.MetroClient) error {
-		log.G(ctx).Trace().Msg("updating instance")
-		_, err := c.UpdateInstances(ctx, reqs)
-		return err
-	})
-	if err != nil {
-		return nil, err
+	if instance.State.IsRunning() && !targetState.IsRunning() {
+		_, err := stopInstances(ctx, g, multimetro.Keys{instance.key()}, StopOpts{DrainTimeout: -1})
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(reqs) > 0 {
+		err = group.DoMetro(ctx, g, instance.key().Metro, func(ctx context.Context, c multimetro.MetroClient) error {
+			log.G(ctx).Trace().Msg("updating instance")
+			_, err := c.UpdateInstances(ctx, reqs)
+			return err
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	if !instance.State.IsRunning() && targetState.IsRunning() {
+		_, err := startInstances(ctx, g, multimetro.Keys{instance.key()})
+		if err != nil {
+			return nil, err
+		}
 	}
 	results, err := Instance{}.Get(ctx, []string{instance.Key().String()})
 	if err != nil {

--- a/internal/resource/patch/collect.go
+++ b/internal/resource/patch/collect.go
@@ -22,6 +22,15 @@ func collectValue(field resource.Field, into reflect.Type) (any, error) {
 	if err != nil {
 		return nil, err
 	}
+	if v != nil {
+		valueType := reflect.TypeOf(v)
+		if valueType.AssignableTo(into) {
+			return v, nil
+		}
+		if valueType.ConvertibleTo(into) {
+			return reflect.ValueOf(v).Convert(into).Interface(), nil
+		}
+	}
 	target := reflect.New(into).Elem().Interface()
 
 	if err := resource.DecodeStruct(v, &target); err != nil {
@@ -71,10 +80,13 @@ func storeValue(field *resource.Field, base reflect.Value) error {
 	}
 
 	if field.Value != nil {
-		if !base.Type().AssignableTo(reflect.TypeOf(field.Value)) {
+		if base.Type().AssignableTo(reflect.TypeOf(field.Value)) {
+			field.Value = base.Interface()
+		} else if base.Type().ConvertibleTo(reflect.TypeOf(field.Value)) {
+			field.Value = base.Convert(reflect.TypeOf(field.Value)).Interface()
+		} else {
 			return fmt.Errorf("cannot assign value of type %s to field %s of type %T", value.Type().String(), field.Name, field.Value)
 		}
-		field.Value = base.Interface()
 	}
 
 	if field.Elem != nil {

--- a/internal/types/states.go
+++ b/internal/types/states.go
@@ -6,6 +6,8 @@
 package types
 
 import (
+	"fmt"
+
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/x/colors"
 )
@@ -16,6 +18,44 @@ type InstanceState platform.InstanceState
 
 func (state InstanceState) String() string {
 	return state.color()(string(state))
+}
+
+func (state InstanceState) IsRunning() bool {
+	switch platform.InstanceState(state) {
+	case platform.InstanceStateRunning,
+		platform.InstanceStateStarting,
+		platform.InstanceStateStandby:
+		return true
+	default:
+		return false
+	}
+}
+
+func (state InstanceState) validate() error {
+	switch platform.InstanceState(state) {
+	case platform.InstanceStateStopped:
+	case platform.InstanceStateStarting:
+	case platform.InstanceStateRunning:
+	case platform.InstanceStateDraining:
+	case platform.InstanceStateStopping:
+	case platform.InstanceStateStandby:
+	default:
+		return fmt.Errorf("unknown instance state: %q", string(state))
+	}
+	return nil
+}
+
+func (state *InstanceState) UnmarshalText(text []byte) error {
+	s := InstanceState(text)
+	if err := s.validate(); err != nil {
+		return err
+	}
+	*state = s
+	return nil
+}
+
+func (state InstanceState) MarshalText() ([]byte, error) {
+	return []byte(state), nil
 }
 
 func (state InstanceState) color() func(...string) string {
@@ -40,6 +80,34 @@ type VolumeState platform.VolumeState
 
 func (state VolumeState) String() string {
 	return state.color()(string(state))
+}
+
+func (state VolumeState) validate() error {
+	switch platform.VolumeState(state) {
+	case platform.VolumeStateUninitialized:
+	case platform.VolumeStateInitializing:
+	case platform.VolumeStateAvailable:
+	case platform.VolumeStateIdle:
+	case platform.VolumeStateMounted:
+	case platform.VolumeStateBusy:
+	case platform.VolumeStateError:
+	default:
+		return fmt.Errorf("unknown volume state: %q", string(state))
+	}
+	return nil
+}
+
+func (state *VolumeState) UnmarshalText(text []byte) error {
+	s := VolumeState(text)
+	if err := s.validate(); err != nil {
+		return err
+	}
+	*state = s
+	return nil
+}
+
+func (state VolumeState) MarshalText() ([]byte, error) {
+	return []byte(state), nil
 }
 
 func (state VolumeState) color() func(...string) string {
@@ -67,6 +135,30 @@ type CertificateState platform.CertificateState
 
 func (state CertificateState) String() string {
 	return state.color()(string(state))
+}
+
+func (state CertificateState) validate() error {
+	switch platform.CertificateState(state) {
+	case platform.CertificateStatePending:
+	case platform.CertificateStateValid:
+	case platform.CertificateStateError:
+	default:
+		return fmt.Errorf("unknown certificate state: %q", string(state))
+	}
+	return nil
+}
+
+func (state *CertificateState) UnmarshalText(text []byte) error {
+	s := CertificateState(text)
+	if err := s.validate(); err != nil {
+		return err
+	}
+	*state = s
+	return nil
+}
+
+func (state CertificateState) MarshalText() ([]byte, error) {
+	return []byte(state), nil
 }
 
 func (state CertificateState) color() func(...string) string {


### PR DESCRIPTION
This isn't *actually* patchable using the PATCH method, but, we can issue a start/stop command instead. This is pretty neat!

Closes https://linear.app/unikraft/issue/CLI-127/add-virtual-patch-for-instance-state.