### PR TITLE
fix: Improve subfield printing

### DIFF
--- a/cmd/unikraft/testdata/TestGolden/auth/help
+++ b/cmd/unikraft/testdata/TestGolden/auth/help
@@ -260,12 +260,22 @@ stdout:
 	  country
 	  endpoint
 	  insecure
-	  quotas, quotas.instances, quotas.instances.active, quotas.instances.total,
-	  quotas.vcpus, quotas.vcpus.active, quotas.memory, quotas.memory.active,
-	  quotas.services, quotas.services.groups, quotas.services.exposed,
-	  quotas.volumes, quotas.volumes.count, quotas.volumes.total, quotas.limits,
-	  quotas.limits.vcpus, quotas.limits.memory, quotas.limits.volume,
-	  quotas.limits.autoscale
+	  quotas, quotas.instances, quotas.instances.active,
+	  quotas.instances.active.used, quotas.instances.active.limit,
+	  quotas.instances.total, quotas.instances.total.used,
+	  quotas.instances.total.limit, quotas.vcpus, quotas.vcpus.active,
+	  quotas.vcpus.active.used, quotas.vcpus.active.limit, quotas.memory,
+	  quotas.memory.active, quotas.memory.active.used, quotas.memory.active.limit,
+	  quotas.services, quotas.services.groups, quotas.services.groups.used,
+	  quotas.services.groups.limit, quotas.services.exposed,
+	  quotas.services.exposed.used, quotas.services.exposed.limit, quotas.volumes,
+	  quotas.volumes.count, quotas.volumes.count.used, quotas.volumes.count.limit,
+	  quotas.volumes.total, quotas.volumes.total.used, quotas.volumes.total.limit,
+	  quotas.limits, quotas.limits.vcpus, quotas.limits.vcpus.min,
+	  quotas.limits.vcpus.max, quotas.limits.memory, quotas.limits.memory.min,
+	  quotas.limits.memory.max, quotas.limits.volume, quotas.limits.volume.min,
+	  quotas.limits.volume.max, quotas.limits.autoscale,
+	  quotas.limits.autoscale.min, quotas.limits.autoscale.max
 	  status, status.ip, status.ping, status.online
 
 	Global flags:
@@ -308,12 +318,22 @@ stdout:
 	  country
 	  endpoint
 	  insecure
-	  quotas, quotas.instances, quotas.instances.active, quotas.instances.total,
-	  quotas.vcpus, quotas.vcpus.active, quotas.memory, quotas.memory.active,
-	  quotas.services, quotas.services.groups, quotas.services.exposed,
-	  quotas.volumes, quotas.volumes.count, quotas.volumes.total, quotas.limits,
-	  quotas.limits.vcpus, quotas.limits.memory, quotas.limits.volume,
-	  quotas.limits.autoscale
+	  quotas, quotas.instances, quotas.instances.active,
+	  quotas.instances.active.used, quotas.instances.active.limit,
+	  quotas.instances.total, quotas.instances.total.used,
+	  quotas.instances.total.limit, quotas.vcpus, quotas.vcpus.active,
+	  quotas.vcpus.active.used, quotas.vcpus.active.limit, quotas.memory,
+	  quotas.memory.active, quotas.memory.active.used, quotas.memory.active.limit,
+	  quotas.services, quotas.services.groups, quotas.services.groups.used,
+	  quotas.services.groups.limit, quotas.services.exposed,
+	  quotas.services.exposed.used, quotas.services.exposed.limit, quotas.volumes,
+	  quotas.volumes.count, quotas.volumes.count.used, quotas.volumes.count.limit,
+	  quotas.volumes.total, quotas.volumes.total.used, quotas.volumes.total.limit,
+	  quotas.limits, quotas.limits.vcpus, quotas.limits.vcpus.min,
+	  quotas.limits.vcpus.max, quotas.limits.memory, quotas.limits.memory.min,
+	  quotas.limits.memory.max, quotas.limits.volume, quotas.limits.volume.min,
+	  quotas.limits.volume.max, quotas.limits.autoscale,
+	  quotas.limits.autoscale.min, quotas.limits.autoscale.max
 	  status, status.ip, status.ping, status.online
 
 	Flags:
@@ -370,12 +390,22 @@ stdout:
 	  country
 	  endpoint
 	  insecure
-	  quotas, quotas.instances, quotas.instances.active, quotas.instances.total,
-	  quotas.vcpus, quotas.vcpus.active, quotas.memory, quotas.memory.active,
-	  quotas.services, quotas.services.groups, quotas.services.exposed,
-	  quotas.volumes, quotas.volumes.count, quotas.volumes.total, quotas.limits,
-	  quotas.limits.vcpus, quotas.limits.memory, quotas.limits.volume,
-	  quotas.limits.autoscale
+	  quotas, quotas.instances, quotas.instances.active,
+	  quotas.instances.active.used, quotas.instances.active.limit,
+	  quotas.instances.total, quotas.instances.total.used,
+	  quotas.instances.total.limit, quotas.vcpus, quotas.vcpus.active,
+	  quotas.vcpus.active.used, quotas.vcpus.active.limit, quotas.memory,
+	  quotas.memory.active, quotas.memory.active.used, quotas.memory.active.limit,
+	  quotas.services, quotas.services.groups, quotas.services.groups.used,
+	  quotas.services.groups.limit, quotas.services.exposed,
+	  quotas.services.exposed.used, quotas.services.exposed.limit, quotas.volumes,
+	  quotas.volumes.count, quotas.volumes.count.used, quotas.volumes.count.limit,
+	  quotas.volumes.total, quotas.volumes.total.used, quotas.volumes.total.limit,
+	  quotas.limits, quotas.limits.vcpus, quotas.limits.vcpus.min,
+	  quotas.limits.vcpus.max, quotas.limits.memory, quotas.limits.memory.min,
+	  quotas.limits.memory.max, quotas.limits.volume, quotas.limits.volume.min,
+	  quotas.limits.volume.max, quotas.limits.autoscale,
+	  quotas.limits.autoscale.min, quotas.limits.autoscale.max
 	  status, status.ip, status.ping, status.online
 
 	Flags:

--- a/internal/cmd/metros.go
+++ b/internal/cmd/metros.go
@@ -20,6 +20,7 @@ import (
 	"unikraft.com/cli/internal/xsync"
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/x/kingkong"
+	"unikraft.com/x/log"
 	"unikraft.com/x/ptr"
 )
 
@@ -62,6 +63,7 @@ func (i Metro) Fields() ([]resource.Field, error) {
 	quotas := &metroQuotas{
 		httpClient: baseClient,
 		endpoint:   i.Endpoint,
+		name:       i.Name,
 	}
 	quotaFields, err := resource.FieldsFromStruct(quotas)
 	if err != nil {
@@ -103,6 +105,7 @@ func (i Metro) Fields() ([]resource.Field, error) {
 			return []string{ip.String()}, nil
 		}
 
+		log.G(ctx).Trace().Str("metro", i.Name).Msg("resolving metro IP")
 		addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
 		if err != nil {
 			return nil, err
@@ -141,6 +144,7 @@ func (i Metro) Fields() ([]resource.Field, error) {
 			return "", nil
 		}
 
+		log.G(ctx).Trace().Str("metro", i.Name).Msg("pinging metro")
 		addr := net.JoinHostPort(ips[0], port)
 		dialer := &net.Dialer{Timeout: timeout}
 		start := time.Now()
@@ -154,6 +158,7 @@ func (i Metro) Fields() ([]resource.Field, error) {
 	})
 
 	online := xsync.OnceCtxValues(func(ctx context.Context) (any, error) {
+		log.G(ctx).Trace().Str("metro", i.Name).Msg("checking metro online status")
 		client := &http.Client{
 			Timeout:   timeout,
 			Transport: baseClient.Transport,
@@ -280,6 +285,7 @@ type metroQuotas struct {
 
 	httpClient *http.Client
 	endpoint   string
+	name       string
 }
 
 func (q *metroQuotas) Lazy(ctx context.Context) (any, error) {
@@ -294,6 +300,7 @@ func (q *metroQuotas) Lazy(ctx context.Context) (any, error) {
 		platform.WithDefaultMetro(q.endpoint),
 	)
 
+	log.G(ctx).Trace().Str("metro", q.name).Msg("fetching metro quotas")
 	resp, err := client.GetUser(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/metros.go
+++ b/internal/cmd/metros.go
@@ -254,28 +254,28 @@ func (Metro) Examples() map[cmd.CmdType][]kingkong.Example {
 
 type metroQuotas struct {
 	Instances struct {
-		Active types.Usage[int64] `field:",long"`
-		Total  types.Usage[int64] `field:",long"`
+		Active types.Usage[int64] `field:",long,embed"`
+		Total  types.Usage[int64] `field:",long,embed"`
 	}
 	Vcpus struct {
-		Active types.Usage[int64] `field:",long"`
+		Active types.Usage[int64] `field:",long,embed"`
 	}
 	Memory struct {
-		Active types.Usage[types.SizeMebibytes] `field:",long"`
+		Active types.Usage[types.SizeMebibytes] `field:",long,embed"`
 	}
 	Services struct {
-		Groups  types.Usage[int64] `field:",long"`
-		Exposed types.Usage[int64] `field:",long"`
+		Groups  types.Usage[int64] `field:",long,embed"`
+		Exposed types.Usage[int64] `field:",long,embed"`
 	}
 	Volumes struct {
-		Count types.Usage[int64]               `field:",long"`
-		Total types.Usage[types.SizeMebibytes] `field:",long"`
+		Count types.Usage[int64]               `field:",long,embed"`
+		Total types.Usage[types.SizeMebibytes] `field:",long,embed"`
 	}
 	Limits struct {
-		Vcpus     types.Range[int64]               `field:",long"`
-		Memory    types.Range[types.SizeMebibytes] `field:",long"`
-		Volume    types.Range[types.SizeMebibytes] `field:",long"`
-		Autoscale types.Range[int64]               `field:",long"`
+		Vcpus     types.Range[int64]               `field:",long,embed"`
+		Memory    types.Range[types.SizeMebibytes] `field:",long,embed"`
+		Volume    types.Range[types.SizeMebibytes] `field:",long,embed"`
+		Autoscale types.Range[int64]               `field:",long,embed"`
 	}
 
 	httpClient *http.Client

--- a/internal/resource/cmd/printers.go
+++ b/internal/resource/cmd/printers.go
@@ -20,8 +20,8 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/muesli/termenv"
-	"golang.org/x/sync/errgroup"
 	"sigs.k8s.io/yaml"
+	"unikraft.com/x/joinerrgroup"
 
 	"unikraft.com/cli/internal/kvwriter"
 	"unikraft.com/cli/internal/resource"
@@ -138,28 +138,38 @@ func (p Printer) Print(ctx context.Context, out io.Writer, fieldSpecs []string, 
 	case PrinterTypeTemplate:
 		return printTemplate(ctx, out, p.Value, resources...)
 	case PrintTypeDebug:
-		return printDebug(out, resources...)
+		return printDebug(ctx, out, resources...)
 	default:
 		return fmt.Errorf("unknown printer type: %s", p.Type)
 	}
 }
 
 func printKV(ctx context.Context, out io.Writer, specs []string, resources ...resource.Resource) error {
-	resolved, err := extractFields(ctx, resources, func(ctx context.Context, res resource.Resource) ([]resource.Field, error) {
-		fields, err := res.Fields()
-		if err != nil {
-			return nil, err
-		}
-		fields, err = selectResourceFields(fields, false, resource.FieldVerbosityLong, specs)
-		if err != nil {
-			return nil, err
-		}
-		if err := resource.ResolveAllFields(ctx, fields); err != nil {
-			return nil, err
-		}
-		return resource.DedupeFields(fields), nil
-	})
-	if err != nil {
+	if len(resources) == 0 {
+		return nil
+	}
+
+	// Resolve all resources in parallel
+	resolved := make([][]resource.Field, len(resources))
+	eg := joinerrgroup.Group{}
+	for i, res := range resources {
+		eg.Go(func() error {
+			fields, err := res.Fields()
+			if err != nil {
+				return err
+			}
+			fields, err = selectResourceFields(fields, false, resource.FieldVerbosityLong, specs)
+			if err != nil {
+				return err
+			}
+			if err := resource.ResolveAllFields(ctx, fields); err != nil {
+				return err
+			}
+			resolved[i] = fields
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
 		return err
 	}
 
@@ -169,6 +179,7 @@ func printKV(ctx context.Context, out io.Writer, specs []string, resources ...re
 				return err
 			}
 		}
+		fields = resource.DedupeFields(fields)
 		if err := printKVFields(out, nil, fields, 0, 0); err != nil {
 			return err
 		}
@@ -288,21 +299,17 @@ func printTable(ctx context.Context, out io.Writer, fieldSpecs []string, base re
 		return err
 	}
 
-	resolved, err := extractFields(ctx, resources, func(ctx context.Context, res resource.Resource) ([]resource.Field, error) {
-		fields, err := res.Fields()
-		if err != nil {
-			return nil, err
-		}
-		if err := resource.ResolveFields(ctx, fields, headerPaths); err != nil {
-			return nil, err
-		}
-		return fields, nil
-	})
+	// Resolve all resources in parallel
+	resolved, err := resolveResources(ctx, resources, headerPaths)
 	if err != nil {
 		return err
 	}
 
-	for _, fields := range resolved {
+	for _, res := range resolved {
+		fields, err := res.Fields()
+		if err != nil {
+			return err
+		}
 
 		firstCol := true
 		for i, header := range headerFields {
@@ -384,21 +391,31 @@ func printQuiet(ctx context.Context, out io.Writer, specs []string, resources ..
 		return nil
 	}
 
-	resolved, err := extractFields(ctx, resources, func(ctx context.Context, res resource.Resource) ([]resource.Field, error) {
-		fields, err := res.Fields()
-		if err != nil {
-			return nil, err
-		}
-		fields, err = selectResourceFields(fields, false, resource.FieldVerbosityNone, specs)
-		if err != nil {
-			return nil, err
-		}
-		if err := resource.ResolveAllFields(ctx, fields); err != nil {
-			return nil, err
-		}
-		return fields, nil
-	})
-	if err != nil {
+	if len(resources) == 0 {
+		return nil
+	}
+
+	// Resolve all resources in parallel
+	resolved := make([][]resource.Field, len(resources))
+	eg := joinerrgroup.Group{}
+	for i, res := range resources {
+		eg.Go(func() error {
+			fields, err := res.Fields()
+			if err != nil {
+				return err
+			}
+			fields, err = selectResourceFields(fields, false, resource.FieldVerbosityNone, specs)
+			if err != nil {
+				return err
+			}
+			if err := resource.ResolveAllFields(ctx, fields); err != nil {
+				return err
+			}
+			resolved[i] = fields
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
 		return err
 	}
 
@@ -424,23 +441,18 @@ func printQuiet(ctx context.Context, out io.Writer, specs []string, resources ..
 }
 
 func printJSON(ctx context.Context, out io.Writer, resources ...resource.Resource) error {
-	fields, err := extractFields(ctx, resources, func(ctx context.Context, res resource.Resource) ([]resource.Field, error) {
-		fields, err := res.Fields()
-		if err != nil {
-			return nil, err
-		}
-		if err := resource.ResolveAllFields(ctx, fields); err != nil {
-			return nil, err
-		}
-		return fields, nil
-	})
+	resolved, err := resolveAllResources(ctx, resources)
 	if err != nil {
 		return err
 	}
 
-	input := make([]any, len(resources))
-	for i := range fields {
-		input[i] = resource.FieldsToMap(fields[i])
+	input := make([]any, len(resolved))
+	for i, res := range resolved {
+		fields, err := res.Fields()
+		if err != nil {
+			return err
+		}
+		input[i] = resource.FieldsToMap(fields)
 	}
 	dt, err := json.MarshalIndent(input, "", "  ")
 	if err != nil {
@@ -451,23 +463,18 @@ func printJSON(ctx context.Context, out io.Writer, resources ...resource.Resourc
 }
 
 func printYAML(ctx context.Context, out io.Writer, resources ...resource.Resource) error {
-	fields, err := extractFields(ctx, resources, func(ctx context.Context, res resource.Resource) ([]resource.Field, error) {
-		fields, err := res.Fields()
-		if err != nil {
-			return nil, err
-		}
-		if err := resource.ResolveAllFields(ctx, fields); err != nil {
-			return nil, err
-		}
-		return fields, nil
-	})
+	resolved, err := resolveAllResources(ctx, resources)
 	if err != nil {
 		return err
 	}
 
-	input := make([]any, len(resources))
-	for i := range fields {
-		input[i] = resource.FieldsToMap(fields[i])
+	input := make([]any, len(resolved))
+	for i, res := range resolved {
+		fields, err := res.Fields()
+		if err != nil {
+			return err
+		}
+		input[i] = resource.FieldsToMap(fields)
 	}
 	dt, err := yaml.Marshal(input)
 	if err != nil {
@@ -498,12 +505,14 @@ func printTemplate(ctx context.Context, out io.Writer, tmplStr string, resources
 		return err
 	}
 
-	for _, res := range resources {
+	resolved, err := resolveAllResources(ctx, resources)
+	if err != nil {
+		return err
+	}
+
+	for _, res := range resolved {
 		fields, err := res.Fields()
 		if err != nil {
-			return err
-		}
-		if err := resource.ResolveAllFields(ctx, fields); err != nil {
 			return err
 		}
 		input := resource.FieldsToMap(fields)
@@ -523,8 +532,13 @@ func printTemplate(ctx context.Context, out io.Writer, tmplStr string, resources
 	return nil
 }
 
-func printDebug(out io.Writer, resources ...resource.Resource) error {
-	for _, res := range resources {
+func printDebug(ctx context.Context, out io.Writer, resources ...resource.Resource) error {
+	resolved, err := resolveAllResources(ctx, resources)
+	if err != nil {
+		return err
+	}
+
+	for _, res := range resolved {
 		fields, err := res.Fields()
 		if err != nil {
 			return err
@@ -656,25 +670,4 @@ func PrintPatches(out io.Writer, fields []resource.Field, create bool) error {
 		}
 	}
 	return tw.Flush()
-}
-
-func extractFields(ctx context.Context, resources []resource.Resource, fn func(context.Context, resource.Resource) ([]resource.Field, error)) ([][]resource.Field, error) {
-	result := make([][]resource.Field, len(resources))
-
-	g, ctx := errgroup.WithContext(ctx)
-	for i, res := range resources {
-		g.Go(func() error {
-			fields, err := fn(ctx, res)
-			if err != nil {
-				return err
-			}
-			result[i] = fields
-			return nil
-		})
-	}
-	if err := g.Wait(); err != nil {
-		return nil, err
-	}
-
-	return result, nil
 }

--- a/internal/resource/cmd/resolve.go
+++ b/internal/resource/cmd/resolve.go
@@ -61,6 +61,43 @@ func resolveResource(ctx context.Context, res resource.Resource, paths []resourc
 	return resolvedResource{Resource: res, fields: resolved}, nil
 }
 
+func resolveAllResources(ctx context.Context, resources []resource.Resource) ([]resource.Resource, error) {
+	if len(resources) == 0 {
+		return resources, nil
+	}
+
+	resolved := make([]resource.Resource, len(resources))
+	eg := joinerrgroup.Group{}
+	for i, res := range resources {
+		eg.Go(func() error {
+			resolvedRes, err := resolveAllResource(ctx, res)
+			if err != nil {
+				return err
+			}
+			resolved[i] = resolvedRes
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+	return resolved, nil
+}
+
+func resolveAllResource(ctx context.Context, res resource.Resource) (resource.Resource, error) {
+	fields, err := res.Fields()
+	if err != nil {
+		return nil, err
+	}
+
+	resolved := resource.CloneFields(fields)
+	if err := resource.ResolveAllFields(ctx, resolved); err != nil {
+		return nil, err
+	}
+
+	return resolvedResource{Resource: res, fields: resolved}, nil
+}
+
 func unwrapResource(r resource.Resource) resource.Resource {
 	if rr, ok := r.(resolvedResource); ok {
 		return rr.Resource


### PR DESCRIPTION
A collection of issues:
- Subfields for ranges and quotas in `unikraft metro` resources weren't being created
- Not all printers (e.g. `debug`) were resolving lazy value callbacks
- Not all printers (e.g. `quiet) were resolving resources in parallel
- Metro subfield resolution wasn't adding adequate logging