### PR TITLE
ci(release): Capture relevant version output from stdout

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,16 +62,16 @@ jobs:
       id: versions
       run: |
         {
-          echo "next-stable=$(make --no-print-directory next-stable)"
-          echo "next-staging=$(make --no-print-directory next-staging)"
-          echo "last-version=$(make --no-print-directory last-version)"
-          echo "last-stable=$(make --no-print-directory last-stable)"
+          echo "next-stable=$(make --no-print-directory next-stable 2>/dev/null)"
+          echo "next-staging=$(make --no-print-directory next-staging 2>/dev/null)"
+          echo "last-version=$(make --no-print-directory last-version 2>/dev/null)"
+          echo "last-stable=$(make --no-print-directory last-stable 2>/dev/null)"
         } >> "$GITHUB_OUTPUT"
 
         if [[ "${{ github.ref }}" == "refs/heads/stable" ]]; then
-          echo "next-version=$(make --no-print-directory next-stable)" >> "$GITHUB_OUTPUT"
+          echo "next-version=$(make --no-print-directory next-stable 2>/dev/null)" >> "$GITHUB_OUTPUT"
         else
-          echo "next-version=$(make --no-print-directory next-staging)" >> "$GITHUB_OUTPUT"
+          echo "next-version=$(make --no-print-directory next-staging 2>/dev/null)" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Tag next version


### PR DESCRIPTION
The version outputs in the gather versions step gets mangled with the prompt/"assume yes" from the remote taskfile.  Luckily, [the prompt occurs only in the stderr][0] so if we filter this out, we'll get clean values.

[0]: https://github.com/go-task/task/blob/6dedcafd7dbc05aa233e1e2a6e5b5d75a50454a8/internal/input/input.go#L63
