### PR TITLE
refactor(version): Move the colon leftmost of attribute

### DIFF
--- a/cmd/unikraft/testdata/TestGolden/version
+++ b/cmd/unikraft/testdata/TestGolden/version
@@ -2,10 +2,10 @@ $ unikraft --version
 
 stdout:
 	Unikraft CLI
-	  version   : dev
-	  commit    : unset
-	  platform  : GOOS/GOARCH
+	  version:    dev
+	  commit:     unset
+	  platform:   GOOS/GOARCH
 	  build time: unknown
 	  go version: goX.Y.Z
-	  docs      : https://unikraft.com/docs
-	  issues    : https://github.com/unikraft/cli/issues
+	  docs:       https://unikraft.com/docs
+	  issues:     https://github.com/unikraft/cli/issues

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -20,13 +20,13 @@ var (
 func String() string {
 	return heredoc.Docf(`
 		Unikraft CLI
-		  version   : %s
-		  commit    : %s
-		  platform  : %s/%s
+		  version:    %s
+		  commit:     %s
+		  platform:   %s/%s
 		  build time: %s
 		  go version: %s
-		  docs      : https://unikraft.com/docs
-		  issues    : https://github.com/unikraft/cli/issues`,
+		  docs:       https://unikraft.com/docs
+		  issues:     https://github.com/unikraft/cli/issues`,
 		Version,
 		Commit,
 		runtime.GOOS,


### PR DESCRIPTION
Now matches the placement of colons in resource get commands.

Signed-off-by: Alexander Jung <alex@unikraft.com>
