### PR TITLE
feat!: Add shortcut flags for patches

### DIFF
--- a/cmd/unikraft/build_test.go
+++ b/cmd/unikraft/build_test.go
@@ -57,7 +57,7 @@ cmd: ["sh", "/entrypoint.sh"]
 			}).
 			run(t, []command{
 				{args: []string{unikraftCmd, "build", ".", "--output", busyboxFull}},
-				{args: []string{unikraftCmd, "run", "--name", "test-$UNIQ_INST", "--metro", metroName, "--output", "quiet", busybox}},
+				{args: []string{unikraftCmd, "run", "--name", "test-$UNIQ_INST", "--metro", metroName, "--output", "quiet", "--image", busybox}},
 				{args: []string{unikraftCmd, "instance", "wait", "--until", "state==stopped", "--timeout", "10s", "test-$UNIQ_INST"}},
 				{args: []string{unikraftCmd, "instance", "logs", "test-$UNIQ_INST"}},
 				{args: []string{unikraftCmd, "instance", "delete", "test-$UNIQ_INST"}},

--- a/cmd/unikraft/examples_test.go
+++ b/cmd/unikraft/examples_test.go
@@ -6,15 +6,18 @@
 package main
 
 import (
+	"io"
 	"iter"
 	"path/filepath"
 	"slices"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/alecthomas/kong"
 	"github.com/stretchr/testify/require"
-	"mvdan.cc/sh/v3/shell"
+	"mvdan.cc/sh/v3/expand"
+	"mvdan.cc/sh/v3/syntax"
 
 	"unikraft.com/cli/internal/cmd"
 	"unikraft.com/cli/internal/config"
@@ -55,7 +58,7 @@ func TestExamples(t *testing.T) {
 		t.Run(nodePath(node), func(t *testing.T) {
 			for _, example := range provider.Examples() {
 				for _, command := range example.Commands {
-					args, err := shell.Fields(command, func(string) string { return "" })
+					args, err := exampleFields(command)
 					require.NoError(t, err)
 					require.NotEmpty(t, args, "no args parsed for example")
 					if args[0] != unikraftCmd {
@@ -119,4 +122,20 @@ func nodePath(node *kong.Node) string {
 		return node.Name
 	}
 	return nodePath(node.Parent) + " " + node.Name
+}
+
+func exampleFields(s string) ([]string, error) {
+	p := syntax.NewParser()
+	var words []*syntax.Word
+	for w, err := range p.WordsSeq(strings.NewReader(s)) {
+		if err != nil {
+			return nil, err
+		}
+		words = append(words, w)
+	}
+	cfg := &expand.Config{
+		Env:      expand.FuncEnviron(func(string) string { return "" }),
+		CmdSubst: func(w io.Writer, _ *syntax.CmdSubst) error { return nil },
+	}
+	return expand.Fields(cfg, words...)
 }

--- a/cmd/unikraft/testdata/TestGolden/build/busybox
+++ b/cmd/unikraft/testdata/TestGolden/build/busybox
@@ -3,7 +3,7 @@ $ unikraft build . --output index.test.unikraft.internal/test/busybox-e2e:$UNIQ_
 stderr:
 	│ found buildkit addr=<docker> version=vX.Y.Z
 
-$ unikraft run --name test-$UNIQ_INST --metro test --output quiet test/busybox-e2e:$UNIQ_IMAGE
+$ unikraft run --name test-$UNIQ_INST --metro test --output quiet --image test/busybox-e2e:$UNIQ_IMAGE
 
 stdout:
 	test/test-<INST>

--- a/cmd/unikraft/testdata/TestGolden/certificates/help
+++ b/cmd/unikraft/testdata/TestGolden/certificates/help
@@ -27,10 +27,10 @@ stdout:
 	  issuer
 	  serial-number
 	  state
-	  timestamps, timestamps.created, timestamps.not-before, timestamps.not-after
 	  cn
 	  chain
 	  pkey
+	  timestamps, timestamps.created, timestamps.not-before, timestamps.not-after
 
 	Global flags:
 	  -h, --help
@@ -74,10 +74,10 @@ stdout:
 	  issuer
 	  serial-number
 	  state
-	  timestamps, timestamps.created, timestamps.not-before, timestamps.not-after
 	  cn
 	  chain
 	  pkey
+	  timestamps, timestamps.created, timestamps.not-before, timestamps.not-after
 
 	Flags:
 	  -w, --watch
@@ -129,10 +129,10 @@ stdout:
 	  issuer
 	  serial-number
 	  state
-	  timestamps, timestamps.created, timestamps.not-before, timestamps.not-after
 	  cn
 	  chain
 	  pkey
+	  timestamps, timestamps.created, timestamps.not-before, timestamps.not-after
 
 	Flags:
 	      --filter
@@ -184,10 +184,10 @@ stdout:
 	  issuer
 	  serial-number
 	  state
-	  timestamps, timestamps.created, timestamps.not-before, timestamps.not-after
 	  cn
 	  chain
 	  pkey
+	  timestamps, timestamps.created, timestamps.not-before, timestamps.not-after
 
 	Flags:
 	      --until, --filter
@@ -235,11 +235,11 @@ stdout:
 	    -keyout cert.key \
 	    -out cert.pem
 	  unikraft certificate create \
-	    --set name=demo-cert \
-	    --set cn=demo.unikraft.dev. \
-	    --set-file chain=cert.pem \
-	    --set-file pkey=cert.key \
-	    --set metro=fra
+	  	  --name demo-cert \
+	  	  --cn demo.unikraft.dev. \
+	  	  --chain cert.pem \
+	  	  --pkey cert.key \
+	  	  --metro fra
 
 	Fields:
 	  metro
@@ -250,15 +250,15 @@ stdout:
 	  issuer
 	  serial-number
 	  state
-	  timestamps, timestamps.created, timestamps.not-before, timestamps.not-after
 	  cn
 	  chain
 	  pkey
+	  timestamps, timestamps.created, timestamps.not-before, timestamps.not-after
 
 	Flags:
-	      --set, --set-file
+	      --set=<name>=<value>, --set-file=<name>=<filename>
 	          Key-value pairs to set on the certificate.
-	  -e, --visual
+	      --visual
 	          Open an editor to modify fields visually.
 	      --cmd
 	          Run a command to edit fields (receives YAML on stdin, outputs edited YAML on stdout).
@@ -288,6 +288,20 @@ stdout:
 	          Toggle anonymous usage analytics.
 	          [default: true]
 
+	Create flags:
+	      --metro=<metro>
+	          Metro to create in.
+	          [examples: fra, sfo, nyc]
+	      --name=<name>
+	          Certificate name.
+	      --common-name=<fqdn>, --cn
+	          Certificate common name.
+	          [example: demo.unikraft.dev.]
+	      --chain=<file>
+	          Certificate chain file.
+	      --private-key=<file>, --pkey
+	          Certificate private key file.
+
 $ unikraft certificate delete --help
 
 stdout:
@@ -313,10 +327,10 @@ stdout:
 	  issuer
 	  serial-number
 	  state
-	  timestamps, timestamps.created, timestamps.not-before, timestamps.not-after
 	  cn
 	  chain
 	  pkey
+	  timestamps, timestamps.created, timestamps.not-before, timestamps.not-after
 
 	Flags:
 	      --all

--- a/cmd/unikraft/testdata/TestGolden/help/empty
+++ b/cmd/unikraft/testdata/TestGolden/help/empty
@@ -63,8 +63,8 @@ stdout:
 	  unikraft build . --output my-org/my-app:latest
 
 	  # Deploy a new instance from an image
-	  unikraft run --metro=sfo --autostart -p 443:8080/http+tls --scale-to-zero
-	  policy=on nginx:latest
+	  unikraft run --metro=sfo --image=nginx:latest --autostart -p 443:8080/http+tls
+	  --scale-to-zero policy=on
 
 	  # Switch to a different profile
 	  unikraft profile use my-other-profile

--- a/cmd/unikraft/testdata/TestGolden/help/help
+++ b/cmd/unikraft/testdata/TestGolden/help/help
@@ -63,8 +63,8 @@ stdout:
 	  unikraft build . --output my-org/my-app:latest
 
 	  # Deploy a new instance from an image
-	  unikraft run --metro=sfo --autostart -p 443:8080/http+tls --scale-to-zero
-	  policy=on nginx:latest
+	  unikraft run --metro=sfo --image=nginx:latest --autostart -p 443:8080/http+tls
+	  --scale-to-zero policy=on
 
 	  # Switch to a different profile
 	  unikraft profile use my-other-profile

--- a/cmd/unikraft/testdata/TestGolden/help/invalid/help
+++ b/cmd/unikraft/testdata/TestGolden/help/invalid/help
@@ -63,8 +63,8 @@ stdout:
 	  unikraft build . --output my-org/my-app:latest
 
 	  # Deploy a new instance from an image
-	  unikraft run --metro=sfo --autostart -p 443:8080/http+tls --scale-to-zero
-	  policy=on nginx:latest
+	  unikraft run --metro=sfo --image=nginx:latest --autostart -p 443:8080/http+tls
+	  --scale-to-zero policy=on
 
 	  # Switch to a different profile
 	  unikraft profile use my-other-profile
@@ -160,8 +160,8 @@ stdout:
 	  unikraft build . --output my-org/my-app:latest
 
 	  # Deploy a new instance from an image
-	  unikraft run --metro=sfo --autostart -p 443:8080/http+tls --scale-to-zero
-	  policy=on nginx:latest
+	  unikraft run --metro=sfo --image=nginx:latest --autostart -p 443:8080/http+tls
+	  --scale-to-zero policy=on
 
 	  # Switch to a different profile
 	  unikraft profile use my-other-profile

--- a/cmd/unikraft/testdata/TestGolden/instances/help
+++ b/cmd/unikraft/testdata/TestGolden/instances/help
@@ -15,10 +15,10 @@ stdout:
 	          List instances.
 	  delete, rm, remove
 	          Remove a instance.
-	  edit
-	          Edit a instance.
 	  create
-	          Create a instance.
+	          Create an instance.
+	  edit
+	          Edit an instance.
 	  logs
 	          Fetch and display instance logs.
 	  start
@@ -37,23 +37,22 @@ stdout:
 	  image
 	  runtime, runtime.args, runtime.env
 	  resources, resources.memory, resources.vcpus
-	  volumes, volumes.*
-	  service, service.uuid, service.name, service.domains, service.domains.*,
-	  service.domains.*.fqdn, service.domains.*.certificate,
+	  service, service.uuid, service.name, service.services, service.domains,
+	  service.domains.*, service.domains.*.fqdn, service.domains.*.certificate,
 	  service.domains.*.certificate.name, service.domains.*.certificate.uuid,
-	  service.services, service.soft-limit, service.hard-limit
+	  service.soft-limit, service.hard-limit
+	  volumes, volumes.*
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped
-	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
-	  zero.stateful, scale-to-zero.cooldown-time
+	  scale-to-zero
 	  timing, timing.uptime, timing.boot-time, timing.net-time
 	  restart, restart.policy, restart.start-count, restart.restart-count
-	  stop, stop.reason, stop.origin, stop.errno, stop.exit-code
 	  autostart
 	  replicas
 	  wait-timeout
 	  features
 	  vsock
+	  stop, stop.reason, stop.origin, stop.errno, stop.exit-code
 
 	Global flags:
 	  -h, --help
@@ -97,23 +96,22 @@ stdout:
 	  image
 	  runtime, runtime.args, runtime.env
 	  resources, resources.memory, resources.vcpus
-	  volumes, volumes.*
-	  service, service.uuid, service.name, service.domains, service.domains.*,
-	  service.domains.*.fqdn, service.domains.*.certificate,
+	  service, service.uuid, service.name, service.services, service.domains,
+	  service.domains.*, service.domains.*.fqdn, service.domains.*.certificate,
 	  service.domains.*.certificate.name, service.domains.*.certificate.uuid,
-	  service.services, service.soft-limit, service.hard-limit
+	  service.soft-limit, service.hard-limit
+	  volumes, volumes.*
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped
-	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
-	  zero.stateful, scale-to-zero.cooldown-time
+	  scale-to-zero
 	  timing, timing.uptime, timing.boot-time, timing.net-time
 	  restart, restart.policy, restart.start-count, restart.restart-count
-	  stop, stop.reason, stop.origin, stop.errno, stop.exit-code
 	  autostart
 	  replicas
 	  wait-timeout
 	  features
 	  vsock
+	  stop, stop.reason, stop.origin, stop.errno, stop.exit-code
 
 	Flags:
 	  -w, --watch
@@ -165,23 +163,22 @@ stdout:
 	  image
 	  runtime, runtime.args, runtime.env
 	  resources, resources.memory, resources.vcpus
-	  volumes, volumes.*
-	  service, service.uuid, service.name, service.domains, service.domains.*,
-	  service.domains.*.fqdn, service.domains.*.certificate,
+	  service, service.uuid, service.name, service.services, service.domains,
+	  service.domains.*, service.domains.*.fqdn, service.domains.*.certificate,
 	  service.domains.*.certificate.name, service.domains.*.certificate.uuid,
-	  service.services, service.soft-limit, service.hard-limit
+	  service.soft-limit, service.hard-limit
+	  volumes, volumes.*
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped
-	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
-	  zero.stateful, scale-to-zero.cooldown-time
+	  scale-to-zero
 	  timing, timing.uptime, timing.boot-time, timing.net-time
 	  restart, restart.policy, restart.start-count, restart.restart-count
-	  stop, stop.reason, stop.origin, stop.errno, stop.exit-code
 	  autostart
 	  replicas
 	  wait-timeout
 	  features
 	  vsock
+	  stop, stop.reason, stop.origin, stop.errno, stop.exit-code
 
 	Flags:
 	      --filter
@@ -233,23 +230,22 @@ stdout:
 	  image
 	  runtime, runtime.args, runtime.env
 	  resources, resources.memory, resources.vcpus
-	  volumes, volumes.*
-	  service, service.uuid, service.name, service.domains, service.domains.*,
-	  service.domains.*.fqdn, service.domains.*.certificate,
+	  service, service.uuid, service.name, service.services, service.domains,
+	  service.domains.*, service.domains.*.fqdn, service.domains.*.certificate,
 	  service.domains.*.certificate.name, service.domains.*.certificate.uuid,
-	  service.services, service.soft-limit, service.hard-limit
+	  service.soft-limit, service.hard-limit
+	  volumes, volumes.*
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped
-	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
-	  zero.stateful, scale-to-zero.cooldown-time
+	  scale-to-zero
 	  timing, timing.uptime, timing.boot-time, timing.net-time
 	  restart, restart.policy, restart.start-count, restart.restart-count
-	  stop, stop.reason, stop.origin, stop.errno, stop.exit-code
 	  autostart
 	  replicas
 	  wait-timeout
 	  features
 	  vsock
+	  stop, stop.reason, stop.origin, stop.errno, stop.exit-code
 
 	Flags:
 	      --until, --filter
@@ -285,7 +281,7 @@ stdout:
 $ unikraft instance create --help
 
 stdout:
-	Create a instance.
+	Create an instance.
 
 	Usage:
 	  unikraft instances create [flags]
@@ -293,12 +289,12 @@ stdout:
 	Examples:
 	  # Create a new instance
 	  unikraft instance create \
-	    --set name=demo-instance \
-	    --set metro=fra \
-	    --set image=nginx:latest \
-	    --set autostart=true \
-	    --set resources.memory=128 \
-	    --set resources.vcpus=1
+	  	  --name demo-instance \
+	  	  --metro fra \
+	  	  --image nginx:latest \
+	  	  --autostart \
+	  	  --memory 128 \
+	  	  --vcpus 1
 
 	Fields:
 	  metro
@@ -309,28 +305,27 @@ stdout:
 	  image
 	  runtime, runtime.args, runtime.env
 	  resources, resources.memory, resources.vcpus
-	  volumes, volumes.*
-	  service, service.uuid, service.name, service.domains, service.domains.*,
-	  service.domains.*.fqdn, service.domains.*.certificate,
+	  service, service.uuid, service.name, service.services, service.domains,
+	  service.domains.*, service.domains.*.fqdn, service.domains.*.certificate,
 	  service.domains.*.certificate.name, service.domains.*.certificate.uuid,
-	  service.services, service.soft-limit, service.hard-limit
+	  service.soft-limit, service.hard-limit
+	  volumes, volumes.*
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped
-	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
-	  zero.stateful, scale-to-zero.cooldown-time
+	  scale-to-zero
 	  timing, timing.uptime, timing.boot-time, timing.net-time
 	  restart, restart.policy, restart.start-count, restart.restart-count
-	  stop, stop.reason, stop.origin, stop.errno, stop.exit-code
 	  autostart
 	  replicas
 	  wait-timeout
 	  features
 	  vsock
+	  stop, stop.reason, stop.origin, stop.errno, stop.exit-code
 
 	Flags:
-	      --set, --set-file
+	      --set=<name>=<value>, --set-file=<name>=<filename>
 	          Key-value pairs to set on the instance.
-	  -e, --visual
+	      --visual
 	          Open an editor to modify fields visually.
 	      --cmd
 	          Run a command to edit fields (receives YAML on stdin, outputs edited YAML on stdout).
@@ -360,10 +355,55 @@ stdout:
 	          Toggle anonymous usage analytics.
 	          [default: true]
 
+	Create flags:
+	      --metro=<metro>
+	          Metro to deploy in.
+	          [examples: fra, sfo, nyc]
+	  -n, --name=<name>
+	          Instance name.
+	      --image=<name>:<tag>
+	          Image to deploy.
+	          [examples: nginx:latest, my-app:v1.2.3]
+	      --args=<arg>
+	          Arguments to pass to the instance.
+	  -e, --env=<key>=<value>
+	          Environment variables.
+	          [examples: DEBUG=true, PORT=8080]
+	  -m, --memory=<size>
+	          Memory allocation.
+	          [examples: 128MiB, 1GiB]
+	      --vcpus=<n>
+	          Number of vCPUs.
+	          [examples: 1, 2, 4]
+	  -v, --volume=<name>:<path>[:<ro>]
+	          Attach volume.
+	          [examples: my-vol:/data, cache:/tmp:ro]
+	      --service=<name>
+	          Service group name or key.
+	  -p, --publish=<src>:<dest>[/<handlers>]
+	          Publish port.
+	          [examples: 443:8080/http+tls, 80:8080/http]
+	      --domain=<fqdn>
+	          Service domain.
+	          [examples: example.com, api.example.com]
+	      --scale-to-zero=<key>=<value>
+	          Scale-to-zero options.
+	          [example: policy=on,cooldown-time=300]
+	      --restart=<policy>
+	          Restart policy.
+	          [examples: always, on-failure, never]
+	      --autostart
+	          Start instance automatically.
+	      --replicas=<n>
+	          Number of replicas.
+	          [examples: 1, 3]
+	      --features=<feature>
+	          Instance features.
+
 $ unikraft instance edit --help
 
 stdout:
-	Edit a instance.
+	Edit an instance.
 
 	Usage:
 	  unikraft instances edit <target> [flags]
@@ -374,7 +414,7 @@ stdout:
 
 	Examples:
 	  # Resize instance memory
-	  unikraft instance edit demo-instance --set resources.memory=256
+	  unikraft instance edit demo-instance --memory 256
 
 	Fields:
 	  metro
@@ -385,32 +425,31 @@ stdout:
 	  image
 	  runtime, runtime.args, runtime.env
 	  resources, resources.memory, resources.vcpus
-	  volumes, volumes.*
-	  service, service.uuid, service.name, service.domains, service.domains.*,
-	  service.domains.*.fqdn, service.domains.*.certificate,
+	  service, service.uuid, service.name, service.services, service.domains,
+	  service.domains.*, service.domains.*.fqdn, service.domains.*.certificate,
 	  service.domains.*.certificate.name, service.domains.*.certificate.uuid,
-	  service.services, service.soft-limit, service.hard-limit
+	  service.soft-limit, service.hard-limit
+	  volumes, volumes.*
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped
-	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
-	  zero.stateful, scale-to-zero.cooldown-time
+	  scale-to-zero
 	  timing, timing.uptime, timing.boot-time, timing.net-time
 	  restart, restart.policy, restart.start-count, restart.restart-count
-	  stop, stop.reason, stop.origin, stop.errno, stop.exit-code
 	  autostart
 	  replicas
 	  wait-timeout
 	  features
 	  vsock
+	  stop, stop.reason, stop.origin, stop.errno, stop.exit-code
 
 	Flags:
-	      --set, --set-file
+	      --set=<name>=<value>, --set-file=<name>=<filename>
 	          Key-value pairs to set on the instance.
-	      --add, --add-file
+	      --add=<name>=<value>, --add-file=<name>=<filename>
 	          Key-value pairs to add to the instance.
-	      --del, --del-file
+	      --del=<name>=<value>, --del-file=<name>=<filename>
 	          Keys to delete from the instance.
-	  -e, --visual
+	      --visual
 	          Open an editor to modify fields visually.
 	      --cmd
 	          Run a command to edit fields (receives YAML on stdin, outputs edited YAML on stdout).
@@ -439,6 +478,25 @@ stdout:
 	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
 	          Toggle anonymous usage analytics.
 	          [default: true]
+
+	Edit flags:
+	      --image=<name>:<tag>
+	          Image to deploy.
+	          [examples: nginx:latest, my-app:v1.2.3]
+	      --args=<arg>
+	          Arguments to pass to the instance.
+	  -e, --env=<key>=<value>
+	          Environment variables.
+	          [examples: DEBUG=true, PORT=8080]
+	  -m, --memory=<size>
+	          Memory allocation.
+	          [examples: 128MiB, 1GiB]
+	      --vcpus=<n>
+	          Number of vCPUs.
+	          [examples: 1, 2, 4]
+	      --scale-to-zero=<key>=<value>
+	          Scale-to-zero options.
+	          [example: policy=on,cooldown-time=300]
 
 $ unikraft instance delete --help
 
@@ -465,23 +523,22 @@ stdout:
 	  image
 	  runtime, runtime.args, runtime.env
 	  resources, resources.memory, resources.vcpus
-	  volumes, volumes.*
-	  service, service.uuid, service.name, service.domains, service.domains.*,
-	  service.domains.*.fqdn, service.domains.*.certificate,
+	  service, service.uuid, service.name, service.services, service.domains,
+	  service.domains.*, service.domains.*.fqdn, service.domains.*.certificate,
 	  service.domains.*.certificate.name, service.domains.*.certificate.uuid,
-	  service.services, service.soft-limit, service.hard-limit
+	  service.soft-limit, service.hard-limit
+	  volumes, volumes.*
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped
-	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
-	  zero.stateful, scale-to-zero.cooldown-time
+	  scale-to-zero
 	  timing, timing.uptime, timing.boot-time, timing.net-time
 	  restart, restart.policy, restart.start-count, restart.restart-count
-	  stop, stop.reason, stop.origin, stop.errno, stop.exit-code
 	  autostart
 	  replicas
 	  wait-timeout
 	  features
 	  vsock
+	  stop, stop.reason, stop.origin, stop.errno, stop.exit-code
 
 	Flags:
 	      --all

--- a/cmd/unikraft/testdata/TestGolden/resources/help
+++ b/cmd/unikraft/testdata/TestGolden/resources/help
@@ -11,10 +11,10 @@ stdout:
 	          Inspect a resource.
 	  list, ls
 	          List resources.
-	  edit
-	          Edit a resource.
 	  create
 	          Create a resource.
+	  edit
+	          Edit a resource.
 	  delete, rm, remove
 	          Remove a resource.
 

--- a/cmd/unikraft/testdata/TestGolden/services/help
+++ b/cmd/unikraft/testdata/TestGolden/services/help
@@ -15,10 +15,10 @@ stdout:
 	          List services.
 	  delete, rm, remove
 	          Remove a service.
-	  edit
-	          Edit a service.
 	  create
-	          Create a service.
+	          Create a service group.
+	  edit
+	          Edit a service group.
 
 	Fields:
 	  metro
@@ -221,7 +221,7 @@ stdout:
 $ unikraft service create --help
 
 stdout:
-	Create a service.
+	Create a service group.
 
 	Usage:
 	  unikraft services create [flags]
@@ -229,10 +229,10 @@ stdout:
 	Examples:
 	  # Create a new service group
 	  unikraft service create \
-	    --set name=demo-service \
-	    --set metro=fra \
-	    --set domains=name=demo \
-	    --set services=443:8080/tls+http
+	  	--name demo-service \
+	  	--metro fra \
+	  	--domains demo \
+	  	--services 443:8080/tls+http
 
 	Fields:
 	  metro
@@ -248,9 +248,9 @@ stdout:
 	  services, services.*
 
 	Flags:
-	      --set, --set-file
+	      --set=<name>=<value>, --set-file=<name>=<filename>
 	          Key-value pairs to set on the service.
-	  -e, --visual
+	      --visual
 	          Open an editor to modify fields visually.
 	      --cmd
 	          Run a command to edit fields (receives YAML on stdin, outputs edited YAML on stdout).
@@ -280,10 +280,29 @@ stdout:
 	          Toggle anonymous usage analytics.
 	          [default: true]
 
+	Create flags:
+	      --metro=<metro>
+	          Metro to create in.
+	          [examples: fra, sfo, nyc]
+	      --name=<name>
+	          Service group name.
+	      --soft-limit=<n>
+	          Soft limit.
+	          [examples: 1, 5]
+	      --hard-limit=<n>
+	          Hard limit.
+	          [examples: 10, 100]
+	      --domains=<fqdn>
+	          Service domains.
+	          [examples: example.com, api.example.com]
+	      --services=<src>:<dest>[/<handlers>]
+	          Service ports.
+	          [examples: 443:8080/http+tls, 80:8080/http]
+
 $ unikraft service edit --help
 
 stdout:
-	Edit a service.
+	Edit a service group.
 
 	Usage:
 	  unikraft services edit <target> [flags]
@@ -294,7 +313,7 @@ stdout:
 
 	Examples:
 	  # Add a new service port
-	  unikraft service edit demo-service --add services=8443:8080/tls
+	  unikraft service edit demo-service --services 8443:8080/tls
 
 	Fields:
 	  metro
@@ -310,13 +329,13 @@ stdout:
 	  services, services.*
 
 	Flags:
-	      --set, --set-file
+	      --set=<name>=<value>, --set-file=<name>=<filename>
 	          Key-value pairs to set on the service.
-	      --add, --add-file
+	      --add=<name>=<value>, --add-file=<name>=<filename>
 	          Key-value pairs to add to the service.
-	      --del, --del-file
+	      --del=<name>=<value>, --del-file=<name>=<filename>
 	          Keys to delete from the service.
-	  -e, --visual
+	      --visual
 	          Open an editor to modify fields visually.
 	      --cmd
 	          Run a command to edit fields (receives YAML on stdin, outputs edited YAML on stdout).
@@ -345,6 +364,20 @@ stdout:
 	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
 	          Toggle anonymous usage analytics.
 	          [default: true]
+
+	Edit flags:
+	      --soft-limit=<n>
+	          Soft limit.
+	          [examples: 1, 5]
+	      --hard-limit=<n>
+	          Hard limit.
+	          [examples: 10, 100]
+	      --domains=<fqdn>
+	          Service domains.
+	          [examples: example.com, api.example.com]
+	      --services=<src>:<dest>[/<handlers>]
+	          Service ports.
+	          [examples: 443:8080/http+tls, 80:8080/http]
 
 $ unikraft service delete --help
 

--- a/cmd/unikraft/testdata/TestGolden/volumes/help
+++ b/cmd/unikraft/testdata/TestGolden/volumes/help
@@ -15,10 +15,10 @@ stdout:
 	          List volumes.
 	  delete, rm, remove
 	          Remove a volume.
-	  edit
-	          Edit a volume.
 	  create
 	          Create a volume.
+	  edit
+	          Edit a volume.
 	  clone
 	          Clone a volume.
 
@@ -231,9 +231,9 @@ stdout:
 	Examples:
 	  # Create a new volume
 	  unikraft volume create \
-	    --set name=demo-volume \
-	    --set size=10 \
-	    --set metro=fra
+	  	  --name demo-volume \
+	  	  --size 10 \
+	  	  --metro fra
 
 	Fields:
 	  metro
@@ -249,9 +249,9 @@ stdout:
 	  by.*.read-only
 
 	Flags:
-	      --set, --set-file
+	      --set=<name>=<value>, --set-file=<name>=<filename>
 	          Key-value pairs to set on the volume.
-	  -e, --visual
+	      --visual
 	          Open an editor to modify fields visually.
 	      --cmd
 	          Run a command to edit fields (receives YAML on stdin, outputs edited YAML on stdout).
@@ -280,6 +280,16 @@ stdout:
 	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
 	          Toggle anonymous usage analytics.
 	          [default: true]
+
+	Create flags:
+	      --metro=<metro>
+	          Metro to create in.
+	          [examples: fra, sfo, nyc]
+	  -n, --name=<name>
+	          Volume name.
+	      --size=<size>
+	          Volume size.
+	          [examples: 10GiB, 100MiB]
 
 $ unikraft volume clone --help
 
@@ -295,10 +305,10 @@ stdout:
 
 	Examples:
 	  # Clone a volume with a new name
-	  unikraft volume clone demo-volume --set name=demo-volume-clone
+	  unikraft volume clone demo-volume --name demo-volume-clone
 
 	Flags:
-	      --set, --set-file
+	      --set=<name>=<value>, --set-file=<name>=<filename>
 	          Key-value pairs to set on the volume.
 	  -f, --field
 	          Specify which fields to include in the output.
@@ -322,6 +332,13 @@ stdout:
 	          Toggle anonymous usage analytics.
 	          [default: true]
 
+	flag-clone
+	  -n, --name=<name>
+	          New volume name.
+	      --tags=<tag>
+	          Volume tags.
+	          [examples: env=prod, team=platform]
+
 $ unikraft volume edit --help
 
 stdout:
@@ -336,7 +353,7 @@ stdout:
 
 	Examples:
 	  # Resize a volume
-	  unikraft volume edit demo-volume --set size=20
+	  unikraft volume edit demo-volume --size 20
 
 	Fields:
 	  metro
@@ -352,13 +369,13 @@ stdout:
 	  by.*.read-only
 
 	Flags:
-	      --set, --set-file
+	      --set=<name>=<value>, --set-file=<name>=<filename>
 	          Key-value pairs to set on the volume.
-	      --add, --add-file
+	      --add=<name>=<value>, --add-file=<name>=<filename>
 	          Key-value pairs to add to the volume.
-	      --del, --del-file
+	      --del=<name>=<value>, --del-file=<name>=<filename>
 	          Keys to delete from the volume.
-	  -e, --visual
+	      --visual
 	          Open an editor to modify fields visually.
 	      --cmd
 	          Run a command to edit fields (receives YAML on stdin, outputs edited YAML on stdout).
@@ -387,6 +404,11 @@ stdout:
 	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
 	          Toggle anonymous usage analytics.
 	          [default: true]
+
+	Edit flags:
+	      --size=<size>
+	          Volume size.
+	          [examples: 20GiB, 100MiB]
 
 $ unikraft volume delete --help
 

--- a/internal/cmd/any.go
+++ b/internal/cmd/any.go
@@ -12,6 +12,9 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/alecthomas/kong"
+
+	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/resource"
 	"unikraft.com/cli/internal/resource/cmd"
 	xslices "unikraft.com/cli/internal/x/slices"
@@ -20,11 +23,43 @@ import (
 
 type AnyResourceCmd struct {
 	cmd.ResourceCmd[AnyResource]
-	cmd.GettableResourceCmd[AnyResource]      `set:"name=resource" set:"names=resources"`
-	cmd.ListableResourceCmd[AnyResource]      `set:"name=resource" set:"names=resources"`
-	cmd.EditableResourceCmd[AnyResource]      `set:"name=resource" set:"names=resources"`
-	cmd.CreatableResourceCmd[AnyResource]     `set:"name=resource" set:"names=resources"`
-	cmd.BulkDeletableResourceCmd[AnyResource] `set:"name=resource" set:"names=resources"`
+	cmd.GettableResourceCmd[AnyResource]
+	cmd.ListableResourceCmd[AnyResource]
+
+	Create AnyResourceCreateCmd `cmd:"" help:"Create a resource."`
+	Edit   AnyResourceEditCmd   `cmd:"" help:"Edit a resource."`
+
+	cmd.BulkDeletableResourceCmd[AnyResource]
+}
+
+// AnyResourceCreateCmd extends the generic resource create command with shortcut
+// flags for commonly used resource fields. Each field tagged with
+// `shortcut:"<path>"` is translated into a --set <path>=<value> entry before
+// the standard create pipeline runs.
+type AnyResourceCreateCmd struct {
+	cmd.ResourceCreateCmd[AnyResource]
+
+	Type string `group:"flag-create" shortcut:"type" help:"Resource type." placeholder:"type" example:"instance,volume,service,certificate"`
+}
+
+func (c *AnyResourceCreateCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox, kctx *kong.Context) error {
+	if err := cmd.ApplyShortcutFlags(&c.SetArgs, kctx.Flags()); err != nil {
+		return err
+	}
+	return c.ResourceCreateCmd.Run(ctx, stdio, sandbox)
+}
+
+// AnyResourceEditCmd extends the generic resource edit command to enable
+// shortcut flag handling.
+type AnyResourceEditCmd struct {
+	cmd.ResourceEditCmd[AnyResource]
+}
+
+func (c *AnyResourceEditCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox, kctx *kong.Context) error {
+	if err := cmd.ApplyShortcutFlags(&c.SetArgs, kctx.Flags()); err != nil {
+		return err
+	}
+	return c.ResourceEditCmd.Run(ctx, stdio, sandbox)
 }
 
 var resourceBackends = []resource.Resource{

--- a/internal/cmd/certificates.go
+++ b/internal/cmd/certificates.go
@@ -11,6 +11,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/alecthomas/kong"
+
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/cloud/sdk/platform/group"
 	"unikraft.com/x/kingkong"
@@ -27,11 +29,34 @@ import (
 
 type CertificatesCmd struct {
 	cmd.ResourceCmd[Certificate]
-	cmd.GettableResourceCmd[Certificate]      `set:"name=certificate" set:"names=certificates"`
-	cmd.WaitableResourceCmd[Certificate]      `set:"name=certificate" set:"names=certificates"`
-	cmd.ListableResourceCmd[Certificate]      `set:"name=certificate" set:"names=certificates"`
-	cmd.BulkDeletableResourceCmd[Certificate] `set:"name=certificate" set:"names=certificates"`
-	cmd.CreatableResourceCmd[Certificate]     `set:"name=certificate" set:"names=certificates"`
+	cmd.GettableResourceCmd[Certificate]
+	cmd.WaitableResourceCmd[Certificate]
+	cmd.ListableResourceCmd[Certificate]
+	cmd.BulkDeletableResourceCmd[Certificate]
+
+	Create CertificateCreateCmd `cmd:"" help:"Create a certificate."`
+}
+
+// CertificateCreateCmd extends the generic resource create command with shortcut
+// flags for commonly used certificate fields. Each field tagged with
+// `shortcut:"<path>"` or `shortcut-file:"<path>"` is translated into a --set or
+// --set-file entry before the standard create pipeline runs.
+type CertificateCreateCmd struct {
+	cmd.ResourceCreateCmd[Certificate]
+
+	Metro string `group:"flag-create" shortcut:"metro" help:"Metro to create in." placeholder:"metro" example:"fra,sfo,nyc"`
+	Name  string `group:"flag-create" shortcut:"name" help:"Certificate name." placeholder:"name"`
+
+	CommonName string `group:"flag-create" shortcut:"cn" help:"Certificate common name." placeholder:"fqdn" example:"demo.unikraft.dev." aliases:"cn"`
+	Chain      string `group:"flag-create" shortcut-file:"chain" help:"Certificate chain file." placeholder:"file"`
+	PrivateKey string `group:"flag-create" shortcut-file:"pkey" help:"Certificate private key file." placeholder:"file" aliases:"pkey"`
+}
+
+func (c *CertificateCreateCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox, kctx *kong.Context) error {
+	if err := cmd.ApplyShortcutFlags(&c.SetArgs, kctx.Flags()); err != nil {
+		return err
+	}
+	return c.ResourceCreateCmd.Run(ctx, stdio, sandbox)
 }
 
 type Certificate struct {
@@ -45,6 +70,10 @@ type Certificate struct {
 	SerialNumber string `mirror:"certificate.serial_number" field:",long"`
 
 	State types.CertificateState `mirror:"certificate.state" field:",short"`
+
+	CN    string `field:"cn,invisible,valueless" create:"set,required"`
+	Chain string `field:"chain,invisible,valueless" create:"set,required"`
+	Pkey  string `field:"pkey,invisible,valueless" create:"set,required"`
 
 	Timestamps struct {
 		Created   types.RelativeTime `mirror:"certificate.created_at" field:",short"`
@@ -89,25 +118,6 @@ func (c Certificate) Fields() ([]resource.Field, error) {
 			}
 		}
 	}
-
-	// Add create-only fields with nil Value
-	result = append(result,
-		resource.Field{
-			Name:      "cn",
-			Verbosity: resource.FieldVerbosityInvisible,
-			Create:    &resource.Patch{Set: "", Required: true},
-		},
-		resource.Field{
-			Name:      "chain",
-			Verbosity: resource.FieldVerbosityInvisible,
-			Create:    &resource.Patch{Set: "", Required: true},
-		},
-		resource.Field{
-			Name:      "pkey",
-			Verbosity: resource.FieldVerbosityInvisible,
-			Create:    &resource.Patch{Set: "", Required: true},
-		},
-	)
 
 	return result, nil
 }
@@ -294,12 +304,18 @@ func (Certificate) Examples() map[cmd.CmdType][]kingkong.Example {
   -subj "/CN=demo.unikraft.dev" \
   -keyout cert.key \
   -out cert.pem`,
+					// `unikraft certificate create \
+					//   --set name=demo-cert \
+					//   --set cn=demo.unikraft.dev. \
+					//   --set-file chain=cert.pem \
+					//   --set-file pkey=cert.key \
+					//   --set metro=fra`,
 					`unikraft certificate create \
-  --set name=demo-cert \
-  --set cn=demo.unikraft.dev. \
-  --set-file chain=cert.pem \
-  --set-file pkey=cert.key \
-  --set metro=fra`,
+	  --name demo-cert \
+	  --cn demo.unikraft.dev. \
+	  --chain cert.pem \
+	  --pkey cert.key \
+	  --metro fra`,
 				},
 			},
 		},

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -18,7 +18,7 @@ import (
 
 type ConfigCmd struct {
 	cmd.ResourceCmd[Config]
-	cmd.GettableResourceCmd[Config] `set:"name=path" set:"names=paths"`
+	cmd.GettableResourceCmd[Config]
 }
 
 // Config wraps config.Config to implement the resource interfaces.

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -36,9 +36,9 @@ import (
 
 type ImagesCmd struct {
 	cmd.ResourceCmd[ImageEntry]
-	cmd.GettableResourceCmd[Image] `set:"name=image" set:"names=images"`
+	cmd.GettableResourceCmd[Image]
 
-	List ImagesListCmd `cmd:"" set:"name=image" set:"names=images" help:"List images." aliases:"ls"`
+	List ImagesListCmd `cmd:"" help:"List images." aliases:"ls"`
 
 	Copy ImagesCopyCmd `cmd:"" help:"Copy images."`
 }

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/alecthomas/kong"
 	"github.com/distribution/reference"
 	"github.com/google/uuid"
 	"unikraft.com/cloud/sdk/platform"
@@ -38,17 +39,85 @@ import (
 
 type InstancesCmd struct {
 	cmd.ResourceCmd[Instance]
-	cmd.GettableResourceCmd[Instance]      `set:"name=instance" set:"names=instances"`
-	cmd.WaitableResourceCmd[Instance]      `set:"name=instance" set:"names=instances"`
-	cmd.ListableResourceCmd[Instance]      `set:"name=instance" set:"names=instances"`
-	cmd.BulkDeletableResourceCmd[Instance] `set:"name=instance" set:"names=instances"`
-	cmd.EditableResourceCmd[Instance]      `set:"name=instance" set:"names=instances"`
-	cmd.CreatableResourceCmd[Instance]     `set:"name=instance" set:"names=instances"`
+	cmd.GettableResourceCmd[Instance]
+	cmd.WaitableResourceCmd[Instance]
+	cmd.ListableResourceCmd[Instance]
+	cmd.BulkDeletableResourceCmd[Instance]
+
+	Create InstanceCreateCmd `cmd:"" help:"Create an instance."`
+	Edit   InstanceEditCmd   `cmd:"" help:"Edit an instance."`
 
 	Logs    InstancesLogsCmd    `cmd:"" help:"Fetch and display instance logs."`
 	Start   InstancesStartCmd   `cmd:"" help:"Start one or more instances."`
 	Stop    InstancesStopCmd    `cmd:"" help:"Stop one or more instances."`
 	Restart InstancesRestartCmd `cmd:"" help:"Restart one or more instances."`
+}
+
+// InstanceCreateCmd extends the generic resource create command with shortcut
+// flags for commonly used instance fields. Each field tagged with
+// `shortcut:"<path>"` is translated into a --set <path>=<value> entry before
+// the standard create pipeline runs.
+type InstanceCreateCmd struct {
+	cmd.ResourceCreateCmd[Instance]
+
+	// Shortcut flags - ordered to match Instance struct layout.
+	Metro string `group:"flag-create" shortcut:"metro" help:"Metro to deploy in." placeholder:"metro" example:"fra,sfo,nyc"`
+	Name  string `group:"flag-create" shortcut:"name" short:"n" help:"Instance name." placeholder:"name"`
+
+	Image string `group:"flag-create" shortcut:"image" help:"Image to deploy." placeholder:"<name>:<tag>" example:"nginx:latest,my-app:v1.2.3"`
+
+	Args []string `group:"flag-create" shortcut:"runtime.args" help:"Arguments to pass to the instance." placeholder:"arg"`
+	Env  []string `group:"flag-create" shortcut:"runtime.env" short:"e" help:"Environment variables." placeholder:"<key>=<value>" example:"DEBUG=true,PORT=8080"`
+
+	Memory types.SizeMebibytes `group:"flag-create" shortcut:"resources.memory" short:"m" help:"Memory allocation." placeholder:"size" example:"128MiB,1GiB"`
+	Vcpus  int                 `group:"flag-create" shortcut:"resources.vcpus" help:"Number of vCPUs." placeholder:"n" example:"1,2,4"`
+
+	Volume []InstanceVolume `group:"flag-create" shortcut:"volumes" short:"v" help:"Attach volume." placeholder:"<name>:<path>[:<ro>]" example:"my-vol:/data,cache:/tmp:ro"`
+
+	Service InstanceService `group:"flag-create" shortcut:"service" help:"Service group name or key." placeholder:"name"`
+	Publish []Service       `group:"flag-create" shortcut:"service.services" short:"p" help:"Publish port." placeholder:"<src>:<dest>[/<handlers>]" example:"443:8080/http+tls,80:8080/http"`
+	Domain  []Domain        `group:"flag-create" shortcut:"service.domains" help:"Service domain." placeholder:"fqdn" example:"example.com,api.example.com"`
+
+	ScaleToZero InstanceScaleToZero `group:"flag-create" shortcut:"scale-to-zero" help:"Scale-to-zero options." placeholder:"<key>=<value>" example:"policy=on\\,cooldown-time=300"`
+
+	Restart string `group:"flag-create" shortcut:"restart.policy" help:"Restart policy." placeholder:"policy" example:"always,on-failure,never"`
+
+	Autostart *bool    `group:"flag-create" shortcut:"autostart" help:"Start instance automatically."`
+	Replicas  int64    `group:"flag-create" shortcut:"replicas" help:"Number of replicas." placeholder:"n" example:"1,3"`
+	Features  []string `group:"flag-create" shortcut:"features" help:"Instance features." placeholder:"feature"`
+}
+
+func (c *InstanceCreateCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox, kctx *kong.Context) error {
+	if err := cmd.ApplyShortcutFlags(&c.SetArgs, kctx.Flags()); err != nil {
+		return err
+	}
+	return c.ResourceCreateCmd.Run(ctx, stdio, sandbox)
+}
+
+// InstanceEditCmd extends the generic resource edit command with shortcut
+// flags for commonly used editable instance fields. Each field tagged with
+// `shortcut:"<path>"` is translated into a --set <path>=<value> entry before
+// the standard edit pipeline runs.
+type InstanceEditCmd struct {
+	cmd.ResourceEditCmd[Instance]
+
+	// Shortcut flags - only fields that support editing.
+	Image string `group:"flag-edit" shortcut:"image" help:"Image to deploy." placeholder:"<name>:<tag>" example:"nginx:latest,my-app:v1.2.3"`
+
+	Args []string `group:"flag-edit" shortcut:"runtime.args" help:"Arguments to pass to the instance." placeholder:"arg"`
+	Env  []string `group:"flag-edit" shortcut:"runtime.env" short:"e" help:"Environment variables." placeholder:"<key>=<value>" example:"DEBUG=true,PORT=8080"`
+
+	Memory types.SizeMebibytes `group:"flag-edit" shortcut:"resources.memory" short:"m" help:"Memory allocation." placeholder:"size" example:"128MiB,1GiB"`
+	Vcpus  int                 `group:"flag-edit" shortcut:"resources.vcpus" help:"Number of vCPUs." placeholder:"n" example:"1,2,4"`
+
+	ScaleToZero InstanceScaleToZero `group:"flag-edit" shortcut:"scale-to-zero" help:"Scale-to-zero options." placeholder:"<key>=<value>" example:"policy=on\\,cooldown-time=300"`
+}
+
+func (c *InstanceEditCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox, kctx *kong.Context) error {
+	if err := cmd.ApplyShortcutFlags(&c.SetArgs, kctx.Flags()); err != nil {
+		return err
+	}
+	return c.ResourceEditCmd.Run(ctx, stdio, sandbox)
 }
 
 type Instance struct {
@@ -72,13 +141,8 @@ type Instance struct {
 		VCPUs  int                 `mirror:"instance.vcpus" field:"vcpus,short" create:"set" edit:"set"`
 	}
 
+	Service *InstanceService  `mirror:"instance.service_group" field:",embed" create:"set"`
 	Volumes []*InstanceVolume `mirror:"instance.volumes" field:",embed" create:"set"`
-
-	Service struct {
-		UUID    string   `mirror:"uuid" field:",long" create:"set"`
-		Name    string   `mirror:"name" field:",long" create:"set"`
-		Domains []Domain `mirror:"domains" field:",short,embed" create:"set"`
-	} `mirror:"instance.service_group"`
 
 	Networks []struct {
 		UUID      string `mirror:"uuid" field:",long"`
@@ -92,7 +156,7 @@ type Instance struct {
 		Stopped types.RelativeTime `mirror:"instance.stopped_at"`
 	}
 
-	ScaleToZero InstanceScaleToZero `field:",embed" mirror:"instance.scale_to_zero"`
+	ScaleToZero InstanceScaleToZero `field:",embed" mirror:"instance.scale_to_zero" create:"set" edit:"set"`
 
 	Timing struct {
 		Uptime   types.DurationMS `mirror:"instance.uptime_ms"`
@@ -105,6 +169,12 @@ type Instance struct {
 		StartCount   int    `mirror:"instance.start_count"`
 		RestartCount int    `mirror:"instance.restart_count"`
 	}
+
+	Autostart   bool            `field:"autostart,invisible,valueless" create:"set"`
+	Replicas    int64           `field:"replicas,invisible,valueless" create:"set"`
+	WaitTimeout types.DurationS `field:"wait-timeout,invisible,valueless" create:"set"`
+	Features    []string        `field:"features,invisible,valueless" create:"set"`
+	Vsock       bool            `field:"vsock,invisible,valueless" create:"set" edit:"set"`
 
 	Stop struct {
 		Reason string     `field:",long"`
@@ -121,13 +191,44 @@ type Instance struct {
 	key multimetro.Key
 }
 
+type InstanceService struct {
+	Metro     string     `field:"-"`
+	UUID      string     `mirror:"uuid" field:",long"`
+	Name      string     `mirror:"name" field:",long"`
+	Services  []*Service `mirror:"services" field:",invisible,valueless" create:"set"`
+	Domains   []Domain   `mirror:"domains" field:",short,embed" create:"set"`
+	SoftLimit uint32     `field:"soft-limit,invisible,valueless" create:"set"`
+	HardLimit uint32     `field:"hard-limit,invisible,valueless" create:"set"`
+}
+
+func (i *InstanceService) UnmarshalText(data []byte) error {
+	str := strings.TrimSpace(string(data))
+	if str == "" {
+		return nil
+	}
+	if strings.Contains(str, "=") {
+		type instanceServiceAlias InstanceService
+		parsed, err := value.Parse[instanceServiceAlias]([]string{str})
+		if err != nil {
+			return err
+		}
+		*i = InstanceService(parsed)
+		return nil
+	}
+	key := multimetro.ParseKey(str)
+	i.Metro = key.Metro
+	i.UUID = key.UUID
+	i.Name = key.Name
+	return nil
+}
+
 type InstanceVolume struct {
 	UUID     string `name:"uuid" mirror:"uuid" json:"uuid,omitempty" field:",long"`
 	Name     string `name:"name" mirror:"name" json:"name,omitempty" field:",long"`
 	At       string `name:"at" mirror:"at" json:"at" field:",long"`
 	Readonly bool   `name:"readonly" mirror:"readonly" json:"readonly,omitempty" field:",long"`
 
-	Size types.SizeMebibytes `name:"size" field:"-"` // excluded from field system, but used for marshalling/unmarshalling
+	Size types.SizeMebibytes `name:"size" field:"size,invisible,valueless" create:"set"`
 }
 
 func (v *InstanceVolume) MarshalText() ([]byte, error) {
@@ -216,10 +317,54 @@ func (v *InstanceVolume) UnmarshalText(data []byte) error {
 }
 
 type InstanceScaleToZero struct {
-	Enabled      bool   `mirror:"enabled" field:",long"`
-	Policy       string `mirror:"policy" field:",long" create:"set" edit:"set"`
-	Stateful     bool   `mirror:"stateful" field:",long" create:"set" edit:"set"`
-	CooldownTime int64  `mirror:"cooldown_time_ms" field:",long" create:"set" edit:"set"`
+	Enabled      bool             `name:"-" json:"-" mirror:"enabled" field:",long"`
+	Policy       string           `name:"policy" json:"policy,omitempty" mirror:"policy" field:",long"`
+	Stateful     bool             `name:"stateful" json:"stateful,omitempty" mirror:"stateful" field:",long"`
+	CooldownTime types.DurationMS `name:"cooldown-time" json:"cooldown-time,omitempty" mirror:"cooldown_time_ms" field:",long"`
+	NotifyTime   types.DurationMS `name:"notify-time" json:"notify-time,omitempty" mirror:"notify_time_ms" field:",long"`
+}
+
+func (s *InstanceScaleToZero) UnmarshalText(data []byte) error {
+	str := strings.TrimSpace(string(data))
+	if str == "" {
+		return nil
+	}
+
+	lower := strings.ToLower(str)
+	if lower == "on" || lower == "off" {
+		s.Policy = lower
+		return nil
+	}
+
+	type scaleToZeroAlias InstanceScaleToZero
+	parsed, err := value.Parse[scaleToZeroAlias]([]string{str})
+	if err != nil {
+		return err
+	}
+	*s = InstanceScaleToZero(parsed)
+	return nil
+}
+
+func (s InstanceScaleToZero) MarshalText() ([]byte, error) {
+	var parts []string
+	if s.Policy != "" {
+		parts = append(parts, fmt.Sprintf("policy=%s", s.Policy))
+	}
+	if s.Stateful {
+		parts = append(parts, "stateful=true")
+	}
+	if s.CooldownTime > 0 {
+		parts = append(parts, fmt.Sprintf("cooldown-time=%s", s.CooldownTime))
+	}
+	if s.NotifyTime > 0 {
+		parts = append(parts, fmt.Sprintf("notify-time=%s", s.NotifyTime))
+	}
+	return []byte(strings.Join(parts, ",")), nil
+}
+
+func (s InstanceScaleToZero) MarshalJSON() ([]byte, error) {
+	type scaleToZeroJSON InstanceScaleToZero
+	return json.Marshal(scaleToZeroJSON(s))
 }
 
 func (Instance) Type() resource.Type {
@@ -269,25 +414,6 @@ func (i Instance) Fields() ([]resource.Field, error) {
 					}.String(),
 				})
 			}
-
-			// Add create-only fields to service with nil Value
-			field.Subfields = append(field.Subfields,
-				resource.Field{
-					Name:      "services",
-					Verbosity: resource.FieldVerbosityInvisible,
-					Create:    &resource.Patch{Set: []*Service(nil)},
-				},
-				resource.Field{
-					Name:      "soft-limit",
-					Verbosity: resource.FieldVerbosityInvisible,
-					Create:    &resource.Patch{Set: uint32(0)},
-				},
-				resource.Field{
-					Name:      "hard-limit",
-					Verbosity: resource.FieldVerbosityInvisible,
-					Create:    &resource.Patch{Set: uint32(0)},
-				},
-			)
 		case key.MatchesString("volumes.*"):
 			// Add link to volume resource
 			nameField, _ := field.Get("name")
@@ -304,15 +430,6 @@ func (i Instance) Fields() ([]resource.Field, error) {
 					}.String(),
 				})
 			}
-
-			// Add create-only size field to each volume with nil Value
-			field.Subfields = append(field.Subfields,
-				resource.Field{
-					Name:      "size",
-					Verbosity: resource.FieldVerbosityInvisible,
-					Create:    &resource.Patch{Set: types.SizeMebibytes(0)},
-				},
-			)
 		case key.String() == "image":
 			if i.Image.Reference != nil {
 				field.Links = append(field.Links, resource.Link{
@@ -322,36 +439,6 @@ func (i Instance) Fields() ([]resource.Field, error) {
 			}
 		}
 	}
-
-	// Add create-only fields at root level with nil Value
-	result = append(result,
-		resource.Field{
-			Name:      "autostart",
-			Verbosity: resource.FieldVerbosityInvisible,
-			Create:    &resource.Patch{Set: false},
-		},
-		resource.Field{
-			Name:      "replicas",
-			Verbosity: resource.FieldVerbosityInvisible,
-			Create:    &resource.Patch{Set: int64(0)},
-		},
-		resource.Field{
-			Name:      "wait-timeout",
-			Verbosity: resource.FieldVerbosityInvisible,
-			Create:    &resource.Patch{Set: types.DurationS(0)},
-		},
-		resource.Field{
-			Name:      "features",
-			Verbosity: resource.FieldVerbosityInvisible,
-			Create:    &resource.Patch{Set: []string(nil)},
-		},
-		resource.Field{
-			Name:      "vsock",
-			Verbosity: resource.FieldVerbosityInvisible,
-			Create:    &resource.Patch{Set: false},
-			Edit:      &resource.Patch{Set: false},
-		},
-	)
 
 	return result, nil
 }
@@ -574,12 +661,22 @@ func instancePatchSpec(path string, op patchOp, value any) (platform.UpdateInsta
 		return platform.UpdateInstancesRequestItemPropMemory_mb, int64(value.(types.SizeMebibytes))
 	case "resources.vcpus":
 		return platform.UpdateInstancesRequestItemPropVcpus, value.(int)
-	case "scale-to-zero.policy":
-		return platform.UpdateInstancesRequestItemPropScale_to_zero, map[string]any{"policy": value.(string)}
-	case "scale-to-zero.stateful":
-		return platform.UpdateInstancesRequestItemPropScale_to_zero, map[string]any{"stateful": value.(bool)}
-	case "scale-to-zero.cooldown-time":
-		return platform.UpdateInstancesRequestItemPropScale_to_zero, map[string]any{"cooldown_time_ms": int32(value.(int64))}
+	case "scale-to-zero":
+		value := value.(InstanceScaleToZero)
+		req := map[string]any{}
+		if value.Policy != "" {
+			req["policy"] = value.Policy
+		}
+		if value.Stateful {
+			req["stateful"] = value.Stateful
+		}
+		if value.CooldownTime > 0 {
+			req["cooldown_time_ms"] = int32(value.CooldownTime)
+		}
+		if value.NotifyTime > 0 {
+			req["notify_time_ms"] = int32(value.NotifyTime)
+		}
+		return platform.UpdateInstancesRequestItemPropScale_to_zero, req
 	case "vsock":
 		return "vsock", value.(bool)
 	default:
@@ -615,24 +712,23 @@ func (Instance) Create(ctx context.Context, fields []resource.Field) ([]resource
 		case "restart.policy":
 			policy := platform.CreateInstanceRequestRestartPolicy(field.Create.Set.(string))
 			req.RestartPolicy = &policy
-		case "scale-to-zero.policy":
-			if req.ScaleToZero == nil {
-				req.ScaleToZero = &platform.CreateInstanceRequestScaleToZero{}
+		case "scale-to-zero":
+			scale := field.Create.Set.(InstanceScaleToZero)
+			req.ScaleToZero = &platform.CreateInstanceRequestScaleToZero{}
+			if scale.Policy != "" {
+				req.ScaleToZero.Policy = new(platform.CreateInstanceRequestScaleToZeroPolicy(scale.Policy))
 			}
-			policy := platform.CreateInstanceRequestScaleToZeroPolicy(field.Create.Set.(string))
-			req.ScaleToZero.Policy = &policy
-		case "scale-to-zero.stateful":
-			if req.ScaleToZero == nil {
-				req.ScaleToZero = &platform.CreateInstanceRequestScaleToZero{}
+			if scale.Stateful {
+				req.ScaleToZero.Stateful = &scale.Stateful
 			}
-			stateful := field.Create.Set.(bool)
-			req.ScaleToZero.Stateful = &stateful
-		case "scale-to-zero.cooldown-time":
-			if req.ScaleToZero == nil {
-				req.ScaleToZero = &platform.CreateInstanceRequestScaleToZero{}
+			if scale.CooldownTime > 0 {
+				cooldown := int32(scale.CooldownTime)
+				req.ScaleToZero.CooldownTimeMs = &cooldown
 			}
-			cooldown := int32(field.Create.Set.(int64))
-			req.ScaleToZero.CooldownTimeMs = &cooldown
+			if scale.NotifyTime > 0 {
+				notify := int32(scale.NotifyTime)
+				req.ScaleToZero.NotifyTimeMs = &notify
+			}
 		case "volumes":
 			for _, vol := range field.Create.Set.([]*InstanceVolume) {
 				reqVol := platform.CreateInstanceRequestVolume{
@@ -652,22 +748,16 @@ func (Instance) Create(ctx context.Context, fields []resource.Field) ([]resource
 				}
 				req.Volumes = append(req.Volumes, reqVol)
 			}
-		case "service.uuid":
-			uuid := field.Create.Set.(string)
-			if uuid != "" {
-				if req.ServiceGroup == nil {
-					req.ServiceGroup = &platform.CreateInstanceRequestServiceGroup{}
-				}
-				req.ServiceGroup.Uuid = &uuid
+		case "service":
+			svc := field.Create.Set.(*InstanceService)
+			if req.ServiceGroup == nil {
+				req.ServiceGroup = &platform.CreateInstanceRequestServiceGroup{}
 			}
-		case "service.name":
-			name := field.Create.Set.(string)
-			if name != "" {
-				if req.ServiceGroup == nil {
-					req.ServiceGroup = &platform.CreateInstanceRequestServiceGroup{}
-				}
-				req.ServiceGroup.Name = &name
+			if svc.Metro != "" && svc.Metro != metro {
+				return nil, fmt.Errorf("cannot create instance: metro mismatch between service (%q) and instance (%q)", svc.Metro, metro)
 			}
+			req.ServiceGroup.Name = ptr.NilIfZero(svc.Name)
+			req.ServiceGroup.Uuid = ptr.NilIfZero(svc.UUID)
 		case "service.services":
 			services := field.Create.Set.([]*Service)
 			if len(services) > 0 {
@@ -793,20 +883,30 @@ func (Instance) Examples() map[cmd.CmdType][]kingkong.Example {
 			{
 				Description: "Create a new instance",
 				Commands: []string{
+					// `unikraft instance create \
+					//   --set name=demo-instance \
+					//   --set metro=fra \
+					//   --set image=nginx:latest \
+					//   --set autostart=true \
+					//   --set resources.memory=128 \
+					//   --set resources.vcpus=1`,
 					`unikraft instance create \
-  --set name=demo-instance \
-  --set metro=fra \
-  --set image=nginx:latest \
-  --set autostart=true \
-  --set resources.memory=128 \
-  --set resources.vcpus=1`,
+	  --name demo-instance \
+	  --metro fra \
+	  --image nginx:latest \
+	  --autostart \
+	  --memory 128 \
+	  --vcpus 1`,
 				},
 			},
 		},
 		cmd.CmdTypeEdit: {
 			{
 				Description: "Resize instance memory",
-				Commands:    []string{"unikraft instance edit demo-instance --set resources.memory=256"},
+				Commands: []string{
+					// "unikraft instance edit demo-instance --set resources.memory=256",
+					"unikraft instance edit demo-instance --memory 256",
+				},
 			},
 		},
 		cmd.CmdTypeDelete: {

--- a/internal/cmd/metros.go
+++ b/internal/cmd/metros.go
@@ -26,8 +26,8 @@ import (
 
 type MetrosCmd struct {
 	cmd.ResourceCmd[Metro]
-	cmd.GettableResourceCmd[Metro] `set:"name=metro" set:"names=metros"`
-	cmd.ListableResourceCmd[Metro] `set:"name=metro" set:"names=metros"`
+	cmd.GettableResourceCmd[Metro]
+	cmd.ListableResourceCmd[Metro]
 }
 
 type Metro struct {

--- a/internal/cmd/profile.go
+++ b/internal/cmd/profile.go
@@ -20,8 +20,8 @@ import (
 
 type ProfileCmd struct {
 	cmd.ResourceCmd[Profile]
-	cmd.GettableResourceCmd[Profile] `set:"name=profile" set:"names=profiles"`
-	cmd.ListableResourceCmd[Profile] `set:"name=profile" set:"names=profiles"`
+	cmd.GettableResourceCmd[Profile]
+	cmd.ListableResourceCmd[Profile]
 
 	Use UseCmd `cmd:"" help:"Switch between profiles."`
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -38,22 +38,22 @@ import (
 type UnikraftCLI struct {
 	globalFlags
 
-	Run   RunCmd   `cmd:"" group:"cmd-commands" help:"Run an image as an instance."`
+	Run   RunCmd   `cmd:"" group:"cmd-commands" help:"Run an image as an instance." set:"name=instance" set:"names=instances"`
 	Build BuildCmd `cmd:"" group:"cmd-commands" help:"Build a Unikraft project into a container image."`
 	TUI   TUICmd   `cmd:"" group:"cmd-commands" help:"Browse resources in a TUI."`
 
-	Metros       MetrosCmd       `cmd:"" group:"cmd-resources" help:"Manage Unikraft Cloud metros." aliases:"metro,metros"`
-	Instances    InstancesCmd    `cmd:"" group:"cmd-resources" help:"Manage Unikraft Cloud instances." aliases:"instance,instances,vm,vms"`
-	Volumes      VolumesCmd      `cmd:"" group:"cmd-resources" help:"Manage Unikraft Cloud volumes." aliases:"volume,volumes,vol,vols"`
-	Services     ServicesCmd     `cmd:"" group:"cmd-resources" help:"Manage Unikraft Cloud services." aliases:"service,services,svc,svcs"`
-	Certificates CertificatesCmd `cmd:"" group:"cmd-resources" help:"Manage Unikraft Cloud certificates." aliases:"certificate,certificates,crt,crts,cert,certs"`
-	Images       ImagesCmd       `cmd:"" group:"cmd-resources" help:"Manage Unikraft Cloud images." aliases:"image,images,img,imgs"`
-	Resources    AnyResourceCmd  `cmd:"" group:"cmd-resources" hidden:"" help:"Manage any Unikraft Cloud resource." aliases:"resource,resources"`
+	Metros       MetrosCmd       `cmd:"" group:"cmd-resources" help:"Manage Unikraft Cloud metros." aliases:"metro,metros" set:"name=metro" set:"names=metros"`
+	Instances    InstancesCmd    `cmd:"" group:"cmd-resources" help:"Manage Unikraft Cloud instances." aliases:"instance,instances,vm,vms" set:"name=instance" set:"names=instances"`
+	Volumes      VolumesCmd      `cmd:"" group:"cmd-resources" help:"Manage Unikraft Cloud volumes." aliases:"volume,volumes,vol,vols" set:"name=volume" set:"names=volumes"`
+	Services     ServicesCmd     `cmd:"" group:"cmd-resources" help:"Manage Unikraft Cloud services." aliases:"service,services,svc,svcs" set:"name=service" set:"names=services"`
+	Certificates CertificatesCmd `cmd:"" group:"cmd-resources" help:"Manage Unikraft Cloud certificates." aliases:"certificate,certificates,crt,crts,cert,certs" set:"name=certificate" set:"names=certificates"`
+	Images       ImagesCmd       `cmd:"" group:"cmd-resources" help:"Manage Unikraft Cloud images." aliases:"image,images,img,imgs" set:"name=image" set:"names=images"`
+	Resources    AnyResourceCmd  `cmd:"" group:"cmd-resources" hidden:"" help:"Manage any Unikraft Cloud resource." aliases:"resource,resources" set:"name=resource" set:"names=resources"`
 
 	Login   login.LoginCmd  `cmd:"" group:"cmd-config" help:"Login to Unikraft Cloud."`
 	Logout  login.LogoutCmd `cmd:"" group:"cmd-config" help:"Logout from Unikraft Cloud."`
-	Profile ProfileCmd      `cmd:"" group:"cmd-config" help:"Manage Unikraft Cloud profiles." aliases:"profile,profiles"`
-	Config  ConfigCmd       `cmd:"" group:"cmd-config" help:"Manage CLI configuration." aliases:"config,conf,cfg"`
+	Profile ProfileCmd      `cmd:"" group:"cmd-config" help:"Manage Unikraft Cloud profiles." aliases:"profile,profiles" set:"name=profile" set:"names=profiles"`
+	Config  ConfigCmd       `cmd:"" group:"cmd-config" help:"Manage CLI configuration." aliases:"config,conf,cfg" set:"name=path" set:"names=paths"`
 
 	Completion kongcompletion.Completion `cmd:"" group:"cmd-utilities" completion-shell-default:"false" help:"Outputs shell code for initialising tab completions."`
 	Version    version.VersionCmd        `cmd:"" group:"cmd-utilities" help:"Show version information." aliases:"version,ver,v"`
@@ -85,7 +85,7 @@ func (cli UnikraftCLI) Examples() []kingkong.Example {
 		{
 			Description: "Deploy a new instance from an image",
 			Commands: []string{
-				"unikraft run --metro=sfo --autostart -p 443:8080/http+tls --scale-to-zero policy=on nginx:latest",
+				"unikraft run --metro=sfo --image=nginx:latest --autostart -p 443:8080/http+tls --scale-to-zero policy=on",
 			},
 		},
 		{
@@ -220,6 +220,7 @@ func NewRootCmd(ctx context.Context, args []string, stdio config.Stdio) (context
 			Msg("loaded sandbox from environment")
 	}
 	kctx.Bind(sandbox)
+	kctx.Bind(kctx)
 
 	cleanup := func() error {
 		if err := sandbox.Save(); err != nil {
@@ -310,6 +311,14 @@ func NewParser(cli *UnikraftCLI) (*kong.Kong, error) {
 			return nil
 		}),
 		kong.ExplicitGroups([]kong.Group{
+			{
+				Key:   "flag-create",
+				Title: kingkong.Underline("Create flags") + ":",
+			},
+			{
+				Key:   "flag-edit",
+				Title: kingkong.Underline("Edit flags") + ":",
+			},
 			globalFlagGroup,
 			{
 				Key:   "flag-local",

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -11,50 +11,25 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/distribution/reference"
+	"github.com/alecthomas/kong"
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/logs"
 	"unikraft.com/cli/internal/multimetro"
 	"unikraft.com/cli/internal/muxreader"
 	"unikraft.com/cli/internal/resource"
-	"unikraft.com/cli/internal/resource/cmd"
-	"unikraft.com/cli/internal/resource/value"
-	"unikraft.com/cli/internal/types"
-	xmaps "unikraft.com/cli/internal/x/maps"
-	"unikraft.com/cloud/sdk/platform"
+	resourcecmd "unikraft.com/cli/internal/resource/cmd"
 	"unikraft.com/cloud/sdk/platform/group"
 	"unikraft.com/x/kingkong"
 )
 
+// RunCmd is a convenience wrapper around `instance create` that adds log
+// following capability. All instance creation flags are inherited from
+// InstanceCreateCmd via embedding.
 type RunCmd struct {
-	Image *types.ImageRef[reference.Named] `arg:"" help:"Image to run."`
-	Args  []string                         `arg:"" optional:"" help:"Arguments to pass to the instance."`
-	Env   []string                         `short:"e" help:"Set environment variables (KEY=VALUE)."`
+	InstanceCreateCmd
 
-	Name  string `short:"n" help:"Name of the instance."`
-	Metro string `help:"Metro to deploy the instance in." required:"" placeholder:"metro"`
-
-	Memory types.SizeMebibytes `short:"m" help:"Memory in IEC format (e.g., 128MiB, 1GiB, 1G)."`
-	Vcpus  int                 `help:"Number of vCPUs."`
-
-	Volume []string `short:"v" help:"Attach a volume (NAME:AT[:ro] or NAME:SIZE:AT[:ro] or UUID:AT[:ro])."`
-
-	Service     string   `help:"Service group name."`
-	Publish     []string `short:"p" help:"Publish a service port (SOURCE:DESTINATION[/HANDLERS])."`
-	Domain      []string `help:"Add a service domain (FQDN)."`
-	ScaleToZero []string `help:"Enable scale-to-zero."`
-
-	Restart       string   `help:"Restart policy."`
-	Autostart     bool     `help:"Start the instance automatically." default:"true"`
-	Replicas      int64    `help:"Number of replicas."`
-	WaitTimeoutMs int64    `help:"Wait timeout in milliseconds."`
-	Features      []string `help:"Enable instance features."`
-
-	DryRun bool `help:"Show the create preview without executing."`
-
+	// Follow is the only run-specific flag; it tails logs after creation.
 	Follow bool `help:"Follow instance logs after creation."`
-
-	cmd.FormatOpts
 }
 
 func (RunCmd) Examples() []kingkong.Example {
@@ -62,259 +37,130 @@ func (RunCmd) Examples() []kingkong.Example {
 		{
 			Description: "Deploy a new instance and expose a HTTPS service",
 			Commands: []string{
-				"unikraft run --metro=sfo -p 443:8080/http+tls nginx:latest",
+				"unikraft run --metro=sfo --image=nginx:latest -p 443:8080/http+tls",
 			},
 		},
 		{
 			Description: "Deploy a new instance and expose a HTTPS service and redirect from HTTP to HTTPS",
 			Commands: []string{
-				"unikraft run --metro=sfo -p 443:8080/http+tls -p 80:443/http+redirect nginx:latest",
+				"unikraft run --metro=sfo --image=nginx:latest -p 443:8080/http+tls -p 80:443/http+redirect",
 			},
 		},
 		{
 			Description: "Deploy and tail logs from a new instance",
 			Commands: []string{
-				"unikraft run --metro=fra --follow nginx:latest",
+				"unikraft run --metro=fra --image=nginx:latest --follow",
 			},
 		},
 		{
 			Description: "Preview instance creation without executing",
 			Commands: []string{
-				"unikraft run --metro=dal --dry-run nginx:latest",
+				"unikraft run --metro=dal --image=nginx:latest --dry-run",
 			},
 		},
 		{
 			Description: "Deploy a new instance with environment variables",
 			Commands: []string{
-				"unikraft run --metro=was -e KEY1=VALUE1 -e KEY2=VALUE2 my-app:latest",
+				"unikraft run --metro=was --image=my-app:latest -e KEY1=VALUE1 -e KEY2=VALUE2",
 			},
 		},
 		{
 			Description: "Deploy a new instance with attached volume",
 			Commands: []string{
-				"unikraft run --metro=sin -v my-volume:/data my-app:latest",
+				"unikraft run --metro=sin --image=my-app:latest -v my-volume:/data",
 			},
 		},
 		{
 			Description: "Deploy a new instance with attached volume which is read-only",
 			Commands: []string{
-				"unikraft run --metro=sin -v my-volume:/data:ro my-app:latest",
+				"unikraft run --metro=sin --image=my-app:latest -v my-volume:/data:ro",
 			},
 		},
 		{
 			Description: "Deploy a new instance with custom resource allocations",
 			Commands: []string{
-				"unikraft run --metro=sfo -m 512MiB --vcpus 2 my-app:latest",
+				"unikraft run --metro=sfo --image=my-app:latest -m 512MiB --vcpus 2",
 			},
 		},
 		{
 			Description: "Deploy a new instance with scale-to-zero enabled",
 			Commands: []string{
-				"unikraft run --metro=fra --scale-to-zero policy=on,cooldown-time=300 my-app:latest",
+				"unikraft run --metro=fra --image=my-app:latest --scale-to-zero policy=on,cooldown-time=300",
 			},
 		},
 		{
 			Description: "Deploy a new instance with specific restart policy",
 			Commands: []string{
-				"unikraft run --metro=dal --restart=on-failure my-app:latest",
+				"unikraft run --metro=dal --image=my-app:latest --restart=on-failure",
 			},
 		},
 	}
 }
 
-func (c *RunCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox) error {
-	if c.Image == nil {
-		return fmt.Errorf("image is required")
+func (c *RunCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox, kctx *kong.Context) error {
+	// Apply shortcut flags first (only user-set flags)
+	if err := resourcecmd.ApplyShortcutFlags(&c.SetArgs, kctx.Flags()); err != nil {
+		return err
 	}
-	if c.Metro == "" {
-		return fmt.Errorf("metro is required")
+	// Default autostart to true for run command if not explicitly set by user.
+	// We add this to SetArgs rather than setting the field directly, because
+	// RunResources uses toPatchSpec() which reads from SetArgs.
+	if c.Autostart == nil {
+		c.Set = append(c.Set, map[string]string{"autostart": "true"})
 	}
-
-	env, err := value.Parse[map[string]string](c.Env)
+	created, err := c.RunResources(ctx, stdio, sandbox)
 	if err != nil {
 		return err
 	}
-	volumes, err := value.Parse[[]*InstanceVolume](c.Volume)
-	if err != nil {
-		return err
-	}
-	services, err := value.Parse[[]*Service](c.Publish)
-	if err != nil {
-		return err
-	}
-	domains, err := value.Parse[[]Domain](c.Domain)
-	if err != nil {
-		return err
-	}
-	scaleToZero, err := value.Parse[*InstanceScaleToZero](c.ScaleToZero)
-	if err != nil {
-		return err
+	if !c.Follow || len(created) == 0 {
+		return nil
 	}
 
-	fields, err := Instance{}.Fields()
-	if err != nil {
-		return err
-	}
-	if err := c.applyCreatePatches(fields, env, volumes, services, domains, scaleToZero); err != nil {
-		return err
-	}
+	fmt.Fprintln(stdio.Stdout)
 
-	if c.DryRun {
-		return cmd.PrintPatches(stdio.Stdout, fields, true)
-	}
-
-	var creatable resource.CreatableResource = Instance{}
-	if sandbox != nil {
-		creatable = sandbox.WrapCreatable(creatable)
-	}
-	created, opErr := creatable.Create(ctx, fields)
-	if opErr != nil && len(created) == 0 {
-		return opErr
-	}
-	if len(created) == 0 {
-		return fmt.Errorf("no instances created")
-	}
-	printErr := c.Output.
-		WithDefault(cmd.PrinterTypeKeyValue).
-		Print(ctx, stdio.Stdout, c.Field, Instance{}, created...)
-	if printErr != nil {
-		return errors.Join(opErr, printErr)
-	}
-	if opErr != nil {
-		return opErr
-	}
-
-	if c.Follow {
-		fmt.Fprintln(stdio.Stdout)
-
-		mux := muxreader.New()
-		defer mux.Close()
-
-		keys := make(multimetro.Keys, 0, len(created))
-		for _, res := range created {
-			instance, ok := res.(Instance)
-			if !ok {
-				return fmt.Errorf("unexpected resource type %T", res)
-			}
-			keys = append(keys, instance.key)
+	keys := make(multimetro.Keys, 0, len(created))
+	for _, res := range created {
+		instance, ok := res.(Instance)
+		if !ok {
+			return fmt.Errorf("unexpected resource type %T", res)
 		}
-
-		ctx, cancel := context.WithCancel(ctx)
-		defer cancel()
-
-		g, err := multimetro.NewClient(ctx)
-		if err != nil {
-			return err
-		}
-		err = group.DoRefs(ctx, g, keys.Refs(), func(_ context.Context, c multimetro.MetroClient, refs group.Refs) (group.Refs, error) {
-			for _, ref := range refs {
-				key := multimetro.Key(ref)
-				r, err := logs.InstanceLogs(ctx, c).Reader(ref.NameOrUUID(), 0, true)
-				if err != nil {
-					return nil, err
-				}
-				mux.With(key.String(), r)
-			}
-			return refs, nil
-		})
-		if err != nil {
-			return err
-		}
-		mux.Seal()
-
-		_, err = io.Copy(stdio.Stdout, mux)
-		if errors.Is(err, context.Canceled) {
-			return nil
-		}
-		return err
+		keys = append(keys, instance.key)
 	}
 
-	return nil
+	return streamInstanceLogs(ctx, stdio, keys, 0, true)
 }
 
-func (c *RunCmd) applyCreatePatches(fields []resource.Field, env map[string]string, volumes []*InstanceVolume, services []*Service, domains []Domain, scaleToZero *InstanceScaleToZero) error {
-	patches := c.runCreatePatches(env, volumes, services, domains, scaleToZero)
-	for path, field := range resource.IterFields(fields) {
-		if field.Create == nil {
-			continue
-		}
-		field.Create = nil
-		if value, ok := patches[path.String()]; ok {
-			field.Create = &resource.Patch{Set: value}
-			delete(patches, path.String())
-		}
-	}
-	if len(patches) > 0 {
-		return fmt.Errorf("unknown create patches: %v", xmaps.OrderedKeys(patches))
+func streamInstanceLogs(ctx context.Context, stdio config.Stdio, keys multimetro.Keys, tail int, follow bool) error {
+	g, err := multimetro.NewClient(ctx)
+	if err != nil {
+		return err
 	}
 
-	return nil
-}
+	mux := muxreader.New()
+	defer mux.Close()
 
-func (c *RunCmd) runCreatePatches(env map[string]string, volumes []*InstanceVolume, services []*Service, domains []Domain, scaleToZero *InstanceScaleToZero) map[string]any {
-	patches := map[string]any{
-		// FIXME: parse image key, don't require exact matches
-		"image": *c.Image,
-		"metro": c.Metro,
-	}
-	if c.Name != "" {
-		patches["name"] = c.Name
-	}
-	if len(c.Args) > 0 {
-		patches["runtime.args"] = c.Args
-	}
-	if len(env) > 0 {
-		patches["runtime.env"] = env
-	}
-	if c.Memory > 0 {
-		patches["resources.memory"] = c.Memory
-	}
-	if c.Vcpus > 0 {
-		patches["resources.vcpus"] = c.Vcpus
-	}
-	if c.Restart != "" {
-		patches["restart.policy"] = c.Restart
-	}
-	if scaleToZero != nil {
-		patches["scale-to-zero.policy"] = string(platform.InstanceScaleToZeroPolicyOn)
-		if scaleToZero.Policy != "" {
-			patches["scale-to-zero.policy"] = scaleToZero.Policy
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	err = group.DoRefs(ctx, g, keys.Refs(), func(_ context.Context, c multimetro.MetroClient, refs group.Refs) (group.Refs, error) {
+		for _, ref := range refs {
+			key := multimetro.Key(ref)
+			r, err := logs.InstanceLogs(ctx, c).Reader(ref.NameOrUUID(), tail, follow)
+			if err != nil {
+				return nil, err
+			}
+			mux.With(key.String(), r)
 		}
-		if scaleToZero.Stateful {
-			patches["scale-to-zero.stateful"] = scaleToZero.Stateful
-		}
-		if scaleToZero.CooldownTime > 0 {
-			patches["scale-to-zero.cooldown-time"] = scaleToZero.CooldownTime
-		}
+		return refs, nil
+	})
+	if err != nil {
+		return err
 	}
-	if len(volumes) > 0 {
-		patches["volumes"] = volumes
+	mux.Seal()
+
+	_, err = io.Copy(stdio.Stdout, mux)
+	if follow && errors.Is(err, context.Canceled) {
+		return nil
 	}
-	if c.Service != "" {
-		key := multimetro.ParseKey(c.Service)
-		if key.UUID != "" {
-			patches["service.uuid"] = key.UUID
-		} else {
-			patches["service.name"] = key.Name
-		}
-	}
-	if len(services) > 0 {
-		patches["service.services"] = services
-	}
-	if len(domains) > 0 {
-		patches["service.domains"] = domains
-	}
-	if c.Autostart {
-		patches["autostart"] = c.Autostart
-	}
-	if c.Replicas > 0 {
-		patches["replicas"] = c.Replicas
-	}
-	if c.WaitTimeoutMs > 0 {
-		patches["wait_timeout_ms"] = c.WaitTimeoutMs
-	}
-	if len(c.Features) > 0 {
-		patches["features"] = c.Features
-	}
-	return patches
+	return err
 }

--- a/internal/cmd/services.go
+++ b/internal/cmd/services.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/alecthomas/kong"
+
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/cloud/sdk/platform/group"
 	"unikraft.com/x/kingkong"
@@ -25,17 +27,64 @@ import (
 	"unikraft.com/cli/internal/multimetro"
 	"unikraft.com/cli/internal/resource"
 	"unikraft.com/cli/internal/resource/cmd"
+	"unikraft.com/cli/internal/resource/value"
 	"unikraft.com/cli/internal/types"
 )
 
 type ServicesCmd struct {
 	cmd.ResourceCmd[ServiceGroup]
-	cmd.GettableResourceCmd[ServiceGroup]      `set:"name=service" set:"names=services"`
-	cmd.WaitableResourceCmd[ServiceGroup]      `set:"name=service" set:"names=services"`
-	cmd.ListableResourceCmd[ServiceGroup]      `set:"name=service" set:"names=services"`
-	cmd.BulkDeletableResourceCmd[ServiceGroup] `set:"name=service" set:"names=services"`
-	cmd.EditableResourceCmd[ServiceGroup]      `set:"name=service" set:"names=services"`
-	cmd.CreatableResourceCmd[ServiceGroup]     `set:"name=service" set:"names=services"`
+	cmd.GettableResourceCmd[ServiceGroup]
+	cmd.WaitableResourceCmd[ServiceGroup]
+	cmd.ListableResourceCmd[ServiceGroup]
+	cmd.BulkDeletableResourceCmd[ServiceGroup]
+
+	Create ServiceCreateCmd `cmd:"" help:"Create a service group."`
+	Edit   ServiceEditCmd   `cmd:"" help:"Edit a service group."`
+}
+
+// ServiceCreateCmd extends the generic resource create command with shortcut
+// flags for commonly used service group fields. Each field tagged with
+// `shortcut:"<path>"` is translated into a --set <path>=<value> entry before
+// the standard create pipeline runs.
+type ServiceCreateCmd struct {
+	cmd.ResourceCreateCmd[ServiceGroup]
+
+	Metro string `group:"flag-create" shortcut:"metro" help:"Metro to create in." placeholder:"metro" example:"fra,sfo,nyc"`
+	Name  string `group:"flag-create" shortcut:"name" help:"Service group name." placeholder:"name"`
+
+	SoftLimit uint64 `group:"flag-create" shortcut:"limits.soft" help:"Soft limit." placeholder:"n" example:"1,5"`
+	HardLimit uint64 `group:"flag-create" shortcut:"limits.hard" help:"Hard limit." placeholder:"n" example:"10,100"`
+
+	Domains  []Domain  `group:"flag-create" shortcut:"domains" help:"Service domains." placeholder:"fqdn" example:"example.com,api.example.com"`
+	Services []Service `group:"flag-create" shortcut:"services" help:"Service ports." placeholder:"<src>:<dest>[/<handlers>]" example:"443:8080/http+tls,80:8080/http"`
+}
+
+func (c *ServiceCreateCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox, kctx *kong.Context) error {
+	if err := cmd.ApplyShortcutFlags(&c.SetArgs, kctx.Flags()); err != nil {
+		return err
+	}
+	return c.ResourceCreateCmd.Run(ctx, stdio, sandbox)
+}
+
+// ServiceEditCmd extends the generic resource edit command with shortcut
+// flags for commonly used editable service group fields. Each field tagged with
+// `shortcut:"<path>"` is translated into a --set <path>=<value> entry before
+// the standard edit pipeline runs.
+type ServiceEditCmd struct {
+	cmd.ResourceEditCmd[ServiceGroup]
+
+	SoftLimit uint64 `group:"flag-edit" shortcut:"limits.soft" help:"Soft limit." placeholder:"n" example:"1,5"`
+	HardLimit uint64 `group:"flag-edit" shortcut:"limits.hard" help:"Hard limit." placeholder:"n" example:"10,100"`
+
+	Domains  []Domain  `group:"flag-edit" shortcut:"domains" help:"Service domains." placeholder:"fqdn" example:"example.com,api.example.com"`
+	Services []Service `group:"flag-edit" shortcut:"services" help:"Service ports." placeholder:"<src>:<dest>[/<handlers>]" example:"443:8080/http+tls,80:8080/http"`
+}
+
+func (c *ServiceEditCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox, kctx *kong.Context) error {
+	if err := cmd.ApplyShortcutFlags(&c.SetArgs, kctx.Flags()); err != nil {
+		return err
+	}
+	return c.ResourceEditCmd.Run(ctx, stdio, sandbox)
 }
 
 type ServiceGroup struct {
@@ -139,6 +188,7 @@ func (s *Service) UnmarshalText(text []byte) error {
 }
 
 type Domain struct {
+	// TODO: consolidate these and make easier to parse
 	FQDN string `name:"fqdn" json:"fqdn" mirror:"fqdn" field:",short"`
 	Name string `name:"name" json:"name,omitempty" field:"-"` // field:"-" excludes from field system, name:"name" allows --set parsing
 
@@ -146,6 +196,36 @@ type Domain struct {
 		Name string `name:"name" json:"name" mirror:"name" field:",long"`
 		UUID string `name:"uuid" json:"uuid" mirror:"uuid" field:",long"`
 	} `name:"certificate" json:"certificate,omitzero" mirror:"certificate"`
+}
+
+func (d *Domain) UnmarshalText(text []byte) error {
+	str := strings.TrimSpace(string(text))
+	if str == "" {
+		return nil
+	}
+
+	if strings.Contains(str, "=") {
+		type domainAlias Domain
+		parsed, err := value.Parse[domainAlias]([]string{str})
+		if err != nil {
+			return err
+		}
+		*d = Domain(parsed)
+		return nil
+	}
+
+	if trimmed, ok := strings.CutSuffix(str, "."); ok {
+		d.FQDN = trimmed
+		return nil
+	}
+
+	if strings.Contains(str, ".") {
+		d.FQDN = str
+		return nil
+	}
+
+	d.Name = str
+	return nil
 }
 
 func (ServiceGroup) Type() resource.Type {
@@ -442,18 +522,26 @@ func (ServiceGroup) Examples() map[cmd.CmdType][]kingkong.Example {
 			{
 				Description: "Create a new service group",
 				Commands: []string{
+					// `unikraft service create \
+					//   --set name=demo-service \
+					//   --set metro=fra \
+					//   --set domains=demo \
+					//   --set services=443:8080/tls+http`,
 					`unikraft service create \
-  --set name=demo-service \
-  --set metro=fra \
-  --set domains=name=demo \
-  --set services=443:8080/tls+http`,
+	--name demo-service \
+	--metro fra \
+	--domains demo \
+	--services 443:8080/tls+http`,
 				},
 			},
 		},
 		cmd.CmdTypeEdit: {
 			{
 				Description: "Add a new service port",
-				Commands:    []string{"unikraft service edit demo-service --add services=8443:8080/tls"},
+				Commands: []string{
+					// "unikraft service edit demo-service --add services=8443:8080/tls",
+					"unikraft service edit demo-service --services 8443:8080/tls",
+				},
 			},
 		},
 		cmd.CmdTypeDelete: {

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/alecthomas/kong"
+
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/cloud/sdk/platform/group"
 	"unikraft.com/x/kingkong"
@@ -30,18 +32,58 @@ import (
 
 type VolumesCmd struct {
 	cmd.ResourceCmd[Volume]
-	cmd.GettableResourceCmd[Volume]      `set:"name=volume" set:"names=volumes"`
-	cmd.WaitableResourceCmd[Volume]      `set:"name=volume" set:"names=volumes"`
-	cmd.ListableResourceCmd[Volume]      `set:"name=volume" set:"names=volumes"`
-	cmd.BulkDeletableResourceCmd[Volume] `set:"name=volume" set:"names=volumes"`
-	cmd.EditableResourceCmd[Volume]      `set:"name=volume" set:"names=volumes"`
-	cmd.CreatableResourceCmd[Volume]     `set:"name=volume" set:"names=volumes"`
+	cmd.GettableResourceCmd[Volume]
+	cmd.WaitableResourceCmd[Volume]
+	cmd.ListableResourceCmd[Volume]
+	cmd.BulkDeletableResourceCmd[Volume]
 
-	Clone VolumesCloneCmd `cmd:"" help:"Clone a volume." set:"name=volume"`
+	Create VolumeCreateCmd `cmd:"" help:"Create a volume."`
+	Edit   VolumeEditCmd   `cmd:"" help:"Edit a volume."`
+
+	Clone VolumesCloneCmd `cmd:"" help:"Clone a volume."`
+}
+
+// VolumeCreateCmd extends the generic resource create command with shortcut
+// flags for commonly used volume fields. Each field tagged with
+// `shortcut:"<path>"` is translated into a --set <path>=<value> entry before
+// the standard create pipeline runs.
+type VolumeCreateCmd struct {
+	cmd.ResourceCreateCmd[Volume]
+
+	Metro string              `group:"flag-create" shortcut:"metro" help:"Metro to create in." placeholder:"metro" example:"fra,sfo,nyc"`
+	Name  string              `group:"flag-create" shortcut:"name" short:"n" help:"Volume name." placeholder:"name"`
+	Size  types.SizeMebibytes `group:"flag-create" shortcut:"size" help:"Volume size." placeholder:"size" example:"10GiB,100MiB"`
+}
+
+func (c *VolumeCreateCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox, kctx *kong.Context) error {
+	if err := cmd.ApplyShortcutFlags(&c.SetArgs, kctx.Flags()); err != nil {
+		return err
+	}
+	return c.ResourceCreateCmd.Run(ctx, stdio, sandbox)
+}
+
+// VolumeEditCmd extends the generic resource edit command with shortcut
+// flags for commonly used editable volume fields. Each field tagged with
+// `shortcut:"<path>"` is translated into a --set <path>=<value> entry before
+// the standard edit pipeline runs.
+type VolumeEditCmd struct {
+	cmd.ResourceEditCmd[Volume]
+
+	Size types.SizeMebibytes `group:"flag-edit" shortcut:"size" help:"Volume size." placeholder:"size" example:"20GiB,100MiB"`
+}
+
+func (c *VolumeEditCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox, kctx *kong.Context) error {
+	if err := cmd.ApplyShortcutFlags(&c.SetArgs, kctx.Flags()); err != nil {
+		return err
+	}
+	return c.ResourceEditCmd.Run(ctx, stdio, sandbox)
 }
 
 type VolumesCloneCmd struct {
 	Source string `arg:"" completion-predictor:"resource-key-volume" help:"Name or UUID of the volume to clone."`
+
+	Name string   `group:"flag-clone" shortcut:"name" short:"n" help:"New volume name." placeholder:"name"`
+	Tags []string `group:"flag-clone" shortcut:"tags" help:"Volume tags." placeholder:"tag" example:"env=prod,team=platform"`
 
 	cmd.SetArgs
 
@@ -52,12 +94,18 @@ func (VolumesCloneCmd) Examples() []kingkong.Example {
 	return []kingkong.Example{
 		{
 			Description: "Clone a volume with a new name",
-			Commands:    []string{"unikraft volume clone demo-volume --set name=demo-volume-clone"},
+			Commands: []string{
+				// "unikraft volume clone demo-volume --set name=demo-volume-clone",
+				"unikraft volume clone demo-volume --name demo-volume-clone",
+			},
 		},
 	}
 }
 
-func (c *VolumesCloneCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox) error {
+func (c *VolumesCloneCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox, kctx *kong.Context) error {
+	if err := cmd.ApplyShortcutFlags(&c.SetArgs, kctx.Flags()); err != nil {
+		return err
+	}
 	spec := patch.PatchSpec{
 		Set: make(map[string][]string),
 	}
@@ -475,17 +523,24 @@ func (Volume) Examples() map[cmd.CmdType][]kingkong.Example {
 			{
 				Description: "Create a new volume",
 				Commands: []string{
+					// `unikraft volume create \
+					//   --set name=demo-volume \
+					//   --set size=10 \
+					//   --set metro=fra`,
 					`unikraft volume create \
-  --set name=demo-volume \
-  --set size=10 \
-  --set metro=fra`,
+	  --name demo-volume \
+	  --size 10 \
+	  --metro fra`,
 				},
 			},
 		},
 		cmd.CmdTypeEdit: {
 			{
 				Description: "Resize a volume",
-				Commands:    []string{"unikraft volume edit demo-volume --set size=20"},
+				Commands: []string{
+					// "unikraft volume edit demo-volume --set size=20",
+					"unikraft volume edit demo-volume --size 20",
+				},
 			},
 		},
 		cmd.CmdTypeDelete: {

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -602,7 +602,7 @@ type ResourceEditCmd[R resource.EditableResource] struct {
 	AddArgs
 	DelArgs
 
-	Visual bool   `xor:"edit-mode" short:"e" help:"Open an editor to modify fields visually."`
+	Visual bool   `xor:"edit-mode" help:"Open an editor to modify fields visually."`
 	Cmd    string `xor:"edit-mode" help:"Run a command to edit fields (receives YAML on stdin, outputs edited YAML on stdout)."`
 	Load   []byte `xor:"edit-mode" collapse:"file-mode" type:"filecontent" help:"Load fields from a YAML file."`
 	Save   string `xor:"edit-mode" collapse:"file-mode" placeholder:"FILE" help:"Save editable fields as YAML to a file (use - for stdout)."`
@@ -752,7 +752,7 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, stdio config.Stdio, sand
 type ResourceCreateCmd[R resource.CreatableResource] struct {
 	SetArgs
 
-	Visual bool   `xor:"edit-mode" short:"e" help:"Open an editor to modify fields visually."`
+	Visual bool   `xor:"edit-mode" help:"Open an editor to modify fields visually."`
 	Cmd    string `xor:"edit-mode" help:"Run a command to edit fields (receives YAML on stdin, outputs edited YAML on stdout)."`
 	Load   []byte `xor:"edit-mode" collapse:"file-mode" type:"filecontent" help:"Load fields from a YAML file."`
 	Save   string `xor:"edit-mode" collapse:"file-mode" placeholder:"FILE" help:"Save creatable fields as YAML to a file (use - for stdout)."`
@@ -786,9 +786,14 @@ func (cmd *ResourceCreateCmd[R]) toPatchSpec() (patch.PatchSpec, error) {
 }
 
 func (cmd *ResourceCreateCmd[R]) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox) error {
+	_, err := cmd.RunResources(ctx, stdio, sandbox)
+	return err
+}
+
+func (cmd *ResourceCreateCmd[R]) RunResources(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox) ([]resource.Resource, error) {
 	spec, err := cmd.toPatchSpec()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var empty R
@@ -803,16 +808,16 @@ func (cmd *ResourceCreateCmd[R]) Run(ctx context.Context, stdio config.Stdio, sa
 	}
 	fields, err := fieldsResource.Fields()
 	if err != nil {
-		return fmt.Errorf("failed to get fields: %w", err)
+		return nil, fmt.Errorf("failed to get fields: %w", err)
 	}
 	patched, err := patch.PatchedFields(fields, spec)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Handle --save: write YAML to file and exit
 	if cmd.Save != "" {
-		return saveYAML(cmd.Save, stdio, empty, fields, patched, true)
+		return nil, saveYAML(cmd.Save, stdio, empty, fields, patched, true)
 	}
 
 	// Handle different editing modes (mutually exclusive via xor:"edit-mode" tag)
@@ -821,7 +826,7 @@ func (cmd *ResourceCreateCmd[R]) Run(ctx context.Context, stdio config.Stdio, sa
 	case cmd.Visual:
 		editor, err = patch.VisualCommandEditorFunc(stdio)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	case cmd.Cmd != "":
 		editor = patch.CommandEditorFunc(stdio, cmd.Cmd)
@@ -831,32 +836,32 @@ func (cmd *ResourceCreateCmd[R]) Run(ctx context.Context, stdio config.Stdio, sa
 	if editor != nil {
 		patched, err = patch.Create(ctx, empty, fields, patched, editor)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
 	patchedFields := patch.FilterCreateFields(patched)
 
 	if cmd.DryRun {
-		return PrintPatches(stdio.Stdout, patchedFields, true)
+		return nil, PrintPatches(stdio.Stdout, patchedFields, true)
 	}
 
 	// Validate required fields right before applying
 	if err := patch.ValidateRequired(fields, patched, true); err != nil {
-		return err
+		return nil, err
 	}
 
 	resources, opErr := r.Create(ctx, patchedFields)
 	if opErr != nil && len(resources) == 0 {
-		return opErr
+		return nil, opErr
 	}
 	printErr := cmd.Output.
 		WithDefault(PrinterTypeKeyValue).
 		Print(ctx, stdio.Stdout, cmd.Field, empty, resources...)
 	if printErr != nil {
-		return errors.Join(opErr, printErr)
+		return resources, errors.Join(opErr, printErr)
 	}
-	return opErr
+	return resources, opErr
 }
 
 // saveYAML writes YAML to a file or stdout (if filename is "-").

--- a/internal/resource/cmd/cmd_test.go
+++ b/internal/resource/cmd/cmd_test.go
@@ -1050,6 +1050,112 @@ func TestCreateDryRun(t *testing.T) {
 	}
 }
 
+func TestCreateDryRunWithShortcutZeroValues(t *testing.T) {
+	// Test that shortcut flags correctly handle zero values when explicitly set.
+	// This validates that we use flag.Set instead of IsZero() to determine
+	// whether a flag was provided.
+	//
+	// The test uses a Kong CLI struct with shortcut tags and calls
+	// ApplyShortcutFlags to populate SetArgs, mirroring how real commands work.
+
+	// shortcutCLI is a Kong-parseable CLI struct that mirrors shortcut flags
+	// for TestResource create fields (settings.foo and settings.bar).
+	type shortcutCLI struct {
+		Foo int    `name:"foo" shortcut:"settings.foo"`
+		Bar string `name:"bar" shortcut:"settings.bar"`
+	}
+
+	// applyShortcuts parses cliArgs via Kong, applies shortcut flags into
+	// baseArgs, and returns the resulting SetArgs.
+	applyShortcuts := func(t *testing.T, baseArgs SetArgs, cliArgs ...string) SetArgs {
+		t.Helper()
+		cli := &shortcutCLI{}
+		flags := parseFlags(t, cli, cliArgs...)
+		require.NoError(t, ApplyShortcutFlags(&baseArgs, flags))
+		return baseArgs
+	}
+
+	t.Run("zero int value is applied when explicitly set", func(t *testing.T) {
+		setArgs := applyShortcuts(t,
+			SetArgs{Set: []map[string]string{{"name": "test-zero"}}},
+			"--foo=0",
+		)
+
+		env := resourcet.NewTestEnv()
+		ctx := resourcet.WithTestEnv(context.Background(), env)
+		sandbox := &resource.Sandbox{}
+
+		var out bytes.Buffer
+		cmd := &ResourceCreateCmd[resourcet.TestResource]{
+			DryRun:  true,
+			SetArgs: setArgs,
+		}
+		err := cmd.Run(ctx, testStdio(&out), sandbox)
+		require.NoError(t, err)
+
+		// Resource should not be created (dry-run)
+		assert.NotContains(t, env.Store, "test-zero")
+
+		// Output should show the zero value being set
+		output := out.String()
+		assert.Contains(t, output, "settings.foo")
+		assert.Contains(t, output, "0")
+	})
+
+	t.Run("empty string value is applied when explicitly set", func(t *testing.T) {
+		setArgs := applyShortcuts(t,
+			SetArgs{Set: []map[string]string{{"name": "test-empty"}}},
+			"--bar=",
+		)
+
+		env := resourcet.NewTestEnv()
+		ctx := resourcet.WithTestEnv(context.Background(), env)
+		sandbox := &resource.Sandbox{}
+
+		var out bytes.Buffer
+		cmd := &ResourceCreateCmd[resourcet.TestResource]{
+			DryRun:  true,
+			SetArgs: setArgs,
+		}
+		err := cmd.Run(ctx, testStdio(&out), sandbox)
+		require.NoError(t, err)
+
+		// Resource should not be created (dry-run)
+		assert.NotContains(t, env.Store, "test-empty")
+
+		// Output should show the empty string being set
+		output := out.String()
+		assert.Contains(t, output, "settings.bar")
+	})
+
+	t.Run("unprovided fields are not included in patches", func(t *testing.T) {
+		// Neither --foo nor --bar provided; shortcut flags should not add them.
+		setArgs := applyShortcuts(t,
+			SetArgs{Set: []map[string]string{{"name": "test-minimal"}}},
+		)
+
+		env := resourcet.NewTestEnv()
+		ctx := resourcet.WithTestEnv(context.Background(), env)
+		sandbox := &resource.Sandbox{}
+
+		var out bytes.Buffer
+		cmd := &ResourceCreateCmd[resourcet.TestResource]{
+			DryRun:  true,
+			SetArgs: setArgs,
+		}
+		err := cmd.Run(ctx, testStdio(&out), sandbox)
+		require.NoError(t, err)
+
+		// Resource should not be created (dry-run)
+		assert.NotContains(t, env.Store, "test-minimal")
+
+		// Output should only show the name, not settings.foo
+		output := out.String()
+		assert.Contains(t, output, "name")
+		assert.NotContains(t, output, "settings.foo")
+	})
+}
+
 func TestCreatePatchSpecFileArgs(t *testing.T) {
 	nameFile := tempFile(t, " test-file ")
 	setFile := tempFile(t, " 123 \n")

--- a/internal/resource/cmd/patches.go
+++ b/internal/resource/cmd/patches.go
@@ -15,8 +15,8 @@ import (
 )
 
 type SetArgs struct {
-	Set     []map[string]string `collapse:"patch-set" help:"Key-value pairs to set on the ${name}." sep:"none" mapsep:"none"`
-	SetFile []map[string]string `collapse:"patch-set" help:"Files containing key-value pairs to set on the ${name}." sep:"none" mapsep:"none"`
+	Set     []map[string]string `collapse:"patch-set" placeholder:"<name>=<value>" help:"Key-value pairs to set on the ${name}." sep:"none" mapsep:"none"`
+	SetFile []map[string]string `collapse:"patch-set" placeholder:"<name>=<filename>" help:"Files containing key-value pairs to set on the ${name}." sep:"none" mapsep:"none"`
 }
 
 func (args SetArgs) Apply(spec *patch.PatchSpec) error {
@@ -28,8 +28,8 @@ func (args SetArgs) Apply(spec *patch.PatchSpec) error {
 }
 
 type AddArgs struct {
-	Add     []map[string]string `collapse:"patch-add" help:"Key-value pairs to add to the ${name}." sep:"none" mapsep:"none"`
-	AddFile []map[string]string `collapse:"patch-add" help:"Files containing key-value pairs to add to the ${name}." sep:"none" mapsep:"none"`
+	Add     []map[string]string `collapse:"patch-add" placeholder:"<name>=<value>" help:"Key-value pairs to add to the ${name}." sep:"none" mapsep:"none"`
+	AddFile []map[string]string `collapse:"patch-add" placeholder:"<name>=<filename>" help:"Files containing key-value pairs to add to the ${name}." sep:"none" mapsep:"none"`
 }
 
 func (args AddArgs) Apply(spec *patch.PatchSpec) error {
@@ -41,8 +41,8 @@ func (args AddArgs) Apply(spec *patch.PatchSpec) error {
 }
 
 type DelArgs struct {
-	Del     []map[string]string `collapse:"patch-del" help:"Keys to delete from the ${name}." sep:"none" mapsep:"none"`
-	DelFile []map[string]string `collapse:"patch-del" help:"Files containing keys to delete from the ${name}." sep:"none" mapsep:"none"`
+	Del     []map[string]string `collapse:"patch-del" placeholder:"<name>=<value>" help:"Keys to delete from the ${name}." sep:"none" mapsep:"none"`
+	DelFile []map[string]string `collapse:"patch-del" placeholder:"<name>=<filename>" help:"Files containing keys to delete from the ${name}." sep:"none" mapsep:"none"`
 }
 
 func (args DelArgs) Apply(spec *patch.PatchSpec) error {

--- a/internal/resource/cmd/shortcuts.go
+++ b/internal/resource/cmd/shortcuts.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package cmd
+
+import (
+	"cmp"
+	"fmt"
+	"reflect"
+
+	"github.com/alecthomas/kong"
+
+	"unikraft.com/cli/internal/resource/value"
+)
+
+// ApplyShortcutFlags scans Kong flags for those tagged with
+// `shortcut:"<field-path>"` or `shortcut-file:"<field-path>"` and appends
+// their values to args as --set or --set-file entries.
+//
+// Only flags that were explicitly set by the user (flag.Set == true) are
+// processed. This allows users to set zero values like --replicas=0 or
+// --name= without them being skipped. Slice fields produce one entry per
+// element.
+func ApplyShortcutFlags(args *SetArgs, flags []*kong.Flag) error {
+	for _, flag := range flags {
+		if flag == nil || flag.Value == nil || flag.Tag == nil {
+			continue
+		}
+
+		key := flag.Tag.Get("shortcut")
+		fileKey := flag.Tag.Get("shortcut-file")
+		if key == "" && fileKey == "" {
+			continue
+		}
+		if key == "-" || fileKey == "-" {
+			continue
+		}
+
+		// Only process flags that were explicitly set by the user.
+		if !flag.Set {
+			continue
+		}
+
+		fv := flag.Target
+		// Dereference pointers to get the underlying value.
+		for fv.Kind() == reflect.Ptr {
+			fv = fv.Elem()
+		}
+
+		// Slice fields produce one --set entry per element.
+		if fv.Kind() == reflect.Slice {
+			for j := range fv.Len() {
+				elem := fv.Index(j)
+				// If the element is addressable, take its address to allow
+				// pointer-receiver MarshalText methods to be called.
+				var elemVal any
+				if elem.CanAddr() {
+					elemVal = elem.Addr().Interface()
+				} else {
+					elemVal = elem.Interface()
+				}
+				s, err := value.Format(elemVal)
+				if err != nil {
+					return fmt.Errorf("shortcut %q[%d]: %w", cmp.Or(key, fileKey), j, err)
+				}
+				if fileKey != "" {
+					args.SetFile = append(args.SetFile, map[string]string{fileKey: s})
+					continue
+				}
+				args.Set = append(args.Set, map[string]string{key: s})
+			}
+			continue
+		}
+
+		s, err := value.Format(fv.Interface())
+		if err != nil {
+			return fmt.Errorf("shortcut %q: %w", cmp.Or(key, fileKey), err)
+		}
+		if fileKey != "" {
+			args.SetFile = append(args.SetFile, map[string]string{fileKey: s})
+			continue
+		}
+		args.Set = append(args.Set, map[string]string{key: s})
+	}
+	return nil
+}

--- a/internal/resource/cmd/shortcuts_test.go
+++ b/internal/resource/cmd/shortcuts_test.go
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type textMarshalerType int
+
+func (t textMarshalerType) MarshalText() ([]byte, error) {
+	return []byte("custom-text"), nil
+}
+
+// parseFlags parses the given CLI struct with args and returns the resulting Kong flags.
+func parseFlags(t *testing.T, cli any, args ...string) []*kong.Flag {
+	t.Helper()
+	parser, err := kong.New(cli)
+	require.NoError(t, err)
+	kctx, err := parser.Parse(args)
+	require.NoError(t, err)
+	return kctx.Flags()
+}
+
+func TestApplyShortcutFlags(t *testing.T) {
+	t.Run("string fields", func(t *testing.T) {
+		var cli struct {
+			Image string `shortcut:"image"`
+			Metro string `shortcut:"metro"`
+		}
+		flags := parseFlags(t, &cli, "--image=nginx:latest", "--metro=fra")
+
+		var args SetArgs
+		err := ApplyShortcutFlags(&args, flags)
+		require.NoError(t, err)
+		assert.Equal(t, []map[string]string{
+			{"image": "nginx:latest"},
+			{"metro": "fra"},
+		}, args.Set)
+	})
+
+	t.Run("file shortcut fields", func(t *testing.T) {
+		var cli struct {
+			Chain string `shortcut-file:"chain"`
+		}
+		flags := parseFlags(t, &cli, "--chain=cert.pem")
+
+		var args SetArgs
+		err := ApplyShortcutFlags(&args, flags)
+		require.NoError(t, err)
+		assert.Equal(t, []map[string]string{
+			{"chain": "cert.pem"},
+		}, args.SetFile)
+		assert.Nil(t, args.Set)
+	})
+
+	t.Run("unprovided values are skipped", func(t *testing.T) {
+		var cli struct {
+			Image string `shortcut:"image"`
+			Metro string `shortcut:"metro"`
+			Name  string `shortcut:"name"`
+		}
+		// Only --image is provided; metro and name are not provided
+		flags := parseFlags(t, &cli, "--image=nginx:latest")
+
+		var args SetArgs
+		err := ApplyShortcutFlags(&args, flags)
+		require.NoError(t, err)
+		assert.Equal(t, []map[string]string{
+			{"image": "nginx:latest"},
+		}, args.Set)
+	})
+
+	t.Run("bool pointer fields", func(t *testing.T) {
+		t.Run("nil pointer is skipped", func(t *testing.T) {
+			var cli struct {
+				Autostart *bool `shortcut:"autostart"`
+			}
+			flags := parseFlags(t, &cli)
+
+			var args SetArgs
+			err := ApplyShortcutFlags(&args, flags)
+			require.NoError(t, err)
+			assert.Nil(t, args.Set)
+		})
+
+		t.Run("true", func(t *testing.T) {
+			var cli struct {
+				Autostart *bool `shortcut:"autostart"`
+			}
+			flags := parseFlags(t, &cli, "--autostart")
+
+			var args SetArgs
+			err := ApplyShortcutFlags(&args, flags)
+			require.NoError(t, err)
+			assert.Equal(t, []map[string]string{{"autostart": "true"}}, args.Set)
+		})
+
+		t.Run("false", func(t *testing.T) {
+			var cli struct {
+				Autostart *bool `shortcut:"autostart" negatable:""`
+			}
+			// *bool(false) is the zero value of the dereferenced bool, but
+			// the pointer itself is non-nil, so it should still be applied.
+			flags := parseFlags(t, &cli, "--no-autostart")
+
+			var args SetArgs
+			err := ApplyShortcutFlags(&args, flags)
+			require.NoError(t, err)
+			assert.Equal(t, []map[string]string{{"autostart": "false"}}, args.Set)
+		})
+	})
+
+	t.Run("int fields", func(t *testing.T) {
+		var cli struct {
+			Vcpus int   `shortcut:"resources.vcpus"`
+			Count int64 `shortcut:"replicas"`
+		}
+		flags := parseFlags(t, &cli, "--vcpus=4", "--count=3")
+
+		var args SetArgs
+		err := ApplyShortcutFlags(&args, flags)
+		require.NoError(t, err)
+		assert.Equal(t, []map[string]string{
+			{"resources.vcpus": "4"},
+			{"replicas": "3"},
+		}, args.Set)
+	})
+
+	t.Run("slice fields produce one entry per element", func(t *testing.T) {
+		var cli struct {
+			Features []string `shortcut:"features"`
+		}
+		flags := parseFlags(t, &cli, "--features=feat-a", "--features=feat-b")
+
+		var args SetArgs
+		err := ApplyShortcutFlags(&args, flags)
+		require.NoError(t, err)
+		assert.Equal(t, []map[string]string{
+			{"features": "feat-a"},
+			{"features": "feat-b"},
+		}, args.Set)
+	})
+
+	t.Run("empty slice is skipped", func(t *testing.T) {
+		var cli struct {
+			Features []string `shortcut:"features"`
+		}
+		flags := parseFlags(t, &cli)
+
+		var args SetArgs
+		err := ApplyShortcutFlags(&args, flags)
+		require.NoError(t, err)
+		assert.Nil(t, args.Set)
+	})
+
+	t.Run("TextMarshaler types", func(t *testing.T) {
+		var cli struct {
+			Memory textMarshalerType `shortcut:"resources.memory"`
+		}
+		flags := parseFlags(t, &cli, "--memory=128")
+
+		var args SetArgs
+		err := ApplyShortcutFlags(&args, flags)
+		require.NoError(t, err)
+		assert.Equal(t, []map[string]string{
+			{"resources.memory": "custom-text"},
+		}, args.Set)
+	})
+
+	t.Run("fields without shortcut tag are ignored", func(t *testing.T) {
+		var cli struct {
+			Image   string `shortcut:"image"`
+			Ignored string `help:"no shortcut tag"`
+			Also    string
+		}
+		flags := parseFlags(t, &cli, "--image=nginx", "--ignored=x", "--also=y")
+
+		var args SetArgs
+		err := ApplyShortcutFlags(&args, flags)
+		require.NoError(t, err)
+		assert.Equal(t, []map[string]string{{"image": "nginx"}}, args.Set)
+	})
+
+	t.Run("shortcut dash tag is ignored", func(t *testing.T) {
+		var cli struct {
+			Image string `shortcut:"-"`
+		}
+		flags := parseFlags(t, &cli, "--image=nginx")
+
+		var args SetArgs
+		err := ApplyShortcutFlags(&args, flags)
+		require.NoError(t, err)
+		assert.Nil(t, args.Set)
+	})
+
+	t.Run("appends to existing Set entries", func(t *testing.T) {
+		var cli struct {
+			Metro string `shortcut:"metro"`
+		}
+		flags := parseFlags(t, &cli, "--metro=fra")
+
+		args := SetArgs{
+			Set: []map[string]string{{"image": "nginx:latest"}},
+		}
+		err := ApplyShortcutFlags(&args, flags)
+		require.NoError(t, err)
+		assert.Equal(t, []map[string]string{
+			{"image": "nginx:latest"},
+			{"metro": "fra"},
+		}, args.Set)
+	})
+
+	t.Run("nil flags slice", func(t *testing.T) {
+		var args SetArgs
+		err := ApplyShortcutFlags(&args, nil)
+		require.NoError(t, err)
+		assert.Nil(t, args.Set)
+	})
+
+	t.Run("empty flags slice", func(t *testing.T) {
+		var args SetArgs
+		err := ApplyShortcutFlags(&args, []*kong.Flag{})
+		require.NoError(t, err)
+		assert.Nil(t, args.Set)
+	})
+
+	t.Run("zero values are applied when explicitly set", func(t *testing.T) {
+		t.Run("int zero", func(t *testing.T) {
+			var cli struct {
+				Replicas int `shortcut:"replicas"`
+			}
+			flags := parseFlags(t, &cli, "--replicas=0")
+
+			var args SetArgs
+			err := ApplyShortcutFlags(&args, flags)
+			require.NoError(t, err)
+			assert.Equal(t, []map[string]string{{"replicas": "0"}}, args.Set)
+		})
+
+		t.Run("int64 zero", func(t *testing.T) {
+			var cli struct {
+				SoftLimit int64 `shortcut:"soft-limit"`
+			}
+			flags := parseFlags(t, &cli, "--soft-limit=0")
+
+			var args SetArgs
+			err := ApplyShortcutFlags(&args, flags)
+			require.NoError(t, err)
+			assert.Equal(t, []map[string]string{{"soft-limit": "0"}}, args.Set)
+		})
+
+		t.Run("string empty", func(t *testing.T) {
+			var cli struct {
+				Name string `shortcut:"name"`
+			}
+			flags := parseFlags(t, &cli, "--name=")
+
+			var args SetArgs
+			err := ApplyShortcutFlags(&args, flags)
+			require.NoError(t, err)
+			assert.Equal(t, []map[string]string{{"name": ""}}, args.Set)
+		})
+	})
+}

--- a/internal/resource/struct.go
+++ b/internal/resource/struct.go
@@ -126,6 +126,10 @@ func fieldFromStruct(pf *ParsedField, v reflect.Value) (field *Field, err error)
 			result.Verbosity = cmp.Or(result.Verbosity, newField.Verbosity)
 		}
 
+		if parsedField.Valueless {
+			result.Value = nil
+		}
+
 		result.Verbosity = cmp.Or(result.Verbosity, FieldVerbosityHidden)
 		fields = append(fields, result)
 	}
@@ -245,7 +249,8 @@ type ParsedField struct {
 	Type      reflect.Type
 	Verbosity FieldVerbosity
 
-	Embed bool
+	Embed     bool
+	Valueless bool
 
 	Edit   *Patch
 	Create *Patch
@@ -289,12 +294,14 @@ func ParseField(field reflect.StructField, value reflect.Value) (*ParsedField, e
 	}
 
 	embed := slices.Contains(opts, "embed")
+	valueless := slices.Contains(opts, "valueless")
 
 	return &ParsedField{
 		Name:      name,
 		Verbosity: verbosity,
 		Type:      field.Type,
 		Embed:     embed,
+		Valueless: valueless,
 		Edit:      edit,
 		Create:    create,
 	}, nil


### PR DESCRIPTION
For `create` and `edit` commands, we can easily support some shortcut flags.

There is one major breaking change - `unikraft run` now takes an explicit `--image` flag, instead of an arg, which is so that `run` and `instance create` are essentially the *same* underlying code.