### PR TITLE
fix: Allow `unikraft image list` on production metros

### DIFF
--- a/internal/cmd/certificates.go
+++ b/internal/cmd/certificates.go
@@ -8,6 +8,7 @@ package cmd
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 
 	"unikraft.com/cloud/sdk/platform"
@@ -93,14 +94,15 @@ func (Certificate) List(ctx context.Context) ([]resource.Resource, error) {
 			return nil, err
 		}
 		var results []resource.Resource
+		var errs []error
 		for _, certificate := range resp.Data.Certificates {
 			result, err := Certificate{}.load(nil, certificate, &c.Metro)
 			if err != nil {
-				return nil, err
+				errs = append(errs, err)
 			}
 			results = append(results, result)
 		}
-		return results, nil
+		return results, errors.Join(errs...)
 	})
 }
 
@@ -117,13 +119,15 @@ func (Certificate) Get(ctx context.Context, keys []string) ([]resource.Resource,
 		}
 		var found []group.Ref
 		var results []resource.Resource
+		var errs []error
 		for i, certificate := range resp.Data.Certificates {
 			if certificate.Status == nil || *certificate.Status != "success" {
 				continue
 			}
 			result, err := Certificate{}.load(&refs[i], certificate, &c.Metro)
 			if err != nil {
-				return nil, nil, err
+				errs = append(errs, err)
+				continue
 			}
 			found = append(found, group.Ref{
 				Metro: c.Metro.Name,
@@ -132,7 +136,7 @@ func (Certificate) Get(ctx context.Context, keys []string) ([]resource.Resource,
 			})
 			results = append(results, result)
 		}
-		return results, found, nil
+		return results, found, errors.Join(errs...)
 	})
 }
 

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -334,6 +334,12 @@ func (ImageEntry) load(image platform.Image, metro *config.Metro) ([]ImageEntry,
 			return nil, fmt.Errorf("could not parse image tag %q", tag)
 		}
 
+		if strings.HasPrefix(tag, "sha256:") {
+			// HACK: skip tags that look like digests, these are malformed
+			// https://linear.app/unikraft/issue/TOOL-618
+			continue
+		}
+
 		ref, err := reference.WithTag(base, tag)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse image tag %q: %w", tag, err)

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -7,6 +7,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -216,16 +217,17 @@ func (ImageEntry) List(ctx context.Context) ([]resource.Resource, error) {
 			return nil, err
 		}
 		var results []resource.Resource
+		var errs []error
 		for _, image := range resp.Data.Images {
 			result, err := ImageEntry{}.load(image, &c.Metro)
 			if err != nil {
-				return nil, err
+				errs = append(errs, err)
 			}
 			for _, result := range result {
 				results = append(results, result)
 			}
 		}
-		return results, nil
+		return results, errors.Join(errs...)
 	})
 }
 
@@ -257,10 +259,12 @@ func (ImageEntry) Get(ctx context.Context, keys []string) ([]resource.Resource, 
 		}
 		var found []group.Ref
 		var results []resource.Resource
+		var errs []error
 		for _, image := range resp.Data.Images {
 			result, err := ImageEntry{}.load(image, &c.Metro)
 			if err != nil {
-				return nil, nil, err
+				errs = append(errs, err)
+				continue
 			}
 			for _, key := range refs {
 				for _, result := range result {
@@ -272,7 +276,7 @@ func (ImageEntry) Get(ctx context.Context, keys []string) ([]resource.Resource, 
 				}
 			}
 		}
-		return results, found, nil
+		return results, found, errors.Join(errs...)
 	})
 }
 

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -285,14 +285,15 @@ func (Instance) List(ctx context.Context) ([]resource.Resource, error) {
 			return nil, err
 		}
 		var results []resource.Resource
+		var errs []error
 		for _, instance := range resp.Data.Instances {
 			result, err := Instance{}.load(nil, instance, &c.Metro, profile)
 			if err != nil {
-				return nil, err
+				errs = append(errs, err)
 			}
 			results = append(results, result)
 		}
-		return results, nil
+		return results, errors.Join(errs...)
 	})
 }
 
@@ -313,13 +314,15 @@ func (Instance) Get(ctx context.Context, keys []string) ([]resource.Resource, er
 		}
 		var found []group.Ref
 		var results []resource.Resource
+		var errs []error
 		for i, instance := range resp.Data.Instances {
 			if instance.Status == nil || *instance.Status != platform.ResponseStatusSUCCESS {
 				continue
 			}
 			result, err := Instance{}.load(&refs[i], instance, &c.Metro, profile)
 			if err != nil {
-				return nil, nil, err
+				errs = append(errs, err)
+				continue
 			}
 			found = append(found, group.Ref{
 				Metro: c.Metro.Name,
@@ -328,7 +331,7 @@ func (Instance) Get(ctx context.Context, keys []string) ([]resource.Resource, er
 			})
 			results = append(results, result)
 		}
-		return results, found, nil
+		return results, found, errors.Join(errs...)
 	})
 }
 

--- a/internal/cmd/services.go
+++ b/internal/cmd/services.go
@@ -8,6 +8,7 @@ package cmd
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -180,14 +181,15 @@ func (ServiceGroup) List(ctx context.Context) ([]resource.Resource, error) {
 			return nil, err
 		}
 		var results []resource.Resource
+		var errs []error
 		for _, serviceGroup := range resp.Data.ServiceGroups {
 			result, err := ServiceGroup{}.load(nil, serviceGroup, &c.Metro)
 			if err != nil {
-				return nil, err
+				errs = append(errs, err)
 			}
 			results = append(results, result)
 		}
-		return results, nil
+		return results, errors.Join(errs...)
 	})
 }
 
@@ -204,13 +206,15 @@ func (ServiceGroup) Get(ctx context.Context, keys []string) ([]resource.Resource
 		}
 		var found []group.Ref
 		var results []resource.Resource
+		var errs []error
 		for i, serviceGroup := range resp.Data.ServiceGroups {
 			if serviceGroup.Status == nil || *serviceGroup.Status != platform.ResponseStatusSUCCESS {
 				continue
 			}
 			result, err := ServiceGroup{}.load(&refs[i], serviceGroup, &c.Metro)
 			if err != nil {
-				return nil, nil, err
+				errs = append(errs, err)
+				continue
 			}
 			found = append(found, group.Ref{
 				Metro: c.Metro.Name,
@@ -219,7 +223,7 @@ func (ServiceGroup) Get(ctx context.Context, keys []string) ([]resource.Resource
 			})
 			results = append(results, result)
 		}
-		return results, found, nil
+		return results, found, errors.Join(errs...)
 	})
 }
 

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -229,14 +229,15 @@ func (Volume) List(ctx context.Context) ([]resource.Resource, error) {
 			return nil, err
 		}
 		var results []resource.Resource
+		var errs []error
 		for _, volume := range resp.Data.Volumes {
 			result, err := Volume{}.load(nil, volume, &c.Metro)
 			if err != nil {
-				return nil, err
+				errs = append(errs, err)
 			}
 			results = append(results, result)
 		}
-		return results, nil
+		return results, errors.Join(errs...)
 	})
 }
 
@@ -254,13 +255,15 @@ func (Volume) Get(ctx context.Context, keys []string) ([]resource.Resource, erro
 		}
 		var found []group.Ref
 		var results []resource.Resource
+		var errs []error
 		for i, volume := range resp.Data.Volumes {
 			if volume.Status == nil || *volume.Status != platform.ResponseStatusSUCCESS {
 				continue
 			}
 			result, err := Volume{}.load(&refs[i], volume, &c.Metro)
 			if err != nil {
-				return nil, nil, err
+				errs = append(errs, err)
+				continue
 			}
 			found = append(found, group.Ref{
 				Metro: c.Metro.Name,
@@ -269,7 +272,7 @@ func (Volume) Get(ctx context.Context, keys []string) ([]resource.Resource, erro
 			})
 			results = append(results, result)
 		}
-		return results, found, nil
+		return results, found, errors.Join(errs...)
 	})
 }
 


### PR DESCRIPTION
Fixes https://linear.app/unikraft/issue/TOOL-618/unikraft-image-ls-on-production-metros-fails.