### PR TITLE
feat: Support unikraft.io images

### DIFF
--- a/cmd/unikraft/testdata/TestGolden/images/help
+++ b/cmd/unikraft/testdata/TestGolden/images/help
@@ -166,16 +166,14 @@ stdout:
 
 	Examples:
 	  # Create a copy of an image
-	  unikraft image copy index.unikraft.io/official/nginx:latest
-	  index.unikraft.io/my-user/my-nginx
+	  unikraft image copy unikraft.io/official/nginx:latest unikraft.io/my-user/my-
+	  nginx
 
 	  # Upload a local image to a remote registry
-	  unikraft image copy ./my-local-image.tar index.unikraft.io/my-user/my-
-	  image:1.0.0
+	  unikraft image copy ./my-local-image.tar unikraft.io/my-user/my-image:1.0.0
 
 	  # Download an image from a remote registry
-	  unikraft image copy index.unikraft.io/official/redis:latest ./my-redis-
-	  image.tar
+	  unikraft image copy unikraft.io/official/redis:latest ./my-redis-image.tar
 
 	Global flags:
 	  -h, --help

--- a/cmd/unikraft/testdata/TestGolden/images/inspect
+++ b/cmd/unikraft/testdata/TestGolden/images/inspect
@@ -7,7 +7,7 @@ stdout:
 $ unikraft image inspect nginx:latest
 
 stdout:
-	ref:        index.unikraft.io/official/nginx:latest
+	ref:        unikraft.io/official/nginx:latest
 	digest:     sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
 	config:
 	  platform: kraftcloud/x86_64

--- a/internal/builder/build_test.go
+++ b/internal/builder/build_test.go
@@ -35,7 +35,7 @@ EOF
 `
 	rootfsPath := writeDockerfile(t, dockerfile)
 	opts := BuildOpts{
-		Runtime: "index.unikraft.io/unikraft.org/base",
+		Runtime: "unikraft.io/unikraft.org/base",
 		Rootfs: RootfsOpts{
 			Format: kraftfile.FsTypeCpio,
 			Path:   rootfsPath,
@@ -59,7 +59,7 @@ EOF
 `
 	rootfsPath := writeDockerfile(t, dockerfile)
 	opts := BuildOpts{
-		Runtime: "index.unikraft.io/unikraft.org/base",
+		Runtime: "unikraft.io/unikraft.org/base",
 		Rootfs: RootfsOpts{
 			Format: kraftfile.FsTypeErofs,
 			Path:   rootfsPath,
@@ -83,7 +83,7 @@ EOF
 `
 	rootfsPath := writeDockerfile(t, dockerfile)
 	opts := BuildOpts{
-		Runtime: "index.unikraft.io/unikraft.org/base",
+		Runtime: "unikraft.io/unikraft.org/base",
 		Rootfs: RootfsOpts{
 			Format: kraftfile.FsTypeCpio,
 			Path:   rootfsPath,
@@ -111,7 +111,7 @@ RUN --mount=type=secret,id=api_key cat /run/secrets/api_key | grep -q s3cr3t
 	require.NoError(t, err)
 
 	opts := BuildOpts{
-		Runtime: "index.unikraft.io/unikraft.org/base",
+		Runtime: "unikraft.io/unikraft.org/base",
 		Rootfs: RootfsOpts{
 			Format:  kraftfile.FsTypeCpio,
 			Path:    rootfsPath,
@@ -134,7 +134,7 @@ CMD ["/dockerfile-cmd"]
 `
 	rootfsPath := writeDockerfile(t, dockerfile)
 	opts := BuildOpts{
-		Runtime: "index.unikraft.io/unikraft.org/base",
+		Runtime: "unikraft.io/unikraft.org/base",
 		Rootfs: RootfsOpts{
 			Format: kraftfile.FsTypeCpio,
 			Path:   rootfsPath,

--- a/internal/builder/kraftfile_test.go
+++ b/internal/builder/kraftfile_test.go
@@ -17,7 +17,7 @@ func TestKraftfileToBuildOpts(t *testing.T) {
 	rootfsDir := t.TempDir()
 	rootfsPath := "Dockerfile"
 
-	runtime := kraftfile.Runtime("index.unikraft.io/unikraft.org/base")
+	runtime := kraftfile.Runtime("unikraft.io/unikraft.org/base")
 	kf := &kraftfile.Kraftfile{
 		Cmd:     kraftfile.Command{"/server", "--flag"},
 		Env:     kraftfile.Map{{Key: "A", Value: "1"}},
@@ -44,7 +44,7 @@ func TestKraftfileToBuildOpts(t *testing.T) {
 	require.Equal(t, []string{"/server", "--flag"}, opts.Cmd)
 	require.Equal(t, kraftfile.Map{{Key: "A", Value: "1"}}, opts.Env)
 	require.Equal(t, map[string]string{"label": "value"}, opts.Labels)
-	require.Equal(t, "index.unikraft.io/unikraft.org/base", opts.Runtime)
+	require.Equal(t, "unikraft.io/unikraft.org/base", opts.Runtime)
 	require.Equal(t, kraftfile.FsTypeErofs, opts.Rootfs.Format)
 	require.Equal(t, rootfsDir, opts.Rootfs.Path)
 	require.Len(t, opts.Platform, 1)
@@ -61,7 +61,7 @@ func TestKraftfileToBuildOptsRootfsSourceError(t *testing.T) {
 	rootfsDir := t.TempDir()
 	rootfsPath := "rootfs.tar"
 
-	runtime := kraftfile.Runtime("index.unikraft.io/unikraft.org/base")
+	runtime := kraftfile.Runtime("unikraft.io/unikraft.org/base")
 	kf := &kraftfile.Kraftfile{
 		Runtime: &runtime,
 		Rootfs: &kraftfile.FS{

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -411,19 +411,19 @@ func (cmd ImagesCopyCmd) Examples() []kingkong.Example {
 		{
 			Description: "Create a copy of an image",
 			Commands: []string{
-				"unikraft image copy index.unikraft.io/official/nginx:latest index.unikraft.io/my-user/my-nginx",
+				"unikraft image copy unikraft.io/official/nginx:latest unikraft.io/my-user/my-nginx",
 			},
 		},
 		{
 			Description: "Upload a local image to a remote registry",
 			Commands: []string{
-				"unikraft image copy ./my-local-image.tar index.unikraft.io/my-user/my-image:1.0.0",
+				"unikraft image copy ./my-local-image.tar unikraft.io/my-user/my-image:1.0.0",
 			},
 		},
 		{
 			Description: "Download an image from a remote registry",
 			Commands: []string{
-				"unikraft image copy index.unikraft.io/official/redis:latest ./my-redis-image.tar",
+				"unikraft image copy unikraft.io/official/redis:latest ./my-redis-image.tar",
 			},
 		},
 	}

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -15,7 +15,12 @@ import (
 	xreference "unikraft.com/cli/internal/x/reference"
 )
 
-const DefaultRegistry = "index.unikraft.io"
+const DefaultRegistry = "unikraft.io"
+
+var defaultRegistries = []string{
+	"unikraft.io",
+	"index.unikraft.io",
+}
 
 func Accessor(ctx context.Context) (*imagespec.Accessor, error) {
 	cfg := config.FromContextOrDefault(ctx)

--- a/internal/images/resolver.go
+++ b/internal/images/resolver.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/containerd/containerd/v2/core/remotes"
@@ -135,7 +136,7 @@ func hostCreds(profile *config.Profile, hostname string) (string, string, error)
 	}
 
 	// FIXME: why are there two different auth schemes?
-	if hostname == DefaultRegistry {
+	if slices.Contains(defaultRegistries, hostname) {
 		return decodeAuth(profile.Token)
 	}
 	for _, metro := range profile.Metros {


### PR DESCRIPTION
`unikraft.io` and `index.unikraft.io` both point to the same place.

We should prefer `unikraft.io`.