### PR TITLE
fix: Ensure cooldown-time has correct casing

### DIFF
--- a/internal/resource/value/parse.go
+++ b/internal/resource/value/parse.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ettle/strcase"
+
 	xmaps "unikraft.com/cli/internal/x/maps"
 )
 
@@ -157,7 +159,12 @@ func parseReflect(input []string, value reflect.Value) error {
 					if !field.IsExported() {
 						continue
 					}
-					if strings.SplitN(field.Tag.Get("field"), ",", 2)[0] == k || strings.EqualFold(field.Name, k) {
+					name, _, _ := strings.Cut(field.Tag.Get("field"), ",")
+					if name == "" {
+						name = field.Name
+						name = strcase.ToKebab(name)
+					}
+					if k == name {
 						fieldVal := s.Field(i)
 						err := parseReflect([]string{v}, fieldVal)
 						if err != nil {


### PR DESCRIPTION
The automatic naming for unpacking values wasn't quite right. We need to explicitly use `strcase.ToKebab` to match the automagic field naming.

This manifested like this:

    $ unikraft run --metro=fra0-bench --scale-to-zero policy=on,cooldown-time=300 nginx:latest
    │
    │ error:
    │   unknown fields: [cooldown-time]