### PR TITLE
fix: Make template behave like docker templates

### DIFF
--- a/cmd/unikraft/instances_test.go
+++ b/cmd/unikraft/instances_test.go
@@ -57,7 +57,7 @@ var instancesTestCases = []testCase{
 			{
 				args: []string{
 					unikraftCmd, "instance", "inspect", "test-$UNIQ_INST",
-					"--output", "template=" + `{{ (index (index (index (index . 0) "service") "domains") 0).fqdn }}`,
+					"--output", "template=" + `{{ (index .service.domains 0).fqdn }}`,
 				},
 				captureEnv: "FQDN",
 			},

--- a/cmd/unikraft/testdata/TestGolden/instances/create
+++ b/cmd/unikraft/testdata/TestGolden/instances/create
@@ -167,7 +167,7 @@ stdout:
 	  private-ip: 10.X.X.X
 	  mac:        aa:bb:cc:dd:ee:ff
 
-$ FQDN=$(unikraft instance inspect test-$UNIQ_INST --output 'template={{ (index (index (index (index . 0) "service") "domains") 0).fqdn }}')
+$ FQDN=$(unikraft instance inspect test-$UNIQ_INST --output 'template={{ (index .service.domains 0).fqdn }}')
 
 $ curl -k --fail --silent --show-error --output /dev/null --write-out 'HTTP %{http_code} OK\n%header{server}\n' --retry 10 --retry-delay 2 --retry-all-errors --connect-timeout 5 --max-time 10 https://$FQDN
 

--- a/internal/resource/cmd/cmd_test.go
+++ b/internal/resource/cmd/cmd_test.go
@@ -227,7 +227,7 @@ func TestListOutput(t *testing.T) {
 	})
 
 	t.Run("template", func(t *testing.T) {
-		output := runList(t, Printer{Type: PrinterTypeTemplate, Value: "{{range .}}{{.name}}-{{.id}}\n{{end}}"})
+		output := runList(t, Printer{Type: PrinterTypeTemplate, Value: "{{.name}}-{{.id}}"})
 		assert.Equal(t, "test1-id-test1\ntest2-id-test2\n", output)
 	})
 }

--- a/internal/resource/cmd/printers.go
+++ b/internal/resource/cmd/printers.go
@@ -408,20 +408,33 @@ func printRaw(out io.Writer, resources ...resource.Resource) error {
 }
 
 func printTemplate(out io.Writer, tmplStr string, resources ...resource.Resource) error {
-	input := make([]any, 0, len(resources))
+	tmpl, err := template.New("out").
+		Funcs(sprig.TxtFuncMap()).
+		Parse(tmplStr)
+	if err != nil {
+		return err
+	}
+
 	for _, res := range resources {
 		fields, err := res.Fields()
 		if err != nil {
 			return err
 		}
-		input = append(input, resource.FieldsToMap(fields))
+		input := resource.FieldsToMap(fields)
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, input); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(out, buf.String()); err != nil {
+			return err
+		}
+		if !strings.HasSuffix(buf.String(), "\n") {
+			if _, err := io.WriteString(out, "\n"); err != nil {
+				return err
+			}
+		}
 	}
-
-	tmpl, err := template.New("out").Funcs(sprig.TxtFuncMap()).Parse(tmplStr)
-	if err != nil {
-		return err
-	}
-	return tmpl.Execute(out, input)
+	return nil
 }
 
 func printDebug(out io.Writer, resources ...resource.Resource) error {


### PR DESCRIPTION
And like kubectl templates. Instead of requiring the user to iterate / index over all the results themselves, the template should be applied to each resource independently.

Fixes https://linear.app/unikraft/issue/CLI-142/template-for-inspect-should-accept-one-list-should-accept-multiple.