### PR TITLE
ci: Make task lint ignore default disables

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -44,6 +44,8 @@ tasks:
     silent: true
     cmds:
       - task: go:lint
+        vars:
+          disable: [""]
 
   unit:
     aliases: [test]


### PR DESCRIPTION
We don't want those default disables, especially since our CI checks against the standard config. This can result in inconsistencies.