### PR TITLE
ci: Disambiguate `UNIKRAFT_CONFIG` env var

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -96,7 +96,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p ~/.config/unikraft
-          echo "${UNIKRAFT_CONFIG}" > ~/.config/unikraft/config.yaml
+          echo "${UNIKRAFT_CONFIG_CONTENT}" > ~/.config/unikraft/config.yaml
           task --yes integration
         env:
-          UNIKRAFT_CONFIG: ${{ secrets.UNIKRAFT_CONFIG }}
+          UNIKRAFT_CONFIG_CONTENT: ${{ secrets.UNIKRAFT_CONFIG }}


### PR DESCRIPTION
Don't use it for *both* the config and the path.