### PR TITLE
chore: Migrate integration tests to staging

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,4 +99,4 @@ jobs:
           echo "${UNIKRAFT_CONFIG_CONTENT}" > ~/.config/unikraft/config.yaml
           task --yes integration
         env:
-          UNIKRAFT_CONFIG_CONTENT: ${{ secrets.UNIKRAFT_CONFIG }}
+          UNIKRAFT_CONFIG_CONTENT: ${{ secrets.UNIKRAFT_CONFIG_STAGING }}

--- a/cmd/unikraft/build_test.go
+++ b/cmd/unikraft/build_test.go
@@ -18,11 +18,13 @@ func buildTests(t *testing.T, r *testRunner) {
 		})
 	})
 
-	var busybox, busyboxFull, metroName string
+	var busybox, metroName string
 	if r.cfg != nil {
-		busybox = r.cfg.Profile.Organization + "/busybox-e2e:$UNIQ_IMAGE"
-		busyboxFull = fmt.Sprintf("%s/%s", r.cfg.Metro.Index().Host, busybox)
 		metroName = r.cfg.MetroName
+
+		busybox = fmt.Sprintf("%s/busybox-e2e:$UNIQ_IMAGE", r.cfg.Profile.Organization)
+		// this is what we'd use to test direct push
+		// busybox := fmt.Sprintf("%s/%s/busybox-e2e:$UNIQ_IMAGE", cfg.Metro.Index().Host, cfg.Profile.Organization)
 	}
 
 	t.Run("busybox", func(t *testing.T) {
@@ -56,7 +58,7 @@ cmd: ["sh", "/entrypoint.sh"]
 `,
 			}).
 			run(t, []command{
-				{args: []string{unikraftCmd, "build", ".", "--output", busyboxFull}},
+				{args: []string{unikraftCmd, "build", ".", "--output", busybox}},
 				{args: []string{unikraftCmd, "run", "--name", "test-$UNIQ_INST", "--metro", metroName, "--output", "quiet", "--image", busybox}},
 				{args: []string{unikraftCmd, "instance", "wait", "--until", "state==stopped", "--timeout", "10s", "test-$UNIQ_INST"}},
 				{args: []string{unikraftCmd, "instance", "logs", "test-$UNIQ_INST"}},

--- a/cmd/unikraft/instances_test.go
+++ b/cmd/unikraft/instances_test.go
@@ -104,6 +104,7 @@ func instancesTests(t *testing.T, r *testRunner) {
 					},
 					captureEnv: "FQDN",
 				},
+				{args: []string{unikraftCmd, "instance", "wait", "--until", "state==running", "--timeout", "10s", "test-$UNIQ_INST"}},
 				{args: []string{
 					"curl",
 					"-k",

--- a/cmd/unikraft/testdata/TestGolden/build/busybox
+++ b/cmd/unikraft/testdata/TestGolden/build/busybox
@@ -1,4 +1,4 @@
-$ unikraft build . --output index.test.unikraft.internal/test/busybox-e2e:$UNIQ_IMAGE
+$ unikraft build . --output test/busybox-e2e:$UNIQ_IMAGE
 
 stderr:
 	│ found buildkit addr=<docker> version=vX.Y.Z

--- a/cmd/unikraft/testdata/TestGolden/instances/connect
+++ b/cmd/unikraft/testdata/TestGolden/instances/connect
@@ -28,6 +28,34 @@ stdout:
 
 $ FQDN=$(unikraft instance inspect test-$UNIQ_INST --output 'template={{ (index .service.domains 0).fqdn }}')
 
+$ unikraft instance wait --until state==running --timeout 10s test-$UNIQ_INST
+
+stdout:
+	metro:        test
+	name:         test-<INST>
+	uuid:         12345678-1234-1234-1234-123456789abc
+	state:        running
+	image:        nginx
+	runtime:
+	  env:
+	    A:        1
+	    B:        2
+	    C:        3
+	resources:
+	  memory:     128MiB
+	  vcpus:      1
+	service:
+	  uuid:       12345678-1234-1234-1234-123456789abc
+	  name:       <SERVICE_NAME>
+	  domains:
+	  - fqdn:     <DOMAIN>.unikraft.internal
+	networks:
+	- uuid:       12345678-1234-1234-1234-123456789abc
+	  private-ip: 10.X.X.X
+	  mac:        aa:bb:cc:dd:ee:ff
+	timestamps:
+	  created:    RELATIVE_TIME
+
 $ curl -k --fail --silent --show-error --output /dev/null --write-out 'HTTP %{http_code} OK\n%header{server}\n' --retry 10 --retry-delay 2 --retry-all-errors --connect-timeout 5 --max-time 10 https://$FQDN
 
 stdout:

--- a/cmd/unikraft/testdata/TestGolden/instances/instances/add-domain
+++ b/cmd/unikraft/testdata/TestGolden/instances/instances/add-domain
@@ -13,7 +13,7 @@ stdout:
 	  uuid:       12345678-1234-1234-1234-123456789abc
 	  name:       <SERVICE_NAME>
 	  domains:
-	  - fqdn:     <SERVICE_NAME>.ukp-stable.unikraft.internal
+	  - fqdn:     <SERVICE_NAME>.ukp-staging.unikraft.internal
 	networks:
 	- uuid:       12345678-1234-1234-1234-123456789abc
 	  private-ip: 10.X.X.X
@@ -43,7 +43,7 @@ stdout:
 	  uuid:       12345678-1234-1234-1234-123456789abc
 	  name:       <SERVICE_NAME>
 	  domains:
-	  - fqdn:     <SERVICE_NAME>.ukp-stable.unikraft.internal
+	  - fqdn:     <SERVICE_NAME>.ukp-staging.unikraft.internal
 	  - fqdn:     <DOMAIN>.unikraft.internal
 	networks:
 	- uuid:       12345678-1234-1234-1234-123456789abc


### PR DESCRIPTION
This is a tests change, a CI change, and also a change to support some of the features on staging.

We need some updates to support image parsing - the images returned are now fully-resolved names, and also contain "oci://" schemes, which we should parse and support.

Includes https://github.com/unikraft/cli/pull/259.