### PR TITLE
fix: Allow editing scale-to-zero

### DIFF
--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -201,9 +201,9 @@ func (v *InstanceVolume) UnmarshalText(data []byte) error {
 
 type InstanceScaleToZero struct {
 	Enabled      bool   `mirror:"enabled" field:",long"`
-	Policy       string `mirror:"policy" field:",long" create:"set"`
-	Stateful     bool   `mirror:"stateful" field:",long" create:"set"`
-	CooldownTime int64  `mirror:"cooldown_time_ms" field:",long" create:"set"`
+	Policy       string `mirror:"policy" field:",long" create:"set" edit:"set"`
+	Stateful     bool   `mirror:"stateful" field:",long" create:"set" edit:"set"`
+	CooldownTime int64  `mirror:"cooldown_time_ms" field:",long" create:"set" edit:"set"`
 }
 
 func (Instance) Type() resource.Type {
@@ -458,6 +458,12 @@ func instancePatchSpec(path string, op patchOp, value any) (platform.UpdateInsta
 		return platform.UpdateInstancesRequestItemPropMemory_mb, int64(value.(types.SizeMebibytes))
 	case "resources.vcpus":
 		return platform.UpdateInstancesRequestItemPropVcpus, value.(int)
+	case "scale-to-zero.policy":
+		return platform.UpdateInstancesRequestItemPropScale_to_zero, map[string]any{"policy": value.(string)}
+	case "scale-to-zero.stateful":
+		return platform.UpdateInstancesRequestItemPropScale_to_zero, map[string]any{"stateful": value.(bool)}
+	case "scale-to-zero.cooldown-time":
+		return platform.UpdateInstancesRequestItemPropScale_to_zero, map[string]any{"cooldown_time_ms": int32(value.(int64))}
 	default:
 		return zero, nil
 	}

--- a/internal/cmd/util.go
+++ b/internal/cmd/util.go
@@ -8,6 +8,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"unikraft.com/cli/internal/resource"
 )
@@ -62,6 +63,19 @@ func patchRequests[P ~string](fields []resource.Field, specFor func(path string,
 		prop, converted := specFor(path, op, value)
 		if converted == nil {
 			return
+		}
+		// If the converted value is a map, try to merge it with an existing
+		// patch for the same prop/op. This allows multiple fields to be
+		// aggregated into a single patch request.
+		if m, ok := converted.(map[string]any); ok {
+			for i := range reqs {
+				if reqs[i].Prop == prop && reqs[i].Op == op {
+					if existing, ok := reqs[i].Value.(map[string]any); ok {
+						maps.Copy(existing, m)
+						return
+					}
+				}
+			}
 		}
 		reqs = append(reqs, patchReq[P]{Op: op, Prop: prop, Value: converted})
 	}


### PR DESCRIPTION
Fixes https://linear.app/unikraft/issue/TOOL-611/new-cli-does-not-allow-editing-of-scale-to-zero-properties.