### PR TITLE
chore: Allow task unit

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -45,7 +45,8 @@ tasks:
     cmds:
       - task: go:lint
 
-  test:
+  unit:
+    aliases: [test]
     desc: Run unit tests.
     silent: true
     cmds:


### PR DESCRIPTION
Muscle memory tells me that since `task integration` is a thing, then so should `task unit`.