### PR TITLE
fix: Allow removing fields using -f -field-name

### DIFF
--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -25,6 +25,7 @@ import (
 	"unikraft.com/cli/internal/resource/patch"
 	"unikraft.com/cli/internal/tui/watcher"
 	xfilters "unikraft.com/cli/internal/x/filters"
+	xkong "unikraft.com/cli/internal/x/kong"
 )
 
 type ResourceCmdInterface interface {
@@ -120,9 +121,7 @@ func (cmd ResourceCmd[R]) Examples() []kingkong.Example {
 }
 
 type FormatOpts struct {
-	// FIXME: not able to pass values beginning with -
-	// https://github.com/alecthomas/kong/issues/290
-	Field []string `short:"f" help:"Specify which fields to include in the output."`
+	Field xkong.GreedyStrings `short:"f" help:"Specify which fields to include in the output."`
 
 	Output Printer `short:"o" help:"Output format. One of: kv, table, json, yaml, raw, quiet, template."`
 }
@@ -183,7 +182,7 @@ func (cmd *ResourceListCmd[R]) Run(ctx context.Context, stdio config.Stdio, sand
 		}
 		return cmd.Output.
 			WithDefault(PrinterTypeTable).
-			Print(ctx, out, cmd.Field, empty, resources...)
+			Print(ctx, out, []string(cmd.Field), empty, resources...)
 	}
 
 	if cmd.Watch != nil {
@@ -223,7 +222,7 @@ func (cmd *ResourceGetCmd[R]) Run(ctx context.Context, stdio config.Stdio, sandb
 		}
 		return cmd.Output.
 			WithDefault(PrinterTypeKeyValue).
-			Print(ctx, out, cmd.Field, empty, resources...)
+			Print(ctx, out, []string(cmd.Field), empty, resources...)
 	}
 
 	if cmd.Watch != nil {
@@ -295,7 +294,7 @@ func (cmd *ResourceWaitCmd[R]) Run(ctx context.Context, stdio config.Stdio, sand
 
 			return cmd.Output.
 				WithDefault(PrinterTypeKeyValue).
-				Print(ctx, stdio.Stdout, cmd.Field, empty, filtered...)
+				Print(ctx, stdio.Stdout, []string(cmd.Field), empty, filtered...)
 		}
 		log.G(ctx).Debug().
 			Strs("resources", cmd.Name).
@@ -406,7 +405,7 @@ func (cmd *ResourceRemoveCmd[R]) Run(ctx context.Context, stdio config.Stdio, sa
 
 	return cmd.Output.
 		WithDefault(PrinterTypeQuiet).
-		Print(ctx, stdio.Stdout, cmd.Field, empty, resources...)
+		Print(ctx, stdio.Stdout, []string(cmd.Field), empty, resources...)
 }
 
 type ResourceBulkRemoveCmd[R interface {
@@ -468,7 +467,7 @@ func (cmd *ResourceBulkRemoveCmd[R]) Run(ctx context.Context, stdio config.Stdio
 
 			err = cmd.Output.
 				WithDefault(PrinterTypeTable).
-				Print(ctx, stdio.Stdout, cmd.Field, empty, resources...)
+				Print(ctx, stdio.Stdout, []string(cmd.Field), empty, resources...)
 			if err != nil {
 				return err
 			}
@@ -521,7 +520,7 @@ func (cmd *ResourceBulkRemoveCmd[R]) Run(ctx context.Context, stdio config.Stdio
 		}
 		return cmd.Output.
 			WithDefault(PrinterTypeQuiet).
-			Print(ctx, stdio.Stdout, cmd.Field, empty, resources...)
+			Print(ctx, stdio.Stdout, []string(cmd.Field), empty, resources...)
 	} else {
 		return fmt.Errorf("no resources specified for deletion")
 	}
@@ -722,5 +721,5 @@ func (cmd *ResourceCreateCmd[R]) Run(ctx context.Context, stdio config.Stdio, sa
 	}
 	return cmd.Output.
 		WithDefault(PrinterTypeKeyValue).
-		Print(ctx, stdio.Stdout, cmd.Field, empty, resources...)
+		Print(ctx, stdio.Stdout, []string(cmd.Field), empty, resources...)
 }

--- a/internal/resource/cmd/cmd_test.go
+++ b/internal/resource/cmd/cmd_test.go
@@ -24,6 +24,7 @@ import (
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/resource"
 	resourcet "unikraft.com/cli/internal/resource/testing"
+	xkong "unikraft.com/cli/internal/x/kong"
 )
 
 var baseTestStore = map[string]resourcet.TestResource{
@@ -89,7 +90,7 @@ func TestList(t *testing.T) {
 		var out bytes.Buffer
 		cmd := &ResourceListCmd[resourcet.TestResource]{
 			FormatOpts: FormatOpts{
-				Field: []string{"name", "id"},
+				Field: xkong.GreedyStrings{"name", "id"},
 			},
 		}
 		err := cmd.Run(ctx, testStdio(&out), sandbox)
@@ -109,6 +110,23 @@ func TestList(t *testing.T) {
 		assert.Contains(t, output, "test1")
 		assert.Contains(t, output, "id-test1")
 		assert.NotContains(t, output, "test2")
+	})
+
+	t.Run("field exclude", func(t *testing.T) {
+		var out bytes.Buffer
+		cmd := &ResourceListCmd[resourcet.TestResource]{
+			FormatOpts: FormatOpts{
+				Field:  xkong.GreedyStrings{"-url"},
+				Output: Printer{Type: PrinterTypeKeyValue},
+			},
+		}
+		err := cmd.Run(ctx, testStdio(&out), sandbox)
+		require.NoError(t, err)
+
+		output := out.String()
+		assert.Contains(t, output, "name:")
+		assert.Contains(t, output, "id:")
+		assert.NotContains(t, output, "url:")
 	})
 
 	t.Run("filter", func(t *testing.T) {
@@ -225,7 +243,7 @@ func TestListOutput(t *testing.T) {
 	})
 
 	t.Run("quiet field", func(t *testing.T) {
-		output := runList(t, FormatOpts{Output: Printer{Type: PrinterTypeQuiet}, Field: []string{"id", "url"}})
+		output := runList(t, FormatOpts{Output: Printer{Type: PrinterTypeQuiet}, Field: xkong.GreedyStrings{"id", "url"}})
 		assert.Equal(t, "id-test1 https://example.com\nid-test2 https://example.org\n", output)
 	})
 
@@ -248,7 +266,7 @@ func TestTableNestedFieldSelection(t *testing.T) {
 		Name: []string{"test1"},
 		FormatOpts: FormatOpts{
 			Output: Printer{Type: PrinterTypeTable},
-			Field:  []string{"name", "authors"},
+			Field:  xkong.GreedyStrings{"name", "authors"},
 		},
 	}
 	err = cmd.Run(ctx, testStdio(&out), sandbox)
@@ -323,7 +341,7 @@ func TestGet(t *testing.T) {
 		cmd := &ResourceGetCmd[resourcet.TestResource]{
 			Name: []string{"test1"},
 			FormatOpts: FormatOpts{
-				Field: []string{"id", "url"},
+				Field: xkong.GreedyStrings{"id", "url"},
 			},
 		}
 		err := cmd.Run(ctx, testStdio(&out), sandbox)
@@ -1006,7 +1024,7 @@ func TestValueCallback(t *testing.T) {
 		var out bytes.Buffer
 		cmd := &ResourceListCmd[resourcet.TestResource]{
 			FormatOpts: FormatOpts{
-				Field: []string{"+lazy"},
+				Field: xkong.GreedyStrings{"+lazy"},
 			},
 		}
 		err := cmd.Run(ctx, testStdio(&out), sandbox)
@@ -1028,7 +1046,7 @@ func TestValueCallback(t *testing.T) {
 		cmd := &ResourceGetCmd[resourcet.TestResource]{
 			Name: []string{"res1"},
 			FormatOpts: FormatOpts{
-				Field: []string{"+lazy"},
+				Field: xkong.GreedyStrings{"+lazy"},
 			},
 		}
 		err := cmd.Run(ctx, testStdio(&out), sandbox)
@@ -1047,7 +1065,7 @@ func TestValueCallback(t *testing.T) {
 		cmd := &ResourceListCmd[resourcet.TestResource]{
 			FormatOpts: FormatOpts{
 				Output: Printer{Type: PrinterTypeQuiet},
-				Field:  []string{"name", "lazy"},
+				Field:  xkong.GreedyStrings{"name", "lazy"},
 			},
 		}
 		err := cmd.Run(ctx, testStdio(&out), sandbox)

--- a/internal/resource/cmd/diff.go
+++ b/internal/resource/cmd/diff.go
@@ -27,11 +27,11 @@ func Diff(ctx context.Context, out io.Writer, format FormatOpts, empty resource.
 	switch format.Output.Type {
 	case "", PrinterTypeKeyValue:
 		start := &bytes.Buffer{}
-		if err := printKV(ctx, start, format.Field, before...); err != nil {
+		if err := printKV(ctx, start, []string(format.Field), before...); err != nil {
 			return err
 		}
 		end := &bytes.Buffer{}
-		if err := printKV(ctx, end, format.Field, after...); err != nil {
+		if err := printKV(ctx, end, []string(format.Field), after...); err != nil {
 			return err
 		}
 
@@ -57,11 +57,11 @@ func Diff(ctx context.Context, out io.Writer, format FormatOpts, empty resource.
 
 	case PrinterTypeTable:
 		start := &bytes.Buffer{}
-		if err := printTable(ctx, start, format.Field, empty, before...); err != nil {
+		if err := printTable(ctx, start, []string(format.Field), empty, before...); err != nil {
 			return err
 		}
 		end := &bytes.Buffer{}
-		if err := printTable(ctx, end, format.Field, empty, after...); err != nil {
+		if err := printTable(ctx, end, []string(format.Field), empty, after...); err != nil {
 			return err
 		}
 
@@ -83,7 +83,7 @@ func Diff(ctx context.Context, out io.Writer, format FormatOpts, empty resource.
 		return nil
 
 	default:
-		return format.Output.Print(ctx, out, format.Field, nil, after...)
+		return format.Output.Print(ctx, out, []string(format.Field), nil, after...)
 	}
 }
 

--- a/internal/x/kong/greedystr.go
+++ b/internal/x/kong/greedystr.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package kong
+
+import (
+	"fmt"
+
+	"github.com/alecthomas/kong"
+)
+
+// GreedyString is a string type that consumes all arguments, including those
+// starting with '-'.
+type GreedyString string
+
+// Decode implements kong.MapperValue.
+func (h *GreedyString) Decode(ctx *kong.DecodeContext) error {
+	t := ctx.Scan.Pop()
+	if t.IsEOL() {
+		return fmt.Errorf("missing value")
+	}
+	// otherwise, ignore the type, we consume it anyways
+
+	switch v := t.Value.(type) {
+	case string:
+		*h = GreedyString(v)
+	default:
+		*h = GreedyString(fmt.Sprint(v))
+	}
+
+	return nil
+}
+
+// GreedyStrings is a string slice type that consumes all arguments, including those
+// beginning with '-'.
+type GreedyStrings []string
+
+// Decode implements kong.MapperValue.
+func (h *GreedyStrings) Decode(ctx *kong.DecodeContext) error {
+	sep := ctx.Value.Tag.Sep
+
+	t := ctx.Scan.Pop()
+	if t.IsEOL() {
+		tail := ""
+		if sep != -1 {
+			tail = string(sep) + "..."
+		}
+		return fmt.Errorf("missing value, expecting \"<arg>%s\"", tail)
+	}
+	// otherwise, ignore the type, we consume it anyways
+
+	switch v := t.Value.(type) {
+	case string:
+		if sep == -1 {
+			*h = append(*h, v)
+			return nil
+		}
+		for _, part := range kong.SplitEscaped(v, sep) {
+			*h = append(*h, part)
+		}
+	case []any:
+		for _, part := range v {
+			*h = append(*h, fmt.Sprint(part))
+		}
+	default:
+		*h = append(*h, fmt.Sprint(v))
+	}
+
+	return nil
+}

--- a/internal/x/kong/greedystr_test.go
+++ b/internal/x/kong/greedystr_test.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package kong
+
+import (
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGreedyStringDecode(t *testing.T) {
+	var cli struct {
+		Field GreedyString `short:"f"`
+	}
+
+	parser, err := kong.New(&cli)
+	require.NoError(t, err)
+
+	_, err = parser.Parse([]string{"-f", "-name"})
+	require.NoError(t, err)
+	require.Equal(t, GreedyString("-name"), cli.Field)
+}
+
+func TestGreedyStringsDecode(t *testing.T) {
+	var cli struct {
+		Field GreedyStrings `short:"f"`
+		Other string        `short:"r"`
+	}
+
+	parser, err := kong.New(&cli)
+	require.NoError(t, err)
+
+	_, err = parser.Parse([]string{"-f", "-name", "-f", "+id", "-r", "value"})
+	require.NoError(t, err)
+	require.Equal(t, GreedyStrings{"-name", "+id"}, cli.Field)
+	require.Equal(t, "value", cli.Other)
+}
+
+func TestGreedyStringsJoinedDecode(t *testing.T) {
+	var cli struct {
+		Field GreedyStrings `short:"f"`
+		Other string        `short:"r"`
+	}
+
+	parser, err := kong.New(&cli)
+	require.NoError(t, err)
+
+	_, err = parser.Parse([]string{"-f", "-name,+id", "-r", "value"})
+	require.NoError(t, err)
+	require.Equal(t, GreedyStrings{"-name", "+id"}, cli.Field)
+	require.Equal(t, "value", cli.Other)
+}


### PR DESCRIPTION
Due to a kong "issue" (intentional design), this was previously only achievable by `--field=-field-name`. Now it's possible, even if the next component *looks* like a flag.