### PR TITLE
docs: Restore info on manual profile creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,25 @@ This opens your browser for authentication. Alternatively, provide a token file:
 unikraft login --token /path/to/token
 ```
 
+Or, if you need to directly specify a metro endpoint, you can manually create a
+profile:
+
+```yaml
+# Linux: ~/.config/unikraft/config.yaml
+# MacOS: ~/Library/Application\ Support/unikraft/config.yaml
+profile: default
+profiles:
+  default:
+    type: cloud
+    organization: <org-name>
+    token: <api-token>
+    metros:
+      - name: <metro-name>         # e.g. fra
+        endpoint: <metro-endpoint> # e.g. https://api.fra.unikraft.cloud
+        country: <metro-country>   # e.g. de
+        insecure: false            # skip tls verification (avoid for production use)
+```
+
 ### 2. Deploy Your First Instance
 
 ```sh


### PR DESCRIPTION
This was deleted as part of https://github.com/unikraft/cli/pull/170.

We should keep this info. I was linking internally to folks who had manually deployed metros. The file *is* designed to be human readable + editable, so I think it's fine to mention here.