### PR TITLE
feat: Preserve original key

### DIFF
--- a/cmd/unikraft/testdata/TestGolden/certificates/create
+++ b/cmd/unikraft/testdata/TestGolden/certificates/create
@@ -74,5 +74,5 @@ stdout:
 $ unikraft certificate delete test-$UNIQ_CERT_A test-$UNIQ_CERT_B
 
 stdout:
-	test/test-<CERT_A>
-	test/test-<CERT_B>
+	test-<CERT_A>
+	test-<CERT_B>

--- a/cmd/unikraft/testdata/TestGolden/instances/connect
+++ b/cmd/unikraft/testdata/TestGolden/instances/connect
@@ -37,4 +37,4 @@ stdout:
 $ unikraft instance delete test-$UNIQ_INST
 
 stdout:
-	test/test-<INST>
+	test-<INST>

--- a/cmd/unikraft/testdata/TestGolden/instances/create
+++ b/cmd/unikraft/testdata/TestGolden/instances/create
@@ -58,7 +58,7 @@ stdout:
 $ unikraft instance delete test-$UNIQ_INST
 
 stdout:
-	test/test-<INST>
+	test-<INST>
 
 $ unikraft instance list
 

--- a/cmd/unikraft/testdata/TestGolden/instances/edit
+++ b/cmd/unikraft/testdata/TestGolden/instances/edit
@@ -6,7 +6,7 @@ stdout:
 $ unikraft instance edit test-$UNIQ_INST --output quiet --set image=redis:latest --set runtime.args=after,second --set runtime.env=A=3,B=4 --set resources.memory=256
 
 stdout:
-	test/test-<INST>
+	test-<INST>
 
 $ unikraft instance inspect test-$UNIQ_INST
 
@@ -34,4 +34,4 @@ stdout:
 $ unikraft instance delete test-$UNIQ_INST
 
 stdout:
-	test/test-<INST>
+	test-<INST>

--- a/cmd/unikraft/testdata/TestGolden/instances/start-stop
+++ b/cmd/unikraft/testdata/TestGolden/instances/start-stop
@@ -24,26 +24,25 @@ stdout:
 $ unikraft instance stop test-$UNIQ_INST
 
 stdout:
-	  metro:        test
-	  name:         test-<INST>
-	  uuid:         12345678-1234-1234-1234-123456789abc
-	- state:        running
+	+ metro:        test
+	+ name:         test-<INST>
+	+ uuid:         12345678-1234-1234-1234-123456789abc
 	+ state:        stopped
-	  image:        nginx
-	  runtime:
-	    env:
-	      A:        1
-	      B:        2
-	      C:        3
-	  resources:
-	    memory:     128MiB
-	    vcpus:      1
-	  networks:
-	  - uuid:       12345678-1234-1234-1234-123456789abc
-	    private-ip: 10.X.X.X
-	    mac:        aa:bb:cc:dd:ee:ff
-	  timestamps:
-	    created:    RELATIVE_TIME
+	+ image:        nginx
+	+ runtime:
+	+   env:
+	+     A:        1
+	+     B:        2
+	+     C:        3
+	+ resources:
+	+   memory:     128MiB
+	+   vcpus:      1
+	+ networks:
+	+ - uuid:       12345678-1234-1234-1234-123456789abc
+	+   private-ip: 10.X.X.X
+	+   mac:        aa:bb:cc:dd:ee:ff
+	+ timestamps:
+	+   created:    RELATIVE_TIME
 
 $ unikraft instance inspect test-$UNIQ_INST
 
@@ -71,26 +70,25 @@ stdout:
 $ unikraft instance start test-$UNIQ_INST
 
 stdout:
-	  metro:        test
-	  name:         test-<INST>
-	  uuid:         12345678-1234-1234-1234-123456789abc
-	- state:        stopped
+	+ metro:        test
+	+ name:         test-<INST>
+	+ uuid:         12345678-1234-1234-1234-123456789abc
 	+ state:        running
-	  image:        nginx
-	  runtime:
-	    env:
-	      A:        1
-	      B:        2
-	      C:        3
-	  resources:
-	    memory:     128MiB
-	    vcpus:      1
-	  networks:
-	  - uuid:       12345678-1234-1234-1234-123456789abc
-	    private-ip: 10.X.X.X
-	    mac:        aa:bb:cc:dd:ee:ff
-	  timestamps:
-	    created:    RELATIVE_TIME
+	+ image:        nginx
+	+ runtime:
+	+   env:
+	+     A:        1
+	+     B:        2
+	+     C:        3
+	+ resources:
+	+   memory:     128MiB
+	+   vcpus:      1
+	+ networks:
+	+ - uuid:       12345678-1234-1234-1234-123456789abc
+	+   private-ip: 10.X.X.X
+	+   mac:        aa:bb:cc:dd:ee:ff
+	+ timestamps:
+	+   created:    RELATIVE_TIME
 
 $ unikraft instance inspect test-$UNIQ_INST
 
@@ -212,4 +210,4 @@ stdout:
 $ unikraft instance delete test-$UNIQ_INST
 
 stdout:
-	test/test-<INST>
+	test-<INST>

--- a/cmd/unikraft/testdata/TestGolden/services/create
+++ b/cmd/unikraft/testdata/TestGolden/services/create
@@ -94,5 +94,5 @@ stdout:
 $ unikraft service delete test-$UNIQ_SVC_A test-$UNIQ_SVC_B
 
 stdout:
-	test/test-<SVC_A>
-	test/test-<SVC_B>
+	test-<SVC_A>
+	test-<SVC_B>

--- a/cmd/unikraft/testdata/TestGolden/services/edit
+++ b/cmd/unikraft/testdata/TestGolden/services/edit
@@ -6,7 +6,7 @@ stdout:
 $ unikraft service edit test-$UNIQ_SVC --output quiet --set limits.soft=2 --set limits.hard=10 --set domains=fqdn=$UNIQ_DOMAIN_EDIT.unikraft.example --set services=1000:2000/tls
 
 stdout:
-	test/test-<SVC>
+	test-<SVC>
 
 $ unikraft service inspect test-$UNIQ_SVC
 
@@ -31,4 +31,4 @@ stdout:
 $ unikraft service delete test-$UNIQ_SVC
 
 stdout:
-	test/test-<SVC>
+	test-<SVC>

--- a/cmd/unikraft/testdata/TestGolden/volumes/clone
+++ b/cmd/unikraft/testdata/TestGolden/volumes/clone
@@ -32,5 +32,5 @@ stdout:
 $ unikraft volume delete test-$UNIQ_VOLUME test-$UNIQ_VOLUME_CLONE
 
 stdout:
-	test/test-<VOLUME>
-	test/test-<VOLUME_CLONE>
+	test-<VOLUME>
+	test-<VOLUME_CLONE>

--- a/cmd/unikraft/testdata/TestGolden/volumes/create
+++ b/cmd/unikraft/testdata/TestGolden/volumes/create
@@ -36,4 +36,4 @@ stdout:
 $ unikraft volume delete test-$UNIQ_VOLUME
 
 stdout:
-	test/test-<VOLUME>
+	test-<VOLUME>

--- a/cmd/unikraft/testdata/TestGolden/volumes/edit
+++ b/cmd/unikraft/testdata/TestGolden/volumes/edit
@@ -6,7 +6,7 @@ stdout:
 $ unikraft volume edit test-$UNIQ_VOLUME --output quiet --set size=20
 
 stdout:
-	test/test-<VOLUME>
+	test-<VOLUME>
 
 $ unikraft volume inspect test-$UNIQ_VOLUME
 
@@ -23,4 +23,4 @@ stdout:
 $ unikraft volume delete test-$UNIQ_VOLUME
 
 stdout:
-	test/test-<VOLUME>
+	test-<VOLUME>

--- a/internal/cmd/any.go
+++ b/internal/cmd/any.go
@@ -90,6 +90,10 @@ func (k anyResourceKey) String() string {
 	return k.typ + ":" + k.key
 }
 
+func (k anyResourceKey) Canonical() string {
+	return k.String()
+}
+
 func (k *anyResourceKey) UnmarshalText(text []byte) error {
 	typ, key, found := strings.Cut(string(text), ":")
 	if found {

--- a/internal/cmd/certificates.go
+++ b/internal/cmd/certificates.go
@@ -6,6 +6,7 @@
 package cmd
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 
@@ -57,6 +58,8 @@ type Certificate struct {
 
 	Certificate platform.Certificate `field:"-" json:"certificate"`
 	Metro       *config.Metro        `field:"-" json:"metro"`
+
+	key multimetro.Key
 }
 
 func (Certificate) Type() resource.Type {
@@ -66,16 +69,8 @@ func (Certificate) Type() resource.Type {
 	}
 }
 
-func (c Certificate) key() multimetro.Key {
-	return multimetro.Key{
-		Metro: c.MetroName,
-		Name:  c.Name,
-		UUID:  c.UUID,
-	}
-}
-
 func (c Certificate) Key() resource.Key {
-	return c.key()
+	return c.key
 }
 
 func (c Certificate) Raw() any {
@@ -99,7 +94,7 @@ func (Certificate) List(ctx context.Context) ([]resource.Resource, error) {
 		}
 		var results []resource.Resource
 		for _, certificate := range resp.Data.Certificates {
-			result, err := Certificate{}.load(certificate, &c.Metro)
+			result, err := Certificate{}.load(nil, certificate, &c.Metro)
 			if err != nil {
 				return nil, err
 			}
@@ -122,11 +117,11 @@ func (Certificate) Get(ctx context.Context, keys []string) ([]resource.Resource,
 		}
 		var found []group.Ref
 		var results []resource.Resource
-		for _, certificate := range resp.Data.Certificates {
+		for i, certificate := range resp.Data.Certificates {
 			if certificate.Status == nil || *certificate.Status != "success" {
 				continue
 			}
-			result, err := Certificate{}.load(certificate, &c.Metro)
+			result, err := Certificate{}.load(&refs[i], certificate, &c.Metro)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -141,10 +136,23 @@ func (Certificate) Get(ctx context.Context, keys []string) ([]resource.Resource,
 	})
 }
 
-func (Certificate) load(certificate platform.Certificate, metro *config.Metro) (Certificate, error) {
+func (Certificate) load(ref *group.Ref, certificate platform.Certificate, metro *config.Metro) (Certificate, error) {
+	if ref == nil {
+		ref = &group.Ref{
+			Metro: metro.Name,
+			Name:  ptr.ZeroIfNil(certificate.Name),
+			UUID:  ptr.ZeroIfNil(certificate.Uuid),
+		}
+	} else {
+		ref.Metro = cmp.Or(ref.Metro, metro.Name)
+		ref.Name = cmp.Or(ref.Name, ptr.ZeroIfNil(certificate.Name))
+		ref.UUID = cmp.Or(ref.UUID, ptr.ZeroIfNil(certificate.Uuid))
+	}
+
 	result := Certificate{
 		Certificate: certificate,
 		Metro:       metro,
+		key:         multimetro.Key(*ref),
 	}
 	err := mirror.Mirror(result, &result)
 	if err != nil {
@@ -157,7 +165,7 @@ func (Certificate) Delete(ctx context.Context, targets []resource.Resource) erro
 	keys := make(multimetro.Keys, 0, len(targets))
 	for _, target := range targets {
 		certificate := target.(Certificate)
-		keys = append(keys, certificate.key())
+		keys = append(keys, certificate.key)
 	}
 
 	g, err := multimetro.NewClient(ctx)

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -122,6 +122,8 @@ type Instance struct {
 	Instance platform.Instance `field:"-" json:"instance"`
 	Metro    *config.Metro     `field:"-" json:"metro"`
 	Profile  *config.Profile   `field:"-" json:"profile"`
+
+	key multimetro.Key
 }
 
 type InstanceVolume struct {
@@ -213,16 +215,8 @@ func (Instance) Type() resource.Type {
 	}
 }
 
-func (i Instance) key() multimetro.Key {
-	return multimetro.Key{
-		Metro: i.MetroName,
-		Name:  i.Name,
-		UUID:  i.UUID,
-	}
-}
-
 func (i Instance) Key() resource.Key {
-	return i.key()
+	return i.key
 }
 
 func (i Instance) Raw() any {
@@ -292,7 +286,7 @@ func (Instance) List(ctx context.Context) ([]resource.Resource, error) {
 		}
 		var results []resource.Resource
 		for _, instance := range resp.Data.Instances {
-			result, err := Instance{}.load(instance, &c.Metro, profile)
+			result, err := Instance{}.load(nil, instance, &c.Metro, profile)
 			if err != nil {
 				return nil, err
 			}
@@ -319,11 +313,11 @@ func (Instance) Get(ctx context.Context, keys []string) ([]resource.Resource, er
 		}
 		var found []group.Ref
 		var results []resource.Resource
-		for _, instance := range resp.Data.Instances {
+		for i, instance := range resp.Data.Instances {
 			if instance.Status == nil || *instance.Status != platform.ResponseStatusSUCCESS {
 				continue
 			}
-			result, err := Instance{}.load(instance, &c.Metro, profile)
+			result, err := Instance{}.load(&refs[i], instance, &c.Metro, profile)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -338,11 +332,24 @@ func (Instance) Get(ctx context.Context, keys []string) ([]resource.Resource, er
 	})
 }
 
-func (Instance) load(instance platform.Instance, metro *config.Metro, profile *config.Profile) (Instance, error) {
+func (Instance) load(ref *group.Ref, instance platform.Instance, metro *config.Metro, profile *config.Profile) (Instance, error) {
+	if ref == nil {
+		ref = &group.Ref{
+			Metro: metro.Name,
+			Name:  ptr.ZeroIfNil(instance.Name),
+			UUID:  ptr.ZeroIfNil(instance.Uuid),
+		}
+	} else {
+		ref.Metro = cmp.Or(ref.Metro, metro.Name)
+		ref.Name = cmp.Or(ref.Name, ptr.ZeroIfNil(instance.Name))
+		ref.UUID = cmp.Or(ref.UUID, ptr.ZeroIfNil(instance.Uuid))
+	}
+
 	result := Instance{
 		Instance: instance,
 		Metro:    metro,
 		Profile:  profile,
+		key:      multimetro.Key(*ref),
 	}
 	err := mirror.Mirror(result, &result)
 	if err != nil {
@@ -360,7 +367,7 @@ func (Instance) Delete(ctx context.Context, targets []resource.Resource) error {
 	keys := make(multimetro.Keys, 0, len(targets))
 	for _, target := range targets {
 		instance := target.(Instance)
-		keys = append(keys, instance.key())
+		keys = append(keys, instance.key)
 	}
 
 	g, err := multimetro.NewClient(ctx)
@@ -414,13 +421,13 @@ func (Instance) Edit(ctx context.Context, target resource.Resource, fields []res
 		return nil, err
 	}
 	if instance.State.IsRunning() && !targetState.IsRunning() {
-		_, err := stopInstances(ctx, g, multimetro.Keys{instance.key()}, StopOpts{DrainTimeout: -1})
+		_, err := stopInstances(ctx, g, multimetro.Keys{instance.key}, StopOpts{DrainTimeout: -1})
 		if err != nil {
 			return nil, err
 		}
 	}
 	if len(reqs) > 0 {
-		err = group.DoMetro(ctx, g, instance.key().Metro, func(ctx context.Context, c multimetro.MetroClient) error {
+		err = group.DoMetro(ctx, g, instance.key.Metro, func(ctx context.Context, c multimetro.MetroClient) error {
 			log.G(ctx).Trace().Msg("updating instance")
 			_, err := c.UpdateInstances(ctx, reqs)
 			return err
@@ -430,7 +437,7 @@ func (Instance) Edit(ctx context.Context, target resource.Resource, fields []res
 		}
 	}
 	if !instance.State.IsRunning() && targetState.IsRunning() {
-		_, err := startInstances(ctx, g, multimetro.Keys{instance.key()})
+		_, err := startInstances(ctx, g, multimetro.Keys{instance.key})
 		if err != nil {
 			return nil, err
 		}
@@ -730,7 +737,7 @@ func (cmd *InstancesLogsCmd) Run(ctx context.Context, stdio config.Stdio) error 
 	}
 	keys := make(multimetro.Keys, 0, len(instances))
 	for _, instance := range instances {
-		key := instance.(Instance).key()
+		key := instance.(Instance).key
 		if key.Metro == "" {
 			return fmt.Errorf("key %q not fully resolved", key)
 		}
@@ -800,7 +807,7 @@ func (c *InstancesStartCmd) Run(ctx context.Context, stdio config.Stdio) error {
 	}
 	var targetKeys multimetro.Keys
 	for _, res := range before {
-		targetKeys = append(targetKeys, res.(Instance).key())
+		targetKeys = append(targetKeys, res.(Instance).key)
 	}
 	if len(targetKeys) == 0 {
 		targetKeys = keys
@@ -877,7 +884,7 @@ func (c *InstancesStopCmd) Run(ctx context.Context, stdio config.Stdio) error {
 	}
 	var targetKeys multimetro.Keys
 	for _, res := range before {
-		targetKeys = append(targetKeys, res.(Instance).key())
+		targetKeys = append(targetKeys, res.(Instance).key)
 	}
 	if len(targetKeys) == 0 {
 		targetKeys = keys
@@ -947,7 +954,7 @@ func (c *InstancesRestartCmd) Run(ctx context.Context, stdio config.Stdio) error
 	}
 	var targetKeys multimetro.Keys
 	for _, res := range before {
-		targetKeys = append(targetKeys, res.(Instance).key())
+		targetKeys = append(targetKeys, res.(Instance).key)
 	}
 
 	stopped, stopErr := stopInstances(ctx, g, targetKeys, c.StopOpts)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -320,3 +320,7 @@ type staticKey string
 func (s staticKey) String() string {
 	return string(s)
 }
+
+func (s staticKey) Canonical() string {
+	return string(s)
+}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -195,7 +195,7 @@ func (c *RunCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.
 			if !ok {
 				return fmt.Errorf("unexpected resource type %T", res)
 			}
-			keys = append(keys, instance.key())
+			keys = append(keys, instance.key)
 		}
 
 		ctx, cancel := context.WithCancel(ctx)

--- a/internal/cmd/services.go
+++ b/internal/cmd/services.go
@@ -6,6 +6,7 @@
 package cmd
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"strconv"
@@ -63,6 +64,8 @@ type ServiceGroup struct {
 
 	ServiceGroup platform.ServiceGroup `field:"-" json:"service_group"`
 	Metro        *config.Metro         `field:"-" json:"metro"`
+
+	key multimetro.Key
 }
 
 type Service struct {
@@ -129,16 +132,8 @@ func (ServiceGroup) Type() resource.Type {
 	}
 }
 
-func (s ServiceGroup) key() multimetro.Key {
-	return multimetro.Key{
-		Metro: s.MetroName,
-		Name:  s.Name,
-		UUID:  s.UUID,
-	}
-}
-
 func (s ServiceGroup) Key() resource.Key {
-	return s.key()
+	return s.key
 }
 
 func (s ServiceGroup) Raw() any {
@@ -186,7 +181,7 @@ func (ServiceGroup) List(ctx context.Context) ([]resource.Resource, error) {
 		}
 		var results []resource.Resource
 		for _, serviceGroup := range resp.Data.ServiceGroups {
-			result, err := ServiceGroup{}.load(serviceGroup, &c.Metro)
+			result, err := ServiceGroup{}.load(nil, serviceGroup, &c.Metro)
 			if err != nil {
 				return nil, err
 			}
@@ -209,11 +204,11 @@ func (ServiceGroup) Get(ctx context.Context, keys []string) ([]resource.Resource
 		}
 		var found []group.Ref
 		var results []resource.Resource
-		for _, serviceGroup := range resp.Data.ServiceGroups {
+		for i, serviceGroup := range resp.Data.ServiceGroups {
 			if serviceGroup.Status == nil || *serviceGroup.Status != platform.ResponseStatusSUCCESS {
 				continue
 			}
-			result, err := ServiceGroup{}.load(serviceGroup, &c.Metro)
+			result, err := ServiceGroup{}.load(&refs[i], serviceGroup, &c.Metro)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -228,10 +223,23 @@ func (ServiceGroup) Get(ctx context.Context, keys []string) ([]resource.Resource
 	})
 }
 
-func (ServiceGroup) load(serviceGroup platform.ServiceGroup, metro *config.Metro) (ServiceGroup, error) {
+func (ServiceGroup) load(ref *group.Ref, serviceGroup platform.ServiceGroup, metro *config.Metro) (ServiceGroup, error) {
+	if ref == nil {
+		ref = &group.Ref{
+			Metro: metro.Name,
+			Name:  ptr.ZeroIfNil(serviceGroup.Name),
+			UUID:  ptr.ZeroIfNil(serviceGroup.Uuid),
+		}
+	} else {
+		ref.Metro = cmp.Or(ref.Metro, metro.Name)
+		ref.Name = cmp.Or(ref.Name, ptr.ZeroIfNil(serviceGroup.Name))
+		ref.UUID = cmp.Or(ref.UUID, ptr.ZeroIfNil(serviceGroup.Uuid))
+	}
+
 	result := ServiceGroup{
 		ServiceGroup: serviceGroup,
 		Metro:        metro,
+		key:          multimetro.Key(*ref),
 	}
 	err := mirror.Mirror(result, &result)
 	if err != nil {
@@ -244,7 +252,7 @@ func (ServiceGroup) Delete(ctx context.Context, targets []resource.Resource) err
 	keys := make(multimetro.Keys, len(targets))
 	for i, target := range targets {
 		sg := target.(ServiceGroup)
-		keys[i] = sg.key()
+		keys[i] = sg.key
 	}
 
 	g, err := multimetro.NewClient(ctx)
@@ -348,7 +356,7 @@ func (ServiceGroup) Edit(ctx context.Context, target resource.Resource, fields [
 	if err != nil {
 		return nil, err
 	}
-	err = group.DoMetro(ctx, g, sg.key().Metro, func(ctx context.Context, metroClient multimetro.MetroClient) error {
+	err = group.DoMetro(ctx, g, sg.key.Metro, func(ctx context.Context, metroClient multimetro.MetroClient) error {
 		log.G(ctx).Trace().Msg("updating service group")
 		_, err := metroClient.UpdateServiceGroups(ctx, reqs)
 		return err

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -6,6 +6,7 @@
 package cmd
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -193,6 +194,8 @@ type Volume struct {
 
 	Volume platform.Volume `field:"-" json:"volume"`
 	Metro  *config.Metro   `field:"-" json:"metro"`
+
+	key multimetro.Key
 }
 
 func (Volume) Type() resource.Type {
@@ -202,16 +205,8 @@ func (Volume) Type() resource.Type {
 	}
 }
 
-func (i Volume) key() multimetro.Key {
-	return multimetro.Key{
-		Metro: i.MetroName,
-		Name:  i.Name,
-		UUID:  i.UUID,
-	}
-}
-
 func (i Volume) Key() resource.Key {
-	return i.key()
+	return i.key
 }
 
 func (i Volume) Raw() any {
@@ -235,7 +230,7 @@ func (Volume) List(ctx context.Context) ([]resource.Resource, error) {
 		}
 		var results []resource.Resource
 		for _, volume := range resp.Data.Volumes {
-			result, err := Volume{}.load(volume, &c.Metro)
+			result, err := Volume{}.load(nil, volume, &c.Metro)
 			if err != nil {
 				return nil, err
 			}
@@ -259,11 +254,11 @@ func (Volume) Get(ctx context.Context, keys []string) ([]resource.Resource, erro
 		}
 		var found []group.Ref
 		var results []resource.Resource
-		for _, volume := range resp.Data.Volumes {
+		for i, volume := range resp.Data.Volumes {
 			if volume.Status == nil || *volume.Status != platform.ResponseStatusSUCCESS {
 				continue
 			}
-			result, err := Volume{}.load(volume, &c.Metro)
+			result, err := Volume{}.load(&refs[i], volume, &c.Metro)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -278,10 +273,23 @@ func (Volume) Get(ctx context.Context, keys []string) ([]resource.Resource, erro
 	})
 }
 
-func (Volume) load(volume platform.Volume, metro *config.Metro) (Volume, error) {
+func (Volume) load(ref *group.Ref, volume platform.Volume, metro *config.Metro) (Volume, error) {
+	if ref == nil {
+		ref = &group.Ref{
+			Metro: metro.Name,
+			Name:  ptr.ZeroIfNil(volume.Name),
+			UUID:  ptr.ZeroIfNil(volume.Uuid),
+		}
+	} else {
+		ref.Metro = cmp.Or(ref.Metro, metro.Name)
+		ref.Name = cmp.Or(ref.Name, ptr.ZeroIfNil(volume.Name))
+		ref.UUID = cmp.Or(ref.UUID, ptr.ZeroIfNil(volume.Uuid))
+	}
+
 	result := Volume{
 		Volume: volume,
 		Metro:  metro,
+		key:    multimetro.Key(*ref),
 	}
 	err := mirror.Mirror(result, &result)
 	if err != nil {
@@ -294,7 +302,7 @@ func (Volume) Delete(ctx context.Context, targets []resource.Resource) error {
 	keys := make(multimetro.Keys, 0, len(targets))
 	for _, target := range targets {
 		volume := target.(Volume)
-		keys = append(keys, volume.key())
+		keys = append(keys, volume.key)
 	}
 
 	g, err := multimetro.NewClient(ctx)
@@ -382,7 +390,7 @@ func (Volume) Edit(ctx context.Context, target resource.Resource, fields []resou
 	if err != nil {
 		return nil, err
 	}
-	err = group.DoMetro(ctx, g, volume.key().Metro, func(ctx context.Context, c multimetro.MetroClient) error {
+	err = group.DoMetro(ctx, g, volume.key.Metro, func(ctx context.Context, c multimetro.MetroClient) error {
 		log.G(ctx).Trace().Msg("updating volume")
 		_, err := c.UpdateVolumes(ctx, reqs)
 		return err

--- a/internal/multimetro/key.go
+++ b/internal/multimetro/key.go
@@ -30,7 +30,12 @@ func ParseKey(s string) Key {
 	}
 
 	name, id := parseKeyValue(key)
-	return Key{Metro: metro, Name: name, UUID: id}
+	return Key{
+		Metro:   metro,
+		Name:    name,
+		UUID:    id,
+		Display: s,
+	}
 }
 
 func parseKeyValue(key string) (name string, id string) {
@@ -71,12 +76,17 @@ func (k Key) Ref() group.Ref {
 }
 
 func (k Key) String() string {
+	if k.Display != "" {
+		return k.Display
+	}
+	return k.Canonical()
+}
+
+func (k Key) Canonical() string {
 	s := ""
 	if k.Metro != "" {
 		s += k.Metro + MetroKeySeparator
 	}
-	// FIXME: ideally format using the same as we parsed, even if we have both
-	// this is a bit tricky, since we construct keys in a few places
 	if k.Name != "" {
 		if requiresNamePrefix(k.Name) {
 			s += KeyNamePrefix

--- a/internal/multimetro/key_test.go
+++ b/internal/multimetro/key_test.go
@@ -22,52 +22,52 @@ func TestParseKey(t *testing.T) {
 		{
 			name:     "metro with uuid",
 			input:    "ams/" + testUUID,
-			expected: Key{Metro: "ams", UUID: testUUID},
+			expected: Key{Metro: "ams", UUID: testUUID, Display: "ams/" + testUUID},
 		},
 		{
 			name:     "metro with explicit uuid",
 			input:    "ams/uuid:" + testUUID,
-			expected: Key{Metro: "ams", UUID: testUUID},
+			expected: Key{Metro: "ams", UUID: testUUID, Display: "ams/uuid:" + testUUID},
 		},
 		{
 			name:     "metro with name",
 			input:    "ams/api-key",
-			expected: Key{Metro: "ams", Name: "api-key"},
+			expected: Key{Metro: "ams", Name: "api-key", Display: "ams/api-key"},
 		},
 		{
 			name:     "metro with explicit name",
 			input:    "ams/name:api-key",
-			expected: Key{Metro: "ams", Name: "api-key"},
+			expected: Key{Metro: "ams", Name: "api-key", Display: "ams/name:api-key"},
 		},
 		{
 			name:     "uuid only",
 			input:    testUUID,
-			expected: Key{UUID: testUUID},
+			expected: Key{UUID: testUUID, Display: testUUID},
 		},
 		{
 			name:     "explicit uuid only",
 			input:    "uuid:" + testUUID,
-			expected: Key{UUID: testUUID},
+			expected: Key{UUID: testUUID, Display: "uuid:" + testUUID},
 		},
 		{
 			name:     "name only",
 			input:    "api-key",
-			expected: Key{Name: "api-key"},
+			expected: Key{Name: "api-key", Display: "api-key"},
 		},
 		{
 			name:     "explicit name only",
 			input:    "name:api-key",
-			expected: Key{Name: "api-key"},
+			expected: Key{Name: "api-key", Display: "name:api-key"},
 		},
 		{
 			name:     "name is uuid",
 			input:    "name:" + testUUID,
-			expected: Key{Name: testUUID},
+			expected: Key{Name: testUUID, Display: "name:" + testUUID},
 		},
 		{
 			name:     "explicit uuid non-uuid",
 			input:    "uuid:not-a-uuid",
-			expected: Key{UUID: "not-a-uuid"},
+			expected: Key{UUID: "not-a-uuid", Display: "uuid:not-a-uuid"},
 		},
 	}
 
@@ -155,9 +155,9 @@ func TestParseKeys(t *testing.T) {
 		"uuid:not-a-uuid",
 	}
 	expected := Keys{
-		{Metro: "ams", UUID: testUUID},
-		{Metro: "lhr", Name: "api-key"},
-		{UUID: "not-a-uuid"},
+		{Metro: "ams", UUID: testUUID, Display: "ams/" + testUUID},
+		{Metro: "lhr", Name: "api-key", Display: "lhr/name:api-key"},
+		{UUID: "not-a-uuid", Display: "uuid:not-a-uuid"},
 	}
 
 	assert.Equal(t, expected, ParseKeys(inputs))

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -21,6 +21,7 @@ type Type struct {
 
 type Key interface {
 	fmt.Stringer
+	Canonical() string
 }
 
 type Resource interface {

--- a/internal/resource/sandbox.go
+++ b/internal/resource/sandbox.go
@@ -157,7 +157,7 @@ func (s *Sandbox) Add(ctx context.Context, r Resource) error {
 	if _, ok := s.Keys[r.Type().Name]; !ok {
 		return nil
 	}
-	s.Keys[r.Type().Name][r.Key().String()] = struct{}{}
+	s.Keys[r.Type().Name][r.Key().Canonical()] = struct{}{}
 
 	fields, err := r.Fields()
 	if err != nil {
@@ -198,7 +198,7 @@ func (s *Sandbox) Remove(r Resource) {
 	if _, ok := s.Keys[r.Type().Name]; !ok {
 		return
 	}
-	delete(s.Keys[r.Type().Name], r.Key().String())
+	delete(s.Keys[r.Type().Name], r.Key().Canonical())
 }
 
 func (s *Sandbox) Has(r Resource) bool {
@@ -208,7 +208,7 @@ func (s *Sandbox) Has(r Resource) bool {
 	if _, ok := s.Keys[r.Type().Name]; !ok {
 		return true
 	}
-	_, ok := s.Keys[r.Type().Name][r.Key().String()]
+	_, ok := s.Keys[r.Type().Name][r.Key().Canonical()]
 	return ok
 }
 

--- a/internal/resource/testing/resource.go
+++ b/internal/resource/testing/resource.go
@@ -106,6 +106,10 @@ func (k staticKey) String() string {
 	return string(k)
 }
 
+func (k staticKey) Canonical() string {
+	return string(k)
+}
+
 func (t TestResource) Key() resource.Key {
 	return staticKey(t.Name)
 }


### PR DESCRIPTION
For example, before:

    $ unikraft instance ls -oquiet ukp-stable/1f7104aa-7a3f-4f39-9126-2de40e6259d8 nginx-9flxw
    ukp-stable/nginx-9flxw
    ukp-stable/nginx-9flxw

And after:

    $ unikraft instance ls -oquiet ukp-stable/1f7104aa-7a3f-4f39-9126-2de40e6259d8 nginx-9flxw
    ukp-stable/1f7104aa-7a3f-4f39-9126-2de40e6259d8
    nginx-9flxw