### PR TITLE
feat: Add flags for sorting asc/desc resource items

### DIFF
--- a/cmd/unikraft/testdata/TestGolden/auth/help
+++ b/cmd/unikraft/testdata/TestGolden/auth/help
@@ -184,6 +184,8 @@ stdout:
 	          Filter output based on a field value (e.g. --filter state==running).
 	  -w, --watch
 	          Watch for changes and refresh output.
+	      --sort
+	          Sort output by field values (e.g. --sort name,-timestamps.created-at). Use - prefix for descending, + for ascending.
 	  -f, --field
 	          Specify which fields to include in the output.
 	  -o, --output
@@ -360,6 +362,8 @@ stdout:
 	          Filter output based on a field value (e.g. --filter state==running).
 	  -w, --watch
 	          Watch for changes and refresh output.
+	      --sort
+	          Sort output by field values (e.g. --sort name,-timestamps.created-at). Use - prefix for descending, + for ascending.
 	  -f, --field
 	          Specify which fields to include in the output.
 	  -o, --output

--- a/cmd/unikraft/testdata/TestGolden/certificates/help
+++ b/cmd/unikraft/testdata/TestGolden/certificates/help
@@ -143,6 +143,8 @@ stdout:
 	          Filter output based on a field value (e.g. --filter state==running).
 	  -w, --watch
 	          Watch for changes and refresh output.
+	      --sort
+	          Sort output by field values (e.g. --sort name,-timestamps.created-at). Use - prefix for descending, + for ascending.
 	  -f, --field
 	          Specify which fields to include in the output.
 	  -o, --output

--- a/cmd/unikraft/testdata/TestGolden/images/help
+++ b/cmd/unikraft/testdata/TestGolden/images/help
@@ -122,6 +122,8 @@ stdout:
 	          Filter output based on a field value (e.g. --filter state==running).
 	  -w, --watch
 	          Watch for changes and refresh output.
+	      --sort
+	          Sort output by field values (e.g. --sort name,-timestamps.created-at). Use - prefix for descending, + for ascending.
 	  -f, --field
 	          Specify which fields to include in the output.
 	  -o, --output

--- a/cmd/unikraft/testdata/TestGolden/instances/help
+++ b/cmd/unikraft/testdata/TestGolden/instances/help
@@ -192,6 +192,8 @@ stdout:
 	          Filter output based on a field value (e.g. --filter state==running).
 	  -w, --watch
 	          Watch for changes and refresh output.
+	      --sort
+	          Sort output by field values (e.g. --sort name,-timestamps.created-at). Use - prefix for descending, + for ascending.
 	  -f, --field
 	          Specify which fields to include in the output.
 	  -o, --output

--- a/cmd/unikraft/testdata/TestGolden/services/help
+++ b/cmd/unikraft/testdata/TestGolden/services/help
@@ -142,6 +142,8 @@ stdout:
 	          Filter output based on a field value (e.g. --filter state==running).
 	  -w, --watch
 	          Watch for changes and refresh output.
+	      --sort
+	          Sort output by field values (e.g. --sort name,-timestamps.created-at). Use - prefix for descending, + for ascending.
 	  -f, --field
 	          Specify which fields to include in the output.
 	  -o, --output

--- a/cmd/unikraft/testdata/TestGolden/volumes/help
+++ b/cmd/unikraft/testdata/TestGolden/volumes/help
@@ -144,6 +144,8 @@ stdout:
 	          Filter output based on a field value (e.g. --filter state==running).
 	  -w, --watch
 	          Watch for changes and refresh output.
+	      --sort
+	          Sort output by field values (e.g. --sort name,-timestamps.created-at). Use - prefix for descending, + for ascending.
 	  -f, --field
 	          Specify which fields to include in the output.
 	  -o, --output

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -127,9 +127,10 @@ type FormatOpts struct {
 }
 
 type ResourceListCmd[R resource.GettableListableResource] struct {
-	Name   []string       `arg:"" optional:"" completion-predictor:"resource-key-${name}" help:"Names of the ${names} to list."`
-	Filter []string       `help:"Filter output based on a field value (e.g. --filter state==running)." sep:"none"`
-	Watch  *time.Duration `short:"w" help:"Watch for changes and refresh output." type:"optional"`
+	Name   []string            `arg:"" optional:"" completion-predictor:"resource-key-${name}" help:"Names of the ${names} to list."`
+	Filter []string            `help:"Filter output based on a field value (e.g. --filter state==running)." sep:"none"`
+	Watch  *time.Duration      `short:"w" help:"Watch for changes and refresh output." type:"optional"`
+	Sort   xkong.GreedyStrings `help:"Sort output by field values (e.g. --sort name,-timestamps.created-at). Use - prefix for descending, + for ascending."`
 
 	FormatOpts
 
@@ -162,6 +163,12 @@ func (cmd *ResourceListCmd[R]) Run(ctx context.Context, stdio config.Stdio, sand
 
 	ctx = resource.WithFilter(ctx, filter)
 
+	// Parse sort configuration
+	sortSpecs, err := parseSortSpecs(cmd.Sort...)
+	if err != nil {
+		return err
+	}
+
 	var empty R
 	render := func(out io.Writer) error {
 		var resources []resource.Resource
@@ -179,6 +186,12 @@ func (cmd *ResourceListCmd[R]) Run(ctx context.Context, stdio config.Stdio, sand
 		resources, err = filterResources(ctx, resources, filter)
 		if err != nil {
 			return err
+		}
+		if len(sortSpecs) > 0 {
+			resources, err = sortResources(ctx, resources, sortSpecs)
+			if err != nil {
+				return err
+			}
 		}
 		return cmd.Output.
 			WithDefault(PrinterTypeTable).

--- a/internal/resource/cmd/cmd_test.go
+++ b/internal/resource/cmd/cmd_test.go
@@ -150,6 +150,229 @@ func TestList(t *testing.T) {
 		assert.Contains(t, output, "test1")
 		assert.NotContains(t, output, "test2")
 	})
+
+	t.Run("sort-asc", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := &ResourceListCmd[resourcet.TestResource]{
+			Sort: xkong.GreedyStrings{"name"},
+			FormatOpts: FormatOpts{
+				Output: Printer{Type: PrinterTypeQuiet},
+			},
+		}
+		err := cmd.Run(ctx, testStdio(&out), sandbox)
+		require.NoError(t, err)
+
+		output := out.String()
+		assert.Equal(t, "test1\ntest2\n", output)
+	})
+
+	t.Run("sort-asc-explicit", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := &ResourceListCmd[resourcet.TestResource]{
+			Sort: xkong.GreedyStrings{"+name"},
+			FormatOpts: FormatOpts{
+				Output: Printer{Type: PrinterTypeQuiet},
+			},
+		}
+		err := cmd.Run(ctx, testStdio(&out), sandbox)
+		require.NoError(t, err)
+
+		output := out.String()
+		assert.Equal(t, "test1\ntest2\n", output)
+	})
+
+	t.Run("sort-desc", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := &ResourceListCmd[resourcet.TestResource]{
+			Sort: xkong.GreedyStrings{"-name"},
+			FormatOpts: FormatOpts{
+				Output: Printer{Type: PrinterTypeQuiet},
+			},
+		}
+		err := cmd.Run(ctx, testStdio(&out), sandbox)
+		require.NoError(t, err)
+
+		output := out.String()
+		assert.Equal(t, "test2\ntest1\n", output)
+	})
+
+	t.Run("sort-asc-nested", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := &ResourceListCmd[resourcet.TestResource]{
+			Sort: xkong.GreedyStrings{"settings.y"},
+			FormatOpts: FormatOpts{
+				Output: Printer{Type: PrinterTypeQuiet},
+			},
+		}
+		err := cmd.Run(ctx, testStdio(&out), sandbox)
+		require.NoError(t, err)
+
+		// test1 has settings.y="hello", test2 has settings.y="world"
+		// ascending: "hello" < "world", so test1 comes first
+		output := out.String()
+		assert.Equal(t, "test1\ntest2\n", output)
+	})
+
+	t.Run("sort-desc-nested", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := &ResourceListCmd[resourcet.TestResource]{
+			Sort: xkong.GreedyStrings{"-settings.y"},
+			FormatOpts: FormatOpts{
+				Output: Printer{Type: PrinterTypeQuiet},
+			},
+		}
+		err := cmd.Run(ctx, testStdio(&out), sandbox)
+		require.NoError(t, err)
+
+		// test1 has settings.y="hello", test2 has settings.y="world"
+		// descending: "world" > "hello", so test2 comes first
+		output := out.String()
+		assert.Equal(t, "test2\ntest1\n", output)
+	})
+
+	t.Run("sort-multi-field", func(t *testing.T) {
+		var out bytes.Buffer
+		// Both test1 and test2 have state="pending", so sort by state first,
+		// then by name descending to break the tie
+		cmd := &ResourceListCmd[resourcet.TestResource]{
+			Sort: xkong.GreedyStrings{"state", "-name"},
+			FormatOpts: FormatOpts{
+				Output: Printer{Type: PrinterTypeQuiet},
+			},
+		}
+		err := cmd.Run(ctx, testStdio(&out), sandbox)
+		require.NoError(t, err)
+
+		// Both have same state, so secondary sort by -name means test2 first
+		output := out.String()
+		assert.Equal(t, "test2\ntest1\n", output)
+	})
+
+	t.Run("sort-multi-field-mixed", func(t *testing.T) {
+		var out bytes.Buffer
+		// Sort by state ascending, then by settings.x ascending
+		// test1 has settings.x=42, test2 has settings.x=7
+		cmd := &ResourceListCmd[resourcet.TestResource]{
+			Sort: xkong.GreedyStrings{"+state", "settings.x"},
+			FormatOpts: FormatOpts{
+				Output: Printer{Type: PrinterTypeQuiet},
+			},
+		}
+		err := cmd.Run(ctx, testStdio(&out), sandbox)
+		require.NoError(t, err)
+
+		// Both have same state, secondary sort by settings.x asc: 7 < 42, so test2 first
+		output := out.String()
+		assert.Equal(t, "test2\ntest1\n", output)
+	})
+}
+
+func TestParseSortSpecs(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []SortSpec
+		wantErr  bool
+	}{
+		{
+			name:     "empty string",
+			input:    []string{""},
+			expected: []SortSpec{},
+		},
+		{
+			name:  "single field ascending implicit",
+			input: []string{"name"},
+			expected: []SortSpec{
+				{Path: resource.ParseFieldPath("name"), Descending: false},
+			},
+		},
+		{
+			name:  "single field ascending explicit",
+			input: []string{"+name"},
+			expected: []SortSpec{
+				{Path: resource.ParseFieldPath("name"), Descending: false},
+			},
+		},
+		{
+			name:  "single field descending",
+			input: []string{"-name"},
+			expected: []SortSpec{
+				{Path: resource.ParseFieldPath("name"), Descending: true},
+			},
+		},
+		{
+			name:  "nested field",
+			input: []string{"timing.uptime"},
+			expected: []SortSpec{
+				{Path: resource.ParseFieldPath("timing.uptime"), Descending: false},
+			},
+		},
+		{
+			name:  "nested field descending",
+			input: []string{"-timing.uptime"},
+			expected: []SortSpec{
+				{Path: resource.ParseFieldPath("timing.uptime"), Descending: true},
+			},
+		},
+		{
+			name:  "multiple fields",
+			input: []string{"state", "name"},
+			expected: []SortSpec{
+				{Path: resource.ParseFieldPath("state"), Descending: false},
+				{Path: resource.ParseFieldPath("name"), Descending: false},
+			},
+		},
+		{
+			name:  "multiple fields mixed directions",
+			input: []string{"state", "-timing.uptime"},
+			expected: []SortSpec{
+				{Path: resource.ParseFieldPath("state"), Descending: false},
+				{Path: resource.ParseFieldPath("timing.uptime"), Descending: true},
+			},
+		},
+		{
+			name:  "multiple fields with explicit prefix",
+			input: []string{"+state", "-name", "+id"},
+			expected: []SortSpec{
+				{Path: resource.ParseFieldPath("state"), Descending: false},
+				{Path: resource.ParseFieldPath("name"), Descending: true},
+				{Path: resource.ParseFieldPath("id"), Descending: false},
+			},
+		},
+		{
+			name:  "with spaces",
+			input: []string{" state ", " -name "},
+			expected: []SortSpec{
+				{Path: resource.ParseFieldPath("state"), Descending: false},
+				{Path: resource.ParseFieldPath("name"), Descending: true},
+			},
+		},
+		{
+			name:    "empty field name",
+			input:   []string{"-"},
+			wantErr: true,
+		},
+		{
+			name:  "empty field in list",
+			input: []string{"state", "", "name"},
+			expected: []SortSpec{
+				{Path: resource.ParseFieldPath("state"), Descending: false},
+				{Path: resource.ParseFieldPath("name"), Descending: false},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			specs, err := parseSortSpecs(tt.input...)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, specs)
+		})
+	}
 }
 
 func TestListOutput(t *testing.T) {

--- a/internal/resource/cmd/sort.go
+++ b/internal/resource/cmd/sort.go
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+	"unikraft.com/cli/internal/resource"
+)
+
+// SortSpec represents a single field sort specification with direction.
+type SortSpec struct {
+	Path       resource.FieldPath
+	Descending bool
+}
+
+// parseSortSpecs parses a comma-separated list of sort specifications.
+// Each spec can be prefixed with - for descending or + for ascending (default).
+// Examples:
+//   - "name" or "+name" -> ascending by name
+//   - "-name" -> descending by name
+//   - "state,-timing.uptime" -> ascending by state, then descending by uptime
+func parseSortSpecs(inputs ...string) ([]SortSpec, error) {
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+
+	specs := make([]SortSpec, 0, len(inputs))
+
+	for _, part := range inputs {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		var descending bool
+		fieldName := part
+
+		if after, found := strings.CutPrefix(part, "-"); found {
+			descending = true
+			fieldName = after
+		} else if after, found := strings.CutPrefix(part, "+"); found {
+			fieldName = after
+		}
+
+		if fieldName == "" {
+			return nil, fmt.Errorf("empty field name in sort specification")
+		}
+
+		specs = append(specs, SortSpec{
+			Path:       resource.ParseFieldPath(fieldName),
+			Descending: descending,
+		})
+	}
+
+	return specs, nil
+}
+
+// sortResources sorts resources by multiple field values specified by the sort
+// specs.  Each spec includes a path and whether to sort descending.  Resources
+// are sorted by the first spec, then ties are broken by subsequent specs.
+func sortResources(ctx context.Context, resources []resource.Resource, specs []SortSpec) ([]resource.Resource, error) {
+	if len(specs) == 0 {
+		return resources, nil
+	}
+	if len(resources) == 0 {
+		return resources, nil
+	}
+
+	// Validate all sort paths up-front against the resource's field schema.
+	schemaFields, err := resources[0].Fields()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get fields for validation: %w", err)
+	}
+	for _, spec := range specs {
+		_, missing := resource.FilterFieldsByPath(schemaFields, []resource.FieldPath{spec.Path}, false)
+		if len(missing) > 0 {
+			return nil, fmt.Errorf("unknown sort field: %s", spec.Path)
+		}
+	}
+
+	// Collect all paths for resolution
+	paths := make([]resource.FieldPath, len(specs))
+	for i, spec := range specs {
+		paths[i] = spec.Path
+	}
+
+	// Pre-resolve field values for sorting
+	type resourceWithValues struct {
+		res    resource.Resource
+		values []any
+	}
+
+	items := make([]resourceWithValues, len(resources))
+
+	g, ctx := errgroup.WithContext(ctx)
+	for i, res := range resources {
+		items[i].res = res
+		items[i].values = make([]any, len(specs))
+		g.Go(func() error {
+			fields, err := res.Fields()
+			if err != nil {
+				return fmt.Errorf("failed to get fields for resource %s: %w", res.Key(), err)
+			}
+
+			// Resolve callbacks for all sort fields
+			fields, err = resolveFields(ctx, fields, paths)
+			if err != nil {
+				return err
+			}
+
+			for j, spec := range specs {
+				matched := resource.GetFieldByPath(fields, spec.Path)
+				if len(matched) == 0 {
+					return fmt.Errorf("sort field %s not found for resource %s", spec.Path, res.Key())
+				}
+				if len(matched) > 1 {
+					return fmt.Errorf("sort field %s is ambiguous for resource %s (matched %d fields)", spec.Path, res.Key(), len(matched))
+				}
+				items[i].values[j] = matched[0].Value
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	// Sort by the extracted field values using type-aware comparison
+	// Apply sort specs in order (first spec is primary, subsequent break ties)
+	slices.SortStableFunc(items, func(a, b resourceWithValues) int {
+		for i, spec := range specs {
+			result := resource.CompareFieldValues(a.values[i], b.values[i])
+			if result != 0 {
+				if spec.Descending {
+					return -result
+				}
+				return result
+			}
+		}
+		return 0
+	})
+
+	// Extract sorted resources
+	sorted := make([]resource.Resource, len(items))
+	for i, item := range items {
+		sorted[i] = item.res
+	}
+	return sorted, nil
+}

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -173,3 +173,9 @@ func (v FieldVerbosity) String() string {
 func (v FieldVerbosity) MarshalJSON() ([]byte, error) {
 	return fmt.Appendf(nil, `%q`, v.String()), nil
 }
+
+// CompareFieldValues compares two field values in a type-aware manner.
+// It returns -1 if a < b, 0 if a == b, and 1 if a > b.
+func CompareFieldValues(a, b any) int {
+	return value.Compare(a, b)
+}

--- a/internal/resource/value/compare.go
+++ b/internal/resource/value/compare.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package value
+
+import (
+	"cmp"
+	"fmt"
+	"reflect"
+	"time"
+)
+
+// Compare compares two values in a type-aware manner.
+//
+// It returns -1 if a < b, 0 if a == b, and 1 if a > b.
+//
+// When possible, it performs type-specific or kind-based comparisons (including
+// for numeric, string, bool, and time-related types, even if they are different
+// named types with compatible underlying kinds). If it cannot perform a
+// type-aware comparison, it falls back to comparing the string representations
+// of the values.
+func Compare(a, b any) int {
+	// Unwrap wrapped values
+	a = unwrap(a)
+	b = unwrap(b)
+
+	// Handle nil cases
+	if a == nil && b == nil {
+		return 0
+	}
+	if a == nil {
+		return -1
+	}
+	if b == nil {
+		return 1
+	}
+
+	// Try type-specific comparisons
+	switch av := a.(type) {
+	case time.Time:
+		if bv, ok := b.(time.Time); ok {
+			return av.Compare(bv)
+		}
+	case *time.Time:
+		if bv, ok := b.(*time.Time); ok {
+			if av == nil && bv == nil {
+				return 0
+			}
+			if av == nil {
+				return -1
+			}
+			if bv == nil {
+				return 1
+			}
+			return av.Compare(*bv)
+		}
+	case time.Duration:
+		if bv, ok := b.(time.Duration); ok {
+			return cmp.Compare(av, bv)
+		}
+	case int:
+		if bv, ok := b.(int); ok {
+			return cmp.Compare(av, bv)
+		}
+	case int8:
+		if bv, ok := b.(int8); ok {
+			return cmp.Compare(av, bv)
+		}
+	case int16:
+		if bv, ok := b.(int16); ok {
+			return cmp.Compare(av, bv)
+		}
+	case int32:
+		if bv, ok := b.(int32); ok {
+			return cmp.Compare(av, bv)
+		}
+	case int64:
+		if bv, ok := b.(int64); ok {
+			return cmp.Compare(av, bv)
+		}
+	case uint:
+		if bv, ok := b.(uint); ok {
+			return cmp.Compare(av, bv)
+		}
+	case uint8:
+		if bv, ok := b.(uint8); ok {
+			return cmp.Compare(av, bv)
+		}
+	case uint16:
+		if bv, ok := b.(uint16); ok {
+			return cmp.Compare(av, bv)
+		}
+	case uint32:
+		if bv, ok := b.(uint32); ok {
+			return cmp.Compare(av, bv)
+		}
+	case uint64:
+		if bv, ok := b.(uint64); ok {
+			return cmp.Compare(av, bv)
+		}
+	case float32:
+		if bv, ok := b.(float32); ok {
+			return cmp.Compare(av, bv)
+		}
+	case float64:
+		if bv, ok := b.(float64); ok {
+			return cmp.Compare(av, bv)
+		}
+	case string:
+		if bv, ok := b.(string); ok {
+			return cmp.Compare(av, bv)
+		}
+	case bool:
+		if bv, ok := b.(bool); ok {
+			// false < true
+			if av == bv {
+				return 0
+			}
+			if !av && bv {
+				return -1
+			}
+			return 1
+		}
+	}
+
+	// Try reflection-based comparison for underlying types
+	if result, ok := compareReflect(a, b); ok {
+		return result
+	}
+
+	// Fall back to string comparison
+	aStr, err := Format(a)
+	if err != nil {
+		aStr = fmt.Sprint(a)
+	}
+	bStr, err := Format(b)
+	if err != nil {
+		bStr = fmt.Sprint(b)
+	}
+	return cmp.Compare(aStr, bStr)
+}
+
+// unwrap recursively unwraps wrapped values.
+func unwrap(v any) any {
+	for {
+		wrapped, ok := v.(Wrapped)
+		if !ok {
+			break
+		}
+		v = wrapped.Unwrap()
+	}
+	return v
+}
+
+// compareReflect attempts to compare values using reflection.
+// It handles cases where the underlying type is comparable but wrapped in a custom type.
+func compareReflect(a, b any) (int, bool) {
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+
+	// Dereference pointers
+	for av.Kind() == reflect.Pointer && !av.IsNil() {
+		av = av.Elem()
+	}
+	for bv.Kind() == reflect.Pointer && !bv.IsNil() {
+		bv = bv.Elem()
+	}
+
+	// Handle pointer nil cases after dereferencing
+	if av.Kind() == reflect.Pointer && av.IsNil() {
+		if bv.Kind() == reflect.Pointer && bv.IsNil() {
+			return 0, true
+		}
+		return -1, true
+	}
+	if bv.Kind() == reflect.Pointer && bv.IsNil() {
+		return 1, true
+	}
+
+	// Check if underlying type is time.Time
+	if av.Type().ConvertibleTo(reflect.TypeFor[time.Time]()) && bv.Type().ConvertibleTo(reflect.TypeFor[time.Time]()) {
+		at := av.Convert(reflect.TypeFor[time.Time]()).Interface().(time.Time)
+		bt := bv.Convert(reflect.TypeFor[time.Time]()).Interface().(time.Time)
+		return at.Compare(bt), true
+	}
+
+	// Check if underlying type is time.Duration
+	if av.Type().ConvertibleTo(reflect.TypeFor[time.Duration]()) && bv.Type().ConvertibleTo(reflect.TypeFor[time.Duration]()) {
+		ad := av.Convert(reflect.TypeFor[time.Duration]()).Interface().(time.Duration)
+		bd := bv.Convert(reflect.TypeFor[time.Duration]()).Interface().(time.Duration)
+		return cmp.Compare(ad, bd), true
+	}
+
+	// Handle numeric types with same underlying kind
+	if av.Kind() == bv.Kind() {
+		switch av.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return cmp.Compare(av.Int(), bv.Int()), true
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return cmp.Compare(av.Uint(), bv.Uint()), true
+		case reflect.Float32, reflect.Float64:
+			return cmp.Compare(av.Float(), bv.Float()), true
+		case reflect.String:
+			return cmp.Compare(av.String(), bv.String()), true
+		case reflect.Bool:
+			ab, bb := av.Bool(), bv.Bool()
+			if ab == bb {
+				return 0, true
+			}
+			if !ab && bb {
+				return -1, true
+			}
+			return 1, true
+		}
+	}
+
+	return 0, false
+}


### PR DESCRIPTION
Add a `--sort` flag for resource listings that supports:
- Prefix notation for direction: -field (descending), +field or field (ascending);
- Multiple comma-separated fields for multi-level sorting; and,
- Mixed ascending/descending in a single sort specification.

Examples:
```
  --sort name                   # ascending by name
  --sort -name                  # descending by name
  --sort state,timing.uptime    # by state, then uptime
  --sort state,-timing.uptime   # ascending state, descending uptime
```

This mirrors the `--field` selection syntax and enables expressive sorting of resource output.
