### PR TITLE
feat: Allow insecure metros

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ profiles:
     organization: <org-name>
     token: <api-token>
     metros:
-      - name: <metro-name> # e.g. fra
+      - name: <metro-name>         # e.g. fra
         endpoint: <metro-endpoint> # e.g. https://api.fra.unikraft.cloud
-        country: <metro-country> # e.g. de
+        country: <metro-country>   # e.g. de
+        insecure: false            # skip tls verification (avoid for production use)
 ```
 
 Then you'll be able to run commands against the platform. For example, to list

--- a/cmd/unikraft/main_test.go
+++ b/cmd/unikraft/main_test.go
@@ -179,7 +179,7 @@ func TestGolden(t *testing.T) {
 							repl:    "https://api." + metro.Name + ".unikraft.internal/",
 						},
 						cleaner{
-							pattern: regexp.MustCompile(regexp.QuoteMeta(metro.Index())),
+							pattern: regexp.MustCompile(regexp.QuoteMeta(metro.Index().Host)),
 							repl:    "index." + metro.Name + ".unikraft.internal",
 						},
 					)

--- a/cmd/unikraft/testdata/TestGolden/auth/help
+++ b/cmd/unikraft/testdata/TestGolden/auth/help
@@ -281,6 +281,7 @@ stdout:
 	  name
 	  country
 	  endpoint
+	  insecure
 
 	Global flags:
 	  -h, --help
@@ -325,6 +326,7 @@ stdout:
 	  name
 	  country
 	  endpoint
+	  insecure
 
 	Flags:
 	  -w, --watch
@@ -377,6 +379,7 @@ stdout:
 	  name
 	  country
 	  endpoint
+	  insecure
 
 	Flags:
 	      --filter

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -360,7 +360,7 @@ func parseNormalizedNamed(key string) (reference.Named, error) {
 func parseNormalizedNamedMetro(metro *config.Metro, key string) (reference.Named, error) {
 	index := "index.unikraft.io"
 	if metro != nil {
-		index = metro.Index()
+		index = metro.Index().Host
 	}
 	return xreference.ParseNormalizedNamed(
 		key,
@@ -377,7 +377,7 @@ func imageRefToKey(metros []config.Metro, named reference.Named) multimetro.Key 
 		}
 	}
 	for _, metro := range metros {
-		if domain == metro.Index() {
+		if domain == metro.Index().Host {
 			return multimetro.Key{
 				Metro: metro.Name,
 				Name:  named.String(),

--- a/internal/cmd/metros.go
+++ b/internal/cmd/metros.go
@@ -24,6 +24,7 @@ type Metro struct {
 	Name     string `field:",short" json:"name"`
 	Country  string `field:",short" json:"country"`
 	Endpoint string `field:",short" json:"endpoint"`
+	Insecure bool   `field:",long" json:"insecure"`
 }
 
 func (Metro) Type() resource.Type {
@@ -58,6 +59,7 @@ func (Metro) List(ctx context.Context) ([]resource.Resource, error) {
 			Name:     metro.Name,
 			Country:  metro.Country,
 			Endpoint: metro.Endpoint,
+			Insecure: metro.Insecure,
 		}
 		results = append(results, result)
 	}

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -60,23 +60,35 @@ type Profile struct {
 	Metros       []Metro     `hidden:"" embed:"" prefix:"metro." help:"Static list of metros." json:"metros,omitempty" yaml:"metros,omitempty"`
 }
 
+// Metro represents a metro configuration for a profile in the Unikraft CLI.
 type Metro struct {
 	Name     string `hidden:"" help:"Name of the metro." json:"name" yaml:"name"`
 	Endpoint string `hidden:"" help:"Endpoint for the metro." json:"endpoint" yaml:"endpoint"`
 	Country  string `hidden:"" help:"Country code for the metro." json:"country" yaml:"country"`
+	Insecure bool   `hidden:"" help:"Allow insecure connections to the metro." json:"insecure" yaml:"insecure"`
 }
 
-func (m Metro) Index() string {
+type Index struct {
+	// Host is the hostname of the index to connect to.
+	Host string
+	// HTTP indicates whether the index should be accessed over HTTP instead of HTTPS.
+	HTTP bool
+	// Insecure skips TLS verification when connecting to the index.
+	Insecure bool
+}
+
+func (m Metro) Index() Index {
 	u, err := url.Parse(m.Endpoint)
 	if err != nil {
-		return m.Endpoint
+		return Index{Host: m.Endpoint}
 	}
 	hostname := u.Hostname()
-	hostname, ok := strings.CutPrefix(hostname, "api.")
-	if !ok {
-		return m.Endpoint
+	hostname, _ = strings.CutPrefix(hostname, "api.")
+	return Index{
+		Host:     "index." + hostname,
+		HTTP:     u.Scheme == "http",
+		Insecure: m.Insecure,
 	}
-	return "index." + hostname
 }
 
 var _ fmt.Stringer = Profile{}

--- a/internal/dockerutil/resolver.go
+++ b/internal/dockerutil/resolver.go
@@ -17,12 +17,38 @@ import (
 	dockerconfig "github.com/docker/cli/cli/config"
 
 	"unikraft.com/cli/internal/config"
+	"unikraft.com/cli/internal/httpclient"
 	"unikraft.com/cli/internal/version"
 )
 
 func Resolver(profile *config.Profile) remotes.Resolver {
 	headers := http.Header{}
 	headers.Set("User-Agent", version.UserAgent())
+
+	var indexes []config.Index
+	if profile != nil {
+		indexes = make([]config.Index, len(profile.Metros))
+		for i, metro := range profile.Metros {
+			indexes[i] = metro.Index()
+		}
+	}
+
+	httpHost := func(host string) (bool, error) {
+		for _, index := range indexes {
+			if host == index.Host {
+				return index.HTTP, nil
+			}
+		}
+		return false, nil
+	}
+	insecureHost := func(host string) (bool, error) {
+		for _, index := range indexes {
+			if host == index.Host {
+				return index.Insecure, nil
+			}
+		}
+		return false, nil
+	}
 
 	dockerConfig := dockerconfig.LoadDefaultConfigFile(os.Stderr)
 	opts := []docker.RegistryOpt{
@@ -32,8 +58,8 @@ func Resolver(profile *config.Profile) remotes.Resolver {
 				if hostname == "index.unikraft.io" {
 					return decodeAuth(profile.Token)
 				}
-				for _, metro := range profile.Metros {
-					if hostname == metro.Index() {
+				for _, index := range indexes {
+					if hostname == index.Host {
 						username := profile.Organization
 						if username == "" {
 							// organization may not be set on old or manually created
@@ -46,7 +72,7 @@ func Resolver(profile *config.Profile) remotes.Resolver {
 				}
 			}
 
-			auth, err := dockerConfig.GetCredentialsStore(hostname).Get(hostname)
+			auth, err := dockerConfig.GetAuthConfig(hostname)
 			if err != nil {
 				return "", "", err
 			}
@@ -56,17 +82,19 @@ func Resolver(profile *config.Profile) remotes.Resolver {
 			return auth.Username, auth.Password, nil
 		},
 		))),
+		docker.WithPlainHTTP(httpHost),
 	}
-	opts = append(opts, docker.WithPlainHTTP(docker.MatchAllHosts))
 
 	dro := docker.ResolverOptions{
 		Headers: headers,
 		Hosts: fallbackHost(
-			docker.ConfigureDefaultRegistries(opts...),
+			insecureHosts(docker.ConfigureDefaultRegistries(opts...), insecureHost),
 			docker.ConfigureDefaultRegistries(append(opts, docker.WithHostTranslator(func(s string) (string, error) {
-				for _, metro := range profile.Metros {
-					if s == metro.Index() {
-						return "index.unikraft.io", nil
+				if profile != nil {
+					for _, index := range indexes {
+						if s == index.Host {
+							return "index.unikraft.io", nil
+						}
 					}
 				}
 				return s, nil
@@ -111,5 +139,25 @@ func fallbackHost(registryHosts ...docker.RegistryHosts) docker.RegistryHosts {
 			allHosts = append(allHosts, hosts...)
 		}
 		return allHosts, nil
+	}
+}
+
+func insecureHosts(hosts docker.RegistryHosts, f func(string) (bool, error)) docker.RegistryHosts {
+	return func(hostname string) ([]docker.RegistryHost, error) {
+		hosts, err := hosts(hostname)
+		if err != nil {
+			return nil, err
+		}
+		for i, host := range hosts {
+			ok, err := f(host.Host)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				host.Client = httpclient.InsecureHTTPClient
+				hosts[i] = host
+			}
+		}
+		return hosts, nil
 	}
 }

--- a/internal/multimetro/client.go
+++ b/internal/multimetro/client.go
@@ -14,6 +14,7 @@ import (
 	"unikraft.com/x/log"
 
 	"unikraft.com/cli/internal/config"
+	"unikraft.com/cli/internal/httpclient"
 )
 
 type MetroClient struct {
@@ -44,7 +45,13 @@ func NewClient(ctx context.Context) (*group.Group[MetroClient], error) {
 
 	group := group.New[MetroClient]()
 	for _, metro := range metros {
+		httpClient := httpclient.DefaultHTTPClient
+		if metro.Insecure {
+			httpClient = httpclient.InsecureHTTPClient
+		}
+
 		client := platform.NewClient(
+			platform.WithHTTPClient(httpClient),
 			platform.WithToken(profile.Token),
 			platform.WithDefaultMetro(metro.Endpoint),
 		)


### PR DESCRIPTION
Fixes https://linear.app/unikraft/issue/CLI-143/add-insecure-tls-for-metros-in-config.

This ensures that we're not always doing http only requests for the platform API or registry interactions.

Instead, we only do HTTP requests when the protocol is set to `http://`. We also have a new `insecure` option for metros which lets us explicitly disable TLS certificate checks.