### PR TITLE
ci: Use public runners

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -14,8 +14,7 @@ concurrency:
 
 jobs:
   actionlint:
-    # runs-on: ubuntu-latest
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'arc-unikraft-cli-ubuntu24.04-standard' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,8 +21,7 @@ concurrency:
 
 jobs:
   cli:
-    # runs-on: ubuntu-latest
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'arc-unikraft-cli-ubuntu24.04-standard' }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/check-pr.yaml
+++ b/.github/workflows/check-pr.yaml
@@ -7,8 +7,7 @@ on:
 
 jobs:
   check-pr:
-    # runs-on: ubuntu-latest
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'arc-unikraft-cli-ubuntu24.04-standard' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
       with:

--- a/.github/workflows/check-static.yaml
+++ b/.github/workflows/check-static.yaml
@@ -22,8 +22,7 @@ permissions:
 
 jobs:
   go:
-    # runs-on: ubuntu-latest
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'arc-unikraft-cli-ubuntu24.04-standard' }}
+    runs-on: ubuntu-latest
     env:
       TASK_X_REMOTE_TASKFILES: 1
     steps:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,8 +29,7 @@ concurrency:
 
 jobs:
   docs:
-    # runs-on: ubuntu-latest
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'arc-unikraft-cli-ubuntu24.04-standard' }}
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,8 +16,7 @@ concurrency:
 
 jobs:
   release:
-    # runs-on: ubuntu-latest
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'arc-unikraft-cli-ubuntu24.04-standard' }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,8 +18,7 @@ concurrency:
 
 jobs:
   go:
-    # runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'arc-unikraft-cli-ubuntu24.04-standard' }}
-    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'arc-unikraft-cli-ubuntu24.04-standard' }}
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'arc-unikraft-cli-ubuntu24.04-standard' }}
     env:
       TASK_X_REMOTE_TASKFILES: 1
     steps:


### PR DESCRIPTION
For all jobs, except `test`s where we want to connect to `ukp-stable`.