### PR TITLE
build: Handle recursive invocations of `task`

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,6 +22,10 @@ vars:
   svu_version: v3.2.3
   svu_bin: "{{.go_bin}} run github.com/caarlos0/svu/v3@{{.svu_version}}"
 
+  task_version: v3.48.0
+  task_bin:
+    sh: command -v task >/dev/null 2>&1 && echo "task --yes" || echo "{{.go_bin}} run github.com/go-task/task/v3/cmd/task@{{.task_version}} --yes"
+
 tasks:
   default:
     cmds:
@@ -127,7 +131,7 @@ tasks:
       if [[ "$NEXT" == *"staging"* ]]; then
         NEXT=$(echo "$NEXT" | awk -F. '{print $1 "." $2 "." $3 "." $4 + 1}')
       else
-        NEXT=$(PRERELEASE=staging.1 task next-stable)
+        NEXT=$(PRERELEASE=staging.1 {{.task_bin}} next-stable)
       fi
       echo $NEXT
 


### PR DESCRIPTION
Since `task` can be called without being installed, handle this
case additionally in the top-level Taskfile.

Signed-off-by: Alexander Jung <alex@unikraft.com>
