### PR TITLE
feat: Add muxed logs

### DIFF
--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"golang.org/x/sync/errgroup"
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/cloud/sdk/platform/group"
 	"unikraft.com/x/kingkong"
@@ -27,6 +26,7 @@ import (
 	"unikraft.com/cli/internal/logs"
 	"unikraft.com/cli/internal/mirror"
 	"unikraft.com/cli/internal/multimetro"
+	"unikraft.com/cli/internal/muxreader"
 	"unikraft.com/cli/internal/resource"
 	"unikraft.com/cli/internal/resource/cmd"
 	"unikraft.com/cli/internal/resource/value"
@@ -736,24 +736,29 @@ func (cmd *InstancesLogsCmd) Run(ctx context.Context, stdio config.Stdio) error 
 		return err
 	}
 
-	eg, ctx := errgroup.WithContext(ctx)
+	mux := muxreader.New()
+	defer mux.Close()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	err = group.DoRefs(ctx, g, keys.Refs(), func(_ context.Context, c multimetro.MetroClient, refs group.Refs) (group.Refs, error) {
-		for _, key := range refs {
-			eg.Go(func() error {
-				r, err := logs.InstanceLogs(ctx, c).Reader(key.NameOrUUID(), cmd.Tail, cmd.Follow)
-				if err != nil {
-					return err
-				}
-				_, err = io.Copy(stdio.Stdout, r)
-				return err
-			})
+		for _, ref := range refs {
+			key := multimetro.Key(ref)
+			r, err := logs.InstanceLogs(ctx, c).Reader(ref.NameOrUUID(), cmd.Tail, cmd.Follow)
+			if err != nil {
+				return nil, err
+			}
+			mux.With(key.String(), r)
 		}
 		return refs, nil
 	})
 	if err != nil {
 		return err
 	}
-	err = eg.Wait()
+	mux.Seal()
+
+	_, err = io.Copy(stdio.Stdout, mux)
 	if cmd.Follow && errors.Is(err, context.Canceled) {
 		return nil
 	}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -11,10 +11,10 @@ import (
 	"fmt"
 	"io"
 
-	"golang.org/x/sync/errgroup"
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/logs"
 	"unikraft.com/cli/internal/multimetro"
+	"unikraft.com/cli/internal/muxreader"
 	"unikraft.com/cli/internal/resource"
 	"unikraft.com/cli/internal/resource/cmd"
 	"unikraft.com/cli/internal/resource/value"
@@ -181,6 +181,11 @@ func (c *RunCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.
 	}
 
 	if c.Follow {
+		fmt.Fprintln(stdio.Stdout)
+
+		mux := muxreader.New()
+		defer mux.Close()
+
 		keys := make(multimetro.Keys, 0, len(created))
 		for _, res := range created {
 			instance, ok := res.(Instance)
@@ -189,28 +194,31 @@ func (c *RunCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.
 			}
 			keys = append(keys, instance.key())
 		}
-		eg, ctx := errgroup.WithContext(ctx)
+
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
 		g, err := multimetro.NewClient(ctx)
 		if err != nil {
 			return err
 		}
 		err = group.DoRefs(ctx, g, keys.Refs(), func(_ context.Context, c multimetro.MetroClient, refs group.Refs) (group.Refs, error) {
-			for _, key := range refs {
-				eg.Go(func() error {
-					r, err := logs.InstanceLogs(ctx, c).Reader(key.NameOrUUID(), 0, true)
-					if err != nil {
-						return err
-					}
-					_, err = io.Copy(stdio.Stdout, r)
-					return err
-				})
+			for _, ref := range refs {
+				key := multimetro.Key(ref)
+				r, err := logs.InstanceLogs(ctx, c).Reader(ref.NameOrUUID(), 0, true)
+				if err != nil {
+					return nil, err
+				}
+				mux.With(key.String(), r)
 			}
 			return refs, nil
 		})
 		if err != nil {
 			return err
 		}
-		err = eg.Wait()
+		mux.Seal()
+
+		_, err = io.Copy(stdio.Stdout, mux)
 		if errors.Is(err, context.Canceled) {
 			return nil
 		}

--- a/internal/muxreader/muxreader.go
+++ b/internal/muxreader/muxreader.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package muxreader
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/charmbracelet/lipgloss"
+	"unikraft.com/x/colors"
+)
+
+type Mux struct {
+	*io.PipeReader
+	w      *io.PipeWriter
+	mu     sync.Mutex
+	width  int
+	last   string
+	sealed bool
+	wg     sync.WaitGroup
+	wOnce  sync.Once
+}
+
+var prefixStyle = lipgloss.NewStyle().Foreground(colors.Slate500).Faint(true)
+
+func New() *Mux {
+	r, w := io.Pipe()
+	return &Mux{PipeReader: r, w: w}
+}
+
+func (m *Mux) With(name string, r io.Reader) {
+	m.mu.Lock()
+	if m.sealed {
+		m.mu.Unlock()
+		panic("called after Seal")
+	}
+	m.width = max(m.width, len(name))
+	m.wg.Add(1)
+	m.mu.Unlock()
+	go m.run(name, r)
+}
+
+func (m *Mux) Seal() {
+	m.mu.Lock()
+	m.sealed = true
+	m.mu.Unlock()
+	go func() {
+		m.wg.Wait()
+		m.closeWriter(nil)
+	}()
+}
+
+func (m *Mux) Close() {
+	_ = m.PipeReader.Close()
+	m.closeWriter(io.ErrClosedPipe)
+}
+
+func (m *Mux) closeWriter(err error) {
+	m.wOnce.Do(func() {
+		if err != nil {
+			_ = m.w.CloseWithError(err)
+		} else {
+			_ = m.w.Close()
+		}
+	})
+}
+
+const (
+	markerNew  = '┏'
+	markerPipe = '│'
+)
+
+func (m *Mux) run(name string, r io.Reader) {
+	defer m.wg.Done()
+	br := bufio.NewReader(r)
+	for {
+		line, err := br.ReadBytes('\n')
+		if len(line) == 0 && err != nil {
+			return
+		}
+		if err == io.EOF && len(line) > 0 && line[len(line)-1] != '\n' {
+			line = append(line, '\n')
+		}
+
+		m.mu.Lock()
+		switched := name != m.last
+		m.last = name
+		width := m.width
+		m.mu.Unlock()
+
+		marker := markerPipe
+		if switched {
+			marker = markerNew
+		}
+		prefix := prefixStyle.Render(fmt.Sprintf("%*s %c ", width, name, marker))
+
+		_, werr := m.w.Write([]byte(prefix))
+		if werr == nil {
+			_, werr = m.w.Write(line)
+		}
+		if werr != nil {
+			return
+		}
+
+		if err != nil {
+			if err != io.EOF {
+				m.closeWriter(err)
+			}
+			return
+		}
+	}
+}

--- a/internal/muxreader/muxreader_test.go
+++ b/internal/muxreader/muxreader_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package muxreader
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/lunixbochs/vtclean"
+	"github.com/stretchr/testify/require"
+	"gotest.tools/v3/golden"
+)
+
+func TestMuxReader(t *testing.T) {
+	p1r, p1w := io.Pipe()
+	p2r, p2w := io.Pipe()
+	t.Cleanup(func() { _ = p1w.Close() })
+	t.Cleanup(func() { _ = p2w.Close() })
+
+	m := New()
+	m.With("foo", p1r)
+	m.With("test", p2r)
+	m.Seal()
+
+	r := bufio.NewReader(m)
+
+	var out bytes.Buffer
+	writeThenReadLine := func(w *io.PipeWriter, line string) {
+		t.Helper()
+		_, err := w.Write([]byte(line))
+		require.NoError(t, err)
+
+		gotLine, err := r.ReadString('\n')
+		require.NoError(t, err)
+		out.WriteString(gotLine)
+	}
+
+	writeThenReadLine(p1w, "one\n")
+	writeThenReadLine(p1w, "two\n")
+	writeThenReadLine(p2w, "three\n")
+	writeThenReadLine(p2w, "four\n")
+	writeThenReadLine(p1w, "five\n")
+
+	require.NoError(t, p1w.Close())
+	require.NoError(t, p2w.Close())
+	result, err := io.ReadAll(r)
+	require.NoError(t, err)
+	out.Write(result)
+
+	got := vtclean.Clean(out.String(), false)
+	golden.Assert(t, got, t.Name())
+}

--- a/internal/muxreader/testdata/TestMuxReader
+++ b/internal/muxreader/testdata/TestMuxReader
@@ -1,0 +1,5 @@
+ foo ┏ one
+ foo │ two
+test ┏ three
+test │ four
+ foo ┏ five


### PR DESCRIPTION
Fixes https://linear.app/unikraft/issue/TOOL-605/support-log-prefixing.

<img width="884" height="745" alt="image" src="https://github.com/user-attachments/assets/c10bcd31-f20c-4d4f-91e0-dbfeb724abc7" />

We use vertical bar characters, with a bold little angle character to indicate that the block has changed (since sometimes the names look very similar).