### PR TITLE
fix: Avoid panic on editing instance state

### DIFF
--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -482,8 +482,10 @@ func (Instance) Edit(ctx context.Context, target resource.Resource, fields []res
 	targetState := instance.State
 	if fields := resource.GetFieldByPath(fields, resource.FieldPath{"state"}); len(fields) > 0 {
 		field := fields[0]
-		targetState = field.Edit.Set.(types.InstanceState)
-		field.Edit = nil
+		if field.Edit != nil && field.Edit.Set != nil {
+			targetState = field.Edit.Set.(types.InstanceState)
+			field.Edit = nil
+		}
 	}
 
 	patches := patchRequests(fields, instancePatchSpec)


### PR DESCRIPTION
Oops this can be nil.