### PR TITLE
feat: New `--dangling` flag for `unikraft image list`

### DIFF
--- a/cmd/unikraft/testdata/TestGolden/images/help
+++ b/cmd/unikraft/testdata/TestGolden/images/help
@@ -126,6 +126,8 @@ stdout:
 	          Specify which fields to include in the output.
 	  -o, --output
 	          Output format. One of: kv, table, json, yaml, raw, quiet, template.
+	      --dangling
+	          Include dangling images with no tags.
 
 	Global flags:
 	  -h, --help

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -258,9 +258,9 @@ func (ImageEntry) load(image platform.Image, metro *config.Metro, allowDangling 
 	if err != nil {
 		return nil, fmt.Errorf("could not parse image ref %q: %w", *image.Digest, err)
 	}
-	baseDigested, ok := base.(reference.Digested)
-	if !ok {
-		return nil, fmt.Errorf("image ref %q is not digested", *image.Digest)
+	var baseDigest digest.Digest
+	if baseDigested, ok := base.(reference.Digested); ok {
+		baseDigest = baseDigested.Digest()
 	}
 	base = reference.TrimNamed(base)
 
@@ -270,16 +270,19 @@ func (ImageEntry) load(image platform.Image, metro *config.Metro, allowDangling 
 		if err != nil {
 			return nil, fmt.Errorf("could not create dangling image tag: %w", err)
 		}
-		canonical, err := reference.WithDigest(ref, baseDigested.Digest())
-		if err != nil {
-			return nil, fmt.Errorf("could not create dangling image canonical reference: %w", err)
+		var canonical reference.Canonical
+		if baseDigest != "" {
+			canonical, err = reference.WithDigest(ref, baseDigest)
+			if err != nil {
+				return nil, fmt.Errorf("could not create dangling image canonical reference: %w", err)
+			}
 		}
 
 		result := ImageEntry{
 			Image:     image,
 			Metro:     metro,
 			Canonical: canonical,
-			Digest:    baseDigested.Digest(),
+			Digest:    baseDigest,
 			Dangling:  true,
 		}
 		err = mirror.Mirror(result, &result)
@@ -320,7 +323,7 @@ func (ImageEntry) load(image platform.Image, metro *config.Metro, allowDangling 
 
 	results := make([]ImageEntry, 0, len(image.Tags))
 	for _, tag := range tagged {
-		canonical, err := reference.WithDigest(tag, baseDigested.Digest())
+		canonical, err := reference.WithDigest(tag, baseDigest)
 		if err != nil {
 			return nil, fmt.Errorf("could not create dangling image canonical reference: %w", err)
 		}
@@ -329,7 +332,7 @@ func (ImageEntry) load(image platform.Image, metro *config.Metro, allowDangling 
 			Image:     image,
 			Metro:     metro,
 			Canonical: canonical,
-			Digest:    baseDigested.Digest(),
+			Digest:    baseDigest,
 		}
 		err = mirror.Mirror(result, &result)
 		if err != nil {

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/containerd/containerd/v2/pkg/filters"
 	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
 	"github.com/opencontainers/go-digest"
@@ -34,10 +35,25 @@ import (
 
 type ImagesCmd struct {
 	cmd.ResourceCmd[ImageEntry]
-	cmd.GettableResourceCmd[Image]      `set:"name=image" set:"names=images"`
-	cmd.ListableResourceCmd[ImageEntry] `set:"name=image" set:"names=images"`
+	cmd.GettableResourceCmd[Image] `set:"name=image" set:"names=images"`
+
+	List ImagesListCmd `cmd:"" set:"name=image" set:"names=images" help:"List images." aliases:"ls"`
 
 	Copy ImagesCopyCmd `cmd:"" help:"Copy images."`
+}
+
+// ImagesListCmd extends the generic ResourceListCmd with a --dangling flag
+// to show dangling images that are hidden by default.
+type ImagesListCmd struct {
+	cmd.ResourceListCmd[ImageEntry]
+	Dangling bool `help:"Include dangling images with no tags."`
+}
+
+func (c *ImagesListCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox) error {
+	if !c.Dangling {
+		c.DefaultFilter, _ = filters.Parse("dangling==false")
+	}
+	return c.ResourceListCmd.Run(ctx, stdio, sandbox)
 }
 
 type Image struct {
@@ -191,7 +207,7 @@ func (ImageEntry) List(ctx context.Context) ([]resource.Resource, error) {
 		}
 		var results []resource.Resource
 		for _, image := range resp.Data.Images {
-			result, err := ImageEntry{}.load(image, &c.Metro, false)
+			result, err := ImageEntry{}.load(image, &c.Metro)
 			if err != nil {
 				return nil, err
 			}
@@ -232,7 +248,7 @@ func (ImageEntry) Get(ctx context.Context, keys []string) ([]resource.Resource, 
 		var found []group.Ref
 		var results []resource.Resource
 		for _, image := range resp.Data.Images {
-			result, err := ImageEntry{}.load(image, &c.Metro, true)
+			result, err := ImageEntry{}.load(image, &c.Metro)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -250,7 +266,7 @@ func (ImageEntry) Get(ctx context.Context, keys []string) ([]resource.Resource, 
 	})
 }
 
-func (ImageEntry) load(image platform.Image, metro *config.Metro, allowDangling bool) ([]ImageEntry, error) {
+func (ImageEntry) load(image platform.Image, metro *config.Metro) ([]ImageEntry, error) {
 	if image.Digest == nil {
 		return nil, fmt.Errorf("image has no digest")
 	}
@@ -264,7 +280,7 @@ func (ImageEntry) load(image platform.Image, metro *config.Metro, allowDangling 
 	}
 	base = reference.TrimNamed(base)
 
-	if len(image.Tags) == 0 && allowDangling {
+	if len(image.Tags) == 0 {
 		// Allow for dangling images (images with no tags)
 		ref, err := reference.WithTag(base, "latest")
 		if err != nil {

--- a/internal/multimetro/filter.go
+++ b/internal/multimetro/filter.go
@@ -14,7 +14,7 @@ import (
 )
 
 func filterMetrosFromContext(ctx context.Context, metros []config.Metro) []config.Metro {
-	spec := resource.FilterFromContext(ctx, metros)
+	spec := resource.FilterFromContext(ctx)
 	return filterMetros(metros, spec)
 }
 

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -120,6 +120,11 @@ type ResourceListCmd[R resource.GettableListableResource] struct {
 	Watch  *time.Duration `short:"w" help:"Watch for changes and refresh output." type:"optional"`
 
 	FormatOpts
+
+	// DefaultFilter is applied when listing.
+	// HACK: not perfect, but lets other commands extend this one easily without
+	// needing weirder runtime introspection
+	DefaultFilter filters.Filter `kong:"-"`
 }
 
 func (cmd ResourceListCmd[R]) HelpSections() []kingkong.HelpSection {
@@ -139,10 +144,13 @@ func (cmd *ResourceListCmd[R]) Run(ctx context.Context, stdio config.Stdio, sand
 	if err != nil {
 		return err
 	}
+	if cmd.DefaultFilter != nil {
+		filter = filters.All{cmd.DefaultFilter, filter}
+	}
+
 	ctx = resource.WithFilter(ctx, filter)
 
 	var empty R
-
 	render := func(out io.Writer) error {
 		var resources []resource.Resource
 		var err error

--- a/internal/resource/ctx.go
+++ b/internal/resource/ctx.go
@@ -9,8 +9,6 @@ import (
 	"context"
 
 	"github.com/containerd/containerd/v2/pkg/filters"
-
-	"unikraft.com/cli/internal/config"
 )
 
 type contextKeyFilters struct{}
@@ -19,7 +17,7 @@ func WithFilter(ctx context.Context, spec filters.Filter) context.Context {
 	return context.WithValue(ctx, contextKeyFilters{}, spec)
 }
 
-func FilterFromContext(ctx context.Context, metros []config.Metro) filters.Filter {
+func FilterFromContext(ctx context.Context) filters.Filter {
 	spec, ok := ctx.Value(contextKeyFilters{}).(filters.Filter)
 	if ok {
 		return spec


### PR DESCRIPTION
We weren't really allowing list dangling images in any way. This now adds a `--dangling` flag that lets the user do this.

Also, some metros (staging) are producing some odd output. These are wrong, and need fixing, but we shouldn't completely fail out on this, we just should discard the digest.