### PR TITLE
fix: Allow best-effort building old-specs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	unikraft.com/x/image-spec v0.0.0-20260304162956-523940cab1de
 	unikraft.com/x/joinerrgroup v0.0.0-20260304162956-523940cab1de
 	unikraft.com/x/kingkong v0.0.0-20260304162956-523940cab1de
-	unikraft.com/x/kraftfile v0.0.0-20260304162956-523940cab1de
+	unikraft.com/x/kraftfile v0.0.0-20260318103446-c2c548a69fc0
 	unikraft.com/x/log v0.0.0-20260126171022-af62c17fcdf7
 	unikraft.com/x/ptr v0.0.0-20260116231133-1da0081544af
 )
@@ -164,7 +164,7 @@ require (
 	go4.org/mem v0.0.0-20240501181205-ae6ca9944745 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/exp v0.0.0-20250911091902-df9299821621 // indirect
-	golang.org/x/mod v0.33.0 // indirect
+	golang.org/x/mod v0.33.0
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/time v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -477,8 +477,8 @@ unikraft.com/x/joinerrgroup v0.0.0-20260304162956-523940cab1de h1:cm4FnPvnahRIK0
 unikraft.com/x/joinerrgroup v0.0.0-20260304162956-523940cab1de/go.mod h1:XND1VvLxwqKFGrmdwUTWps4WEpMm7HTHPQg9HWQtrxg=
 unikraft.com/x/kingkong v0.0.0-20260304162956-523940cab1de h1:jrsspHGxv0kXZG/9aZRQNwJidV/ZmI2ywkw2Zh4ZbeE=
 unikraft.com/x/kingkong v0.0.0-20260304162956-523940cab1de/go.mod h1:r7a+ee0VOkocN4sCclW70Z3dFTShgfUcnyHOW/p/2A4=
-unikraft.com/x/kraftfile v0.0.0-20260304162956-523940cab1de h1:6I5NCCc8BCoJqPDTE9RKXQVfuEGg/CIVnDcZTCVT/ow=
-unikraft.com/x/kraftfile v0.0.0-20260304162956-523940cab1de/go.mod h1:OYaIMOzV1IpbZCe2J3SuC5jvT4tAfR0XG9uOPPD+p50=
+unikraft.com/x/kraftfile v0.0.0-20260318103446-c2c548a69fc0 h1:uhgXdAhZzAM5AGeymiyeP8zmZGcOj94YYsnc0JmuRTg=
+unikraft.com/x/kraftfile v0.0.0-20260318103446-c2c548a69fc0/go.mod h1:OYaIMOzV1IpbZCe2J3SuC5jvT4tAfR0XG9uOPPD+p50=
 unikraft.com/x/log v0.0.0-20260126171022-af62c17fcdf7 h1:kFOE7rmK33PiJ2GbWFd3v0WrE8DeAaQsPjrUQ+15CIU=
 unikraft.com/x/log v0.0.0-20260126171022-af62c17fcdf7/go.mod h1:f/+5628rnWTnRaRrCDD9mOMf7OV5QmkGIgARlTu4XGE=
 unikraft.com/x/ptr v0.0.0-20260116231133-1da0081544af h1:qEEtHdfIKn1p4OGrekAxbPe+Kbd1Gi1g5S3iJgTRcWM=

--- a/internal/cmd/build.go
+++ b/internal/cmd/build.go
@@ -8,6 +8,7 @@ package cmd
 import (
 	"context"
 
+	"golang.org/x/mod/semver"
 	"unikraft.com/cli/internal/builder"
 	"unikraft.com/cli/internal/buildkit"
 	"unikraft.com/cli/internal/config"
@@ -15,6 +16,7 @@ import (
 	imagespec "unikraft.com/x/image-spec"
 	"unikraft.com/x/kingkong"
 	"unikraft.com/x/kraftfile"
+	"unikraft.com/x/log"
 )
 
 type BuildCmd struct {
@@ -64,12 +66,23 @@ func (BuildCmd) Examples() []kingkong.Example {
 }
 
 func (c *BuildCmd) Run(ctx context.Context, cfg *config.Config) error {
-	kraftfile, err := kraftfile.ParseDirectory(c.Input)
+	kf, err := kraftfile.ParseDirectory(c.Input, kraftfile.WithSkippedVersionCheck())
 	if err != nil {
 		return err
 	}
+	if semver.Compare(kf.Spec, kraftfile.SpecVersionMin) < 0 {
+		log.G(ctx).Warn().
+			Str("spec", kf.Spec).
+			Str("min", kraftfile.SpecVersionMin).
+			Msg("Kraftfile spec version is older than minimum; parsing is best-effort")
+	} else if semver.Compare(kf.Spec, kraftfile.SpecVersionMax) > 0 {
+		log.G(ctx).Warn().
+			Str("spec", kf.Spec).
+			Str("max", kraftfile.SpecVersionMax).
+			Msg("Kraftfile spec version is newer than maximum; parsing is best-effort")
+	}
 
-	buildOpts, err := builder.KraftfileToBuildOpts(c.Input, kraftfile)
+	buildOpts, err := builder.KraftfileToBuildOpts(c.Input, kf)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Uses https://github.com/unikraft-cloud/x/pull/164.

The in-progress v0.7 spec still has some rough compatibility with v0.6. So we should warn, but continue to try and build.