### PR TITLE
ci: Publish for more ubuntu distros

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -132,8 +132,11 @@ jobs:
         DISTROS+=("bookworm") # 12
         DISTROS+=("trixie")   # 13
         # Ubuntu
-        DISTROS+=("jammy")  # 22.04
-        DISTROS+=("noble")  # 24.04
+        DISTROS+=("jammy")     # 22.04
+        DISTROS+=("noble")     # 24.04
+        DISTROS+=("plucky")    # 25.05
+        DISTROS+=("questing")  # 25.10
+        DISTROS+=("resolute")  # 26.04 (preview)
 
         for DISTRO in "${DISTROS[@]}"; do
           for DEB in dist/*.deb; do


### PR DESCRIPTION
Fixes https://linear.app/unikraft/issue/CLI-105/add-all-the-ubuntu-versions-to-the-release.

Following https://en.wikipedia.org/wiki/Ubuntu_version_history#Table_of_versions. We include:
- `questing` (within standard support)
- `plucky` (ended standard support last month, @razvand was using it)
- `resolute` (available within preview)