### PR TITLE
test: Fix race conditions causing flaky tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,8 +17,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}
 
 jobs:
-  go:
-    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'arc-unikraft-cli-ubuntu24.04-standard' }}
+  unit:
+    runs-on: ubuntu-latest
     env:
       TASK_X_REMOTE_TASKFILES: 1
     steps:
@@ -50,7 +50,40 @@ jobs:
       - name: Run unit tests
         shell: bash
         run: |
-          task --yes test
+          task --yes unit-race
+        env:
+          CGO_ENABLED: 1 # needed for race checker
+
+  integration:
+    runs-on: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'ubuntu-latest' || 'arc-unikraft-cli-ubuntu24.04-standard' }}
+    needs: unit
+    env:
+      TASK_X_REMOTE_TASKFILES: 1
+    steps:
+      - uses: actions/checkout@v6
+      - uses: go-task/setup-task@v1
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Set Go variables
+        id: goenv
+        run: |
+          {
+            echo "cache=$(go env GOCACHE)"
+            echo "modcache=$(go env GOMODCACHE)"
+            echo "mod=$(go env GOMOD)"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Go caches
+        uses: actions/cache@v5
+        with:
+          path: |
+            ${{ steps.goenv.outputs.cache }}
+            ${{ steps.goenv.outputs.modcache }}
+          key: ${{ github.job }}-${{ runner.os }}-go-${{ hashFiles(steps.goenv.outputs.mod) }}
+          restore-keys: |
+            ${{ github.job }}-${{ runner.os }}-go-
 
       - name: Run integration tests (without auth)
         if: ${{ !(github.event_name == 'push' || !github.event.pull_request.head.repo.fork) }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -54,6 +54,14 @@ tasks:
     cmds:
     - task: go:test
 
+  unit-race:
+    desc: Run unit tests with the race detector.
+    silent: true
+    cmds:
+    - task: go:test
+      vars:
+        CLI_ARGS: "-race"
+
   integration:
     desc: Run integration tests.
     silent: true

--- a/internal/resource/cmd/cmd_test.go
+++ b/internal/resource/cmd/cmd_test.go
@@ -13,7 +13,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1378,9 +1380,12 @@ func TestValueCallback(t *testing.T) {
 		env := resourcet.NewTestEnv()
 		env.Add(resourcet.TestResource{ID: "1", Name: "res1", State: "running"})
 		env.Add(resourcet.TestResource{ID: "2", Name: "res2", State: "stopped"})
+		var resolvedMu sync.Mutex
 		var resolved []string
 		env.Hooks.OnLazyResolve = func(resourceName string) {
+			resolvedMu.Lock()
 			resolved = append(resolved, resourceName)
+			resolvedMu.Unlock()
 		}
 		ctx := resourcet.WithTestEnv(context.Background(), env)
 
@@ -1394,16 +1399,22 @@ func TestValueCallback(t *testing.T) {
 		assert.Contains(t, output, "running")
 		assert.NotContains(t, output, "computed-")
 		// Callback should not be invoked when lazy field is not requested
-		assert.Empty(t, resolved, "callbacks should not be invoked when lazy field not selected")
+		resolvedMu.Lock()
+		resolvedCopy := slices.Clone(resolved)
+		resolvedMu.Unlock()
+		assert.Empty(t, resolvedCopy, "callbacks should not be invoked when lazy field not selected")
 	})
 
 	t.Run("list_with_lazy_field", func(t *testing.T) {
 		env := resourcet.NewTestEnv()
 		env.Add(resourcet.TestResource{ID: "1", Name: "res1", State: "running"})
 		env.Add(resourcet.TestResource{ID: "2", Name: "res2", State: "stopped"})
+		var resolvedMu sync.Mutex
 		var resolved []string
 		env.Hooks.OnLazyResolve = func(resourceName string) {
+			resolvedMu.Lock()
 			resolved = append(resolved, resourceName)
+			resolvedMu.Unlock()
 		}
 		ctx := resourcet.WithTestEnv(context.Background(), env)
 
@@ -1422,16 +1433,22 @@ func TestValueCallback(t *testing.T) {
 		assert.Contains(t, output, "res2")
 		assert.Contains(t, output, "computed-res2")
 		// Callback should be invoked once per resource
-		assert.ElementsMatch(t, []string{"res1", "res2"}, resolved, "callbacks should be invoked for each resource")
+		resolvedMu.Lock()
+		resolvedCopy := slices.Clone(resolved)
+		resolvedMu.Unlock()
+		assert.ElementsMatch(t, []string{"res1", "res2"}, resolvedCopy, "callbacks should be invoked for each resource")
 	})
 
 	t.Run("get_with_lazy_field", func(t *testing.T) {
 		env := resourcet.NewTestEnv()
 		env.Add(resourcet.TestResource{ID: "1", Name: "res1", State: "running"})
 		env.Add(resourcet.TestResource{ID: "2", Name: "res2", State: "stopped"})
+		var resolvedMu sync.Mutex
 		var resolved []string
 		env.Hooks.OnLazyResolve = func(resourceName string) {
+			resolvedMu.Lock()
 			resolved = append(resolved, resourceName)
+			resolvedMu.Unlock()
 		}
 		ctx := resourcet.WithTestEnv(context.Background(), env)
 
@@ -1448,16 +1465,22 @@ func TestValueCallback(t *testing.T) {
 		output := out.String()
 		assert.Contains(t, output, "res1")
 		assert.Contains(t, output, "computed-res1")
-		assert.ElementsMatch(t, []string{"res1"}, resolved, "callback should be invoked once for requested resource")
+		resolvedMu.Lock()
+		resolvedCopy := slices.Clone(resolved)
+		resolvedMu.Unlock()
+		assert.ElementsMatch(t, []string{"res1"}, resolvedCopy, "callback should be invoked once for requested resource")
 	})
 
 	t.Run("quiet_output_with_lazy_field", func(t *testing.T) {
 		env := resourcet.NewTestEnv()
 		env.Add(resourcet.TestResource{ID: "1", Name: "res1", State: "running"})
 		env.Add(resourcet.TestResource{ID: "2", Name: "res2", State: "stopped"})
+		var resolvedMu sync.Mutex
 		var resolved []string
 		env.Hooks.OnLazyResolve = func(resourceName string) {
+			resolvedMu.Lock()
 			resolved = append(resolved, resourceName)
+			resolvedMu.Unlock()
 		}
 		ctx := resourcet.WithTestEnv(context.Background(), env)
 
@@ -1474,16 +1497,22 @@ func TestValueCallback(t *testing.T) {
 		output := out.String()
 		assert.Contains(t, output, "res1 computed-res1")
 		assert.Contains(t, output, "res2 computed-res2")
-		assert.ElementsMatch(t, []string{"res1", "res2"}, resolved)
+		resolvedMu.Lock()
+		resolvedCopy := slices.Clone(resolved)
+		resolvedMu.Unlock()
+		assert.ElementsMatch(t, []string{"res1", "res2"}, resolvedCopy)
 	})
 
 	t.Run("filter_on_lazy_field_without_selecting_it", func(t *testing.T) {
 		env := resourcet.NewTestEnv()
 		env.Add(resourcet.TestResource{ID: "1", Name: "res1", State: "running"})
 		env.Add(resourcet.TestResource{ID: "2", Name: "res2", State: "stopped"})
+		var resolvedMu sync.Mutex
 		var resolved []string
 		env.Hooks.OnLazyResolve = func(resourceName string) {
+			resolvedMu.Lock()
 			resolved = append(resolved, resourceName)
+			resolvedMu.Unlock()
 		}
 		ctx := resourcet.WithTestEnv(context.Background(), env)
 
@@ -1500,16 +1529,22 @@ func TestValueCallback(t *testing.T) {
 		assert.Contains(t, output, "res1")
 		assert.NotContains(t, output, "res2")
 		// Callbacks should be invoked to evaluate the filter for all resources
-		assert.ElementsMatch(t, []string{"res1", "res2"}, resolved, "callbacks should be invoked to evaluate filter")
+		resolvedMu.Lock()
+		resolvedCopy := slices.Clone(resolved)
+		resolvedMu.Unlock()
+		assert.ElementsMatch(t, []string{"res1", "res2"}, resolvedCopy, "callbacks should be invoked to evaluate filter")
 	})
 
 	t.Run("filter_and_select_lazy_field", func(t *testing.T) {
 		env := resourcet.NewTestEnv()
 		env.Add(resourcet.TestResource{ID: "1", Name: "res1", State: "running"})
 		env.Add(resourcet.TestResource{ID: "2", Name: "res2", State: "stopped"})
+		var resolvedMu sync.Mutex
 		var resolved []string
 		env.Hooks.OnLazyResolve = func(resourceName string) {
+			resolvedMu.Lock()
 			resolved = append(resolved, resourceName)
+			resolvedMu.Unlock()
 		}
 		ctx := resourcet.WithTestEnv(context.Background(), env)
 
@@ -1531,16 +1566,22 @@ func TestValueCallback(t *testing.T) {
 		assert.NotContains(t, output, "res2")
 		// Callback should only be invoked once per resource, not twice
 		// (once for filtering, once for display would be wrong)
-		assert.ElementsMatch(t, []string{"res1", "res2"}, resolved, "callbacks should be invoked once per resource, not twice")
+		resolvedMu.Lock()
+		resolvedCopy := slices.Clone(resolved)
+		resolvedMu.Unlock()
+		assert.ElementsMatch(t, []string{"res1", "res2"}, resolvedCopy, "callbacks should be invoked once per resource, not twice")
 	})
 
 	t.Run("list_filter_sort_select_lazy_once", func(t *testing.T) {
 		env := resourcet.NewTestEnv()
 		env.Add(resourcet.TestResource{ID: "1", Name: "res1", State: "running"})
 		env.Add(resourcet.TestResource{ID: "2", Name: "res2", State: "stopped"})
+		var resolvedMu sync.Mutex
 		var resolved []string
 		env.Hooks.OnLazyResolve = func(resourceName string) {
+			resolvedMu.Lock()
 			resolved = append(resolved, resourceName)
+			resolvedMu.Unlock()
 		}
 		ctx := resourcet.WithTestEnv(context.Background(), env)
 
@@ -1560,7 +1601,10 @@ func TestValueCallback(t *testing.T) {
 		assert.Contains(t, output, "res1")
 		assert.Contains(t, output, "computed-res1")
 		assert.NotContains(t, output, "res2")
-		assert.ElementsMatch(t, []string{"res1", "res2"}, resolved, "callback should be invoked once per resource")
+		resolvedMu.Lock()
+		resolvedCopy := slices.Clone(resolved)
+		resolvedMu.Unlock()
+		assert.ElementsMatch(t, []string{"res1", "res2"}, resolvedCopy, "callback should be invoked once per resource")
 	})
 }
 


### PR DESCRIPTION
Example failure: https://github.com/unikraft/cli/actions/runs/23244092286/job/67567774290

```
=== Failed
=== FAIL: internal/resource/cmd TestValueCallback/filter_on_lazy_field_without_selecting_it (0.00s)
    cmd_test.go:1569: 
        	Error Trace:	/home/runner/_work/cli/cli/internal/resource/cmd/cmd_test.go:1569
        	Error:      	elements differ
        	            	
        	            	extra elements in list A:
        	            	([]interface {}) (len=1) {
        	            	 (string) (len=4) "res1"
        	            	}
        	            	
        	            	
        	            	listA:
        	            	([]string) (len=2) {
        	            	 (string) (len=4) "res1",
        	            	 (string) (len=4) "res2"
        	            	}
        	            	
        	            	
        	            	listB:
        	            	([]string) (len=1) {
        	            	 (string) (len=4) "res2"
        	            	}
        	Test:       	TestValueCallback/filter_on_lazy_field_without_selecting_it
        	Messages:   	callbacks should be invoked to evaluate filter

=== FAIL: internal/resource/cmd TestValueCallback (0.00s) 
```

Caused by a race condition in a flaky new test. Very simple, we need to just do atomic append operations.