### PR TITLE
fix: Preserve yaml metadata on config save

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	golang.org/x/net v0.49.0
 	golang.org/x/sync v0.19.0
+	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.2
 	mvdan.cc/sh/v3 v3.12.0
 	sigs.k8s.io/yaml v1.6.0
@@ -132,7 +133,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251222181119-0a764e51fe1b // indirect
 	google.golang.org/grpc v1.78.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	tailscale.com v1.94.1 // indirect
 )
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,8 @@ import (
 
 	jujuerrors "github.com/juju/errors"
 	"sigs.k8s.io/yaml"
+
+	"unikraft.com/cli/internal/yamlmerge"
 )
 
 // Config represents the global configuration for the Unikraft CLI.
@@ -48,9 +50,9 @@ func (c *Config) Save() error {
 		return jujuerrors.New("config file path is not set")
 	}
 
-	dt, err := yaml.Marshal(c)
+	updated, err := mergeConfig(c)
 	if err != nil {
-		return jujuerrors.Annotate(err, "marshalling config to yaml")
+		return err
 	}
 
 	if err := os.MkdirAll(filepath.Dir(c.Path), 0o755); err != nil {
@@ -61,7 +63,7 @@ func (c *Config) Save() error {
 		return jujuerrors.Annotate(err, "opening config file")
 	}
 
-	if _, err := f.Write(dt); err != nil {
+	if _, err := f.Write(updated); err != nil {
 		f.Close()
 		return jujuerrors.Annotate(err, "writing config file")
 	}
@@ -105,4 +107,21 @@ func Load(path string) (*Config, error) {
 
 	c.Path = path
 	return &c, nil
+}
+
+func mergeConfig(c *Config) ([]byte, error) {
+	desired, err := yaml.Marshal(c)
+	if err != nil {
+		return nil, jujuerrors.Annotate(err, "marshalling config to yaml")
+	}
+
+	existing, err := os.ReadFile(c.Path)
+	if errors.Is(err, os.ErrNotExist) {
+		return desired, nil
+	}
+	if err != nil {
+		return nil, jujuerrors.Annotate(err, "reading config file")
+	}
+
+	return yamlmerge.MergeYAML(existing, desired)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSavePreservesCommentsAndDropsUnknownKeys(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "config.yaml")
+
+	input := strings.TrimSpace(`
+# global comment
+profile: default
+profiles:
+  # default profile comment
+  default:
+    type: cloud
+    token: oldtoken
+    foobar: remove-me
+`) + "\n"
+
+	if err := os.WriteFile(path, []byte(input), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	config := &Config{
+		Path:           path,
+		DefaultProfile: "default",
+		Profiles: map[string]Profile{
+			"default": {
+				Type:  ProfileTypeCloud,
+				Token: "newtoken",
+			},
+		},
+	}
+
+	if err := config.Save(); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	output, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	content := string(output)
+
+	if !strings.Contains(content, "# global comment") {
+		t.Fatalf("expected global comment to be preserved, got:\n%s", content)
+	}
+	if !strings.Contains(content, "# default profile comment") {
+		t.Fatalf("expected profile comment to be preserved, got:\n%s", content)
+	}
+	if !strings.Contains(content, "token: newtoken") {
+		t.Fatalf("expected token to be updated, got:\n%s", content)
+	}
+	if strings.Contains(content, "foobar") {
+		t.Fatalf("expected unknown profile key to be removed, got:\n%s", content)
+	}
+}

--- a/internal/yamlmerge/merge.go
+++ b/internal/yamlmerge/merge.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package yamlmerge
+
+import (
+	"bytes"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// MergeYAML merges desired into existing while preserving comments.
+// All keys not present in desired are removed. Sequences are merged by index
+// when lengths match.
+func MergeYAML(existing, desired []byte) ([]byte, error) {
+	if len(desired) == 0 {
+		return existing, nil
+	}
+
+	desiredDoc, err := decodeDocument(desired)
+	if err != nil {
+		return nil, err
+	}
+	if len(existing) == 0 {
+		return encodeDocument(desiredDoc)
+	}
+	desiredRoot := rootNode(desiredDoc)
+
+	existingDoc, err := decodeDocument(existing)
+	if err != nil {
+		return nil, err
+	}
+	existingRoot := rootNode(existingDoc)
+
+	if existingRoot == nil {
+		return encodeDocument(desiredDoc)
+	}
+	if desiredRoot == nil {
+		return encodeDocument(existingDoc)
+	}
+
+	mergeNode(existingRoot, desiredRoot)
+	return encodeDocument(existingDoc)
+}
+
+func mergeNode(existing *yaml.Node, desired *yaml.Node) {
+	if existing.Kind == yaml.MappingNode && desired.Kind == yaml.MappingNode {
+		mergeMap(existing, desired)
+		return
+	}
+	if existing.Kind == yaml.SequenceNode && desired.Kind == yaml.SequenceNode {
+		mergeSeq(existing, desired)
+		return
+	}
+	applyData(existing, desired)
+}
+
+func mergeMap(existing *yaml.Node, desired *yaml.Node) {
+	if existing.Kind != yaml.MappingNode || desired.Kind != yaml.MappingNode {
+		applyData(existing, desired)
+		return
+	}
+
+	applyMetadata(existing, desired)
+
+	index := make(map[string]int, len(existing.Content)/2)
+	for i := 0; i < len(existing.Content); i += 2 {
+		key := existing.Content[i]
+		index[key.Value] = i
+	}
+
+	desiredKeys := make(map[string]struct{}, len(desired.Content)/2)
+	for i := 0; i < len(desired.Content); i += 2 {
+		key := desired.Content[i]
+		value := desired.Content[i+1]
+		desiredKeys[key.Value] = struct{}{}
+
+		if pos, ok := index[key.Value]; ok {
+			mergeNode(existing.Content[pos+1], value)
+			continue
+		}
+		existing.Content = append(existing.Content, key, value)
+	}
+
+	filtered := make([]*yaml.Node, 0, len(existing.Content))
+	for i := 0; i < len(existing.Content); i += 2 {
+		key := existing.Content[i]
+		if _, ok := desiredKeys[key.Value]; ok {
+			filtered = append(filtered, existing.Content[i], existing.Content[i+1])
+		}
+	}
+	existing.Content = filtered
+}
+
+func mergeSeq(existing *yaml.Node, desired *yaml.Node) {
+	if len(existing.Content) != len(desired.Content) {
+		applyData(existing, desired)
+		return
+	}
+
+	// Merge sequence items by index to keep per-item comments stable.
+	applyMetadata(existing, desired)
+
+	for i := range desired.Content {
+		mergeNode(existing.Content[i], desired.Content[i])
+	}
+}
+
+func applyData(existing *yaml.Node, desired *yaml.Node) {
+	// Preserve metadata while swapping out the node value.
+	headComment := existing.HeadComment
+	lineComment := existing.LineComment
+	footComment := existing.FootComment
+	prevStyle := existing.Style
+	prevAnchor := existing.Anchor
+	prevTag := existing.Tag
+	prevKind := existing.Kind
+	prevValue := existing.Value
+	*existing = *desired
+	if prevStyle != 0 && prevKind == desired.Kind {
+		existing.Style = prevStyle
+	}
+	if prevKind == yaml.ScalarNode && (prevStyle == yaml.LiteralStyle || prevStyle == yaml.FoldedStyle) {
+		if strings.HasSuffix(prevValue, "\n") && !strings.HasSuffix(existing.Value, "\n") {
+			existing.Value += "\n"
+		}
+	}
+	if prevAnchor != "" {
+		existing.Anchor = prevAnchor
+	}
+	if desired.Tag == "" {
+		existing.Tag = prevTag
+	}
+	existing.HeadComment = headComment
+	existing.LineComment = lineComment
+	existing.FootComment = footComment
+}
+
+func applyMetadata(existing *yaml.Node, desired *yaml.Node) {
+	if desired.Tag != "" {
+		existing.Tag = desired.Tag
+	}
+	if existing.Style == 0 && desired.Style != 0 {
+		existing.Style = desired.Style
+	}
+	if existing.Anchor == "" && desired.Anchor != "" {
+		existing.Anchor = desired.Anchor
+	}
+}
+
+func rootNode(doc *yaml.Node) *yaml.Node {
+	if doc == nil {
+		return nil
+	}
+	if doc.Kind == yaml.DocumentNode {
+		if len(doc.Content) == 0 {
+			return nil
+		}
+		return doc.Content[0]
+	}
+	return doc
+}
+
+func decodeDocument(input []byte) (*yaml.Node, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(input, &doc); err != nil {
+		return nil, err
+	}
+	return &doc, nil
+}
+
+func encodeDocument(doc *yaml.Node) ([]byte, error) {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+		if err := encoder.Encode(doc.Content[0]); err != nil {
+			encoder.Close()
+			return nil, err
+		}
+	} else {
+		if err := encoder.Encode(doc); err != nil {
+			encoder.Close()
+			return nil, err
+		}
+	}
+	if err := encoder.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/yamlmerge/merge_test.go
+++ b/internal/yamlmerge/merge_test.go
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package yamlmerge
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeYAMLPrunesUnknownKeys(t *testing.T) {
+	existing := strings.TrimSpace(`
+# global comment
+profile: default
+profiles:
+  # default profile comment
+  default:
+    type: cloud
+    token: oldtoken
+    foobar: remove-me
+extra:
+  enabled: true
+`) + "\n"
+
+	desired := strings.TrimSpace(`
+profile: default
+profiles:
+  default:
+    type: cloud
+    token: newtoken
+`) + "\n"
+
+	output, err := MergeYAML([]byte(existing), []byte(desired))
+	require.NoError(t, err)
+
+	expected := strings.TrimSpace(`
+# global comment
+profile: default
+profiles:
+  # default profile comment
+  default:
+    type: cloud
+    token: newtoken
+`) + "\n"
+	assert.Equal(t, expected, string(output))
+}
+
+func TestMergeYAMLMergesSequencesByIndex(t *testing.T) {
+	existing := strings.TrimSpace(`
+items:
+  # first item
+  - name: alpha
+    value: 1
+    extra: drop
+  # second item
+  - name: beta
+    value: 2
+`) + "\n"
+
+	desired := strings.TrimSpace(`
+items:
+  - name: alpha
+    value: 10
+  - name: beta
+    value: 20
+`) + "\n"
+
+	output, err := MergeYAML([]byte(existing), []byte(desired))
+	require.NoError(t, err)
+
+	expected := strings.TrimSpace(`
+items:
+  # first item
+  - name: alpha
+    value: 10
+  # second item
+  - name: beta
+    value: 20
+`) + "\n"
+	assert.Equal(t, expected, string(output))
+}
+
+func TestMergeYAMLPreservesAnchors(t *testing.T) {
+	existing := strings.TrimSpace(`
+profiles: &profiles
+  default:
+    token: old
+`) + "\n"
+
+	desired := strings.TrimSpace(`
+profiles:
+  default:
+    token: new
+`) + "\n"
+
+	output, err := MergeYAML([]byte(existing), []byte(desired))
+	require.NoError(t, err)
+
+	expected := strings.TrimSpace(`
+profiles: &profiles
+  default:
+    token: new
+`) + "\n"
+	assert.Equal(t, expected, string(output))
+}
+
+func TestMergeYAMLAddsAnchorsFromDesired(t *testing.T) {
+	existing := strings.TrimSpace(`
+profiles:
+  default:
+    token: old
+`) + "\n"
+
+	desired := strings.TrimSpace(`
+profiles: &profiles
+  default:
+    token: new
+`) + "\n"
+
+	output, err := MergeYAML([]byte(existing), []byte(desired))
+	require.NoError(t, err)
+
+	expected := strings.TrimSpace(`
+profiles: &profiles
+  default:
+    token: new
+`) + "\n"
+	assert.Equal(t, expected, string(output))
+}
+
+func TestMergeYAMLPreservesFlowMappingStyle(t *testing.T) {
+	existing := strings.TrimSpace(`
+settings: {region: eu, retries: 2}
+`) + "\n"
+
+	desired := strings.TrimSpace(`
+settings:
+  region: us
+  retries: 3
+`) + "\n"
+
+	output, err := MergeYAML([]byte(existing), []byte(desired))
+	require.NoError(t, err)
+
+	expected := strings.TrimSpace(`
+settings: {region: us, retries: 3}
+`) + "\n"
+	assert.Equal(t, expected, string(output))
+}
+
+func TestMergeYAMLPreservesFlowSequenceStyle(t *testing.T) {
+	existing := strings.TrimSpace(`
+items: [alpha, beta]
+`) + "\n"
+
+	desired := strings.TrimSpace(`
+items:
+  - alpha
+  - gamma
+`) + "\n"
+
+	output, err := MergeYAML([]byte(existing), []byte(desired))
+	require.NoError(t, err)
+
+	expected := strings.TrimSpace(`
+items: [alpha, gamma]
+`) + "\n"
+	assert.Equal(t, expected, string(output))
+}
+
+func TestMergeYAMLPreservesLiteralStyle(t *testing.T) {
+	existing := strings.TrimSpace(`
+note: |
+  line one
+  line two
+`) + "\n"
+
+	desired := strings.TrimSpace(`
+note: "line one\nline two\nline three"
+`) + "\n"
+
+	output, err := MergeYAML([]byte(existing), []byte(desired))
+	require.NoError(t, err)
+
+	expected := strings.TrimSpace(`
+note: |
+  line one
+  line two
+  line three
+`) + "\n"
+	assert.Equal(t, expected, string(output))
+}
+
+func TestMergeYAMLUsesTwoSpaceIndent(t *testing.T) {
+	existing := strings.TrimSpace(`
+root:
+    child: old
+`) + "\n"
+
+	desired := strings.TrimSpace(`
+root:
+  child: new
+`) + "\n"
+
+	output, err := MergeYAML([]byte(existing), []byte(desired))
+	require.NoError(t, err)
+
+	expected := strings.TrimSpace(`
+root:
+  child: new
+`) + "\n"
+	assert.Equal(t, expected, string(output))
+}
+
+func TestMergeYAMLPreservesTrailingComment(t *testing.T) {
+	existing := strings.TrimSpace(`
+profile: default
+# trailing comment
+`) + "\n"
+
+	desired := strings.TrimSpace(`
+profile: updated
+`) + "\n"
+
+	output, err := MergeYAML([]byte(existing), []byte(desired))
+	require.NoError(t, err)
+
+	expected := strings.TrimSpace(`
+profile: updated
+# trailing comment
+`) + "\n"
+	assert.Equal(t, expected, string(output))
+}
+
+func TestMergeYAMLPreservesInlineComment(t *testing.T) {
+	existing := strings.TrimSpace(`
+profile: default # inline note
+`) + "\n"
+
+	desired := strings.TrimSpace(`
+profile: updated
+`) + "\n"
+
+	output, err := MergeYAML([]byte(existing), []byte(desired))
+	require.NoError(t, err)
+
+	expected := strings.TrimSpace(`
+profile: updated # inline note
+`) + "\n"
+	assert.Equal(t, expected, string(output))
+}
+
+func TestMergeYAMLRemovesDroppedKeyComments(t *testing.T) {
+	existing := strings.TrimSpace(`
+profiles:
+  default:
+    token: old
+    # removed key comment
+    foobar: drop
+    type: cloud
+`) + "\n"
+
+	desired := strings.TrimSpace(`
+profiles:
+  default:
+    token: new
+    type: cloud
+`) + "\n"
+
+	output, err := MergeYAML([]byte(existing), []byte(desired))
+	require.NoError(t, err)
+
+	expected := strings.TrimSpace(`
+profiles:
+  default:
+    token: new
+    type: cloud
+`) + "\n"
+	assert.Equal(t, expected, string(output))
+}
+
+func TestMergeYAMLRemovesUnknownProfiles(t *testing.T) {
+	existing := strings.TrimSpace(`
+profile: dev
+profiles:
+  # hello world
+  dev:
+    controlplane: https://controlplane.unikraft.cloud
+    metros:
+    - country: xx # void
+      endpoint: http://api.ukp-stable.apw.unikraft.internal/
+      name: ukp-stable
+    organization: jedevc
+`) + "\n"
+
+	desired := strings.TrimSpace(`
+profile: prod
+profiles:
+  prod:
+    controlplane: https://controlplane.unikraft.cloud
+`) + "\n"
+
+	output, err := MergeYAML([]byte(existing), []byte(desired))
+	require.NoError(t, err)
+
+	expected := strings.TrimSpace(`
+profile: prod
+profiles:
+  prod:
+    controlplane: https://controlplane.unikraft.cloud
+`) + "\n"
+	assert.Equal(t, expected, string(output))
+}


### PR DESCRIPTION
Fixes https://linear.app/unikraft/issue/TOOL-592/streamline-quick-metroprofile-switching.

Mostly, this preserves comments. Whitespace isn't fully preserved sadly, this isn't preserved by the parser.

As reported by @jschlumpp here: https://discord.com/channels/879723098881028167/1448722316782735463/1473248133801709691.