### PR TITLE
feat(internal)!: Add timeouts to all supported endpoints

### DIFF
--- a/cmd/unikraft/integration/instance_checkpoint_test.go
+++ b/cmd/unikraft/integration/instance_checkpoint_test.go
@@ -6,10 +6,12 @@
 package integration
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	integ "unikraft.com/cli/internal/integration"
 )
@@ -63,6 +65,37 @@ func TestInstanceCheckpoints(t *testing.T) {
 		out = r.Run(t, []string{"unikraft", "instance", "checkpoint", "list", "--output", "quiet"})
 		assert.NotContains(t, out, checkpointName)
 
+		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName})
+	})
+
+	t.Run("create-is-immediately-visible", func(t *testing.T) {
+		r := runner(t, true, []string{staging, stable})
+		instName := uniq()
+
+		r.Run(t, []string{
+			"unikraft", "instance", "create",
+			"--output", "quiet",
+			"--set", "name=test-" + instName,
+			"--set", "metro=" + r.Config.MetroName,
+			"--set", "image=nginx:latest",
+			"--set", "autostart=false",
+			"--set", "resources.memory=128",
+			"--set", "resources.vcpus=1",
+		})
+
+		// The create output itself must describe the checkpoint, not an error
+		out := r.Run(t, []string{
+			"unikraft", "instance", "checkpoint", "create", "test-" + instName,
+		})
+		assert.NotContains(t, out, "references not found")
+		assert.Regexp(t, `state:\s+checkpoint`, out)
+
+		// The generated name is only reported by the create call itself.
+		name := regexp.MustCompile(`(?m)^name:\s+(\S+)$`).FindStringSubmatch(out)
+		require.Len(t, name, 2, "create output should report the checkpoint name")
+		checkpointName := name[1]
+
+		r.Run(t, []string{"unikraft", "instance", "checkpoint", "delete", checkpointName})
 		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName})
 	})
 
@@ -205,7 +238,6 @@ func TestInstanceCheckpoints(t *testing.T) {
 
 		out = r.Run(t, []string{
 			"unikraft", "instance", "checkpoint", "create", "test-" + instName,
-			"--set", "wait-timeout=30s",
 			"--output", "template={{ .name }}",
 		})
 		checkpointName := strings.TrimSpace(out)
@@ -256,7 +288,6 @@ func TestInstanceCheckpoints(t *testing.T) {
 
 		out := r.Run(t, []string{
 			"unikraft", "instance", "checkpoint", "create", "test-base-" + baseName,
-			"--set", "wait-timeout=30s",
 			"--output", "template={{ .name }}",
 		})
 		checkpointName := strings.TrimSpace(out)
@@ -300,7 +331,6 @@ func TestInstanceCheckpoints(t *testing.T) {
 
 		out := r.Run(t, []string{
 			"unikraft", "instance", "checkpoint", "create", "test-base-" + baseName,
-			"--set", "wait-timeout=30s",
 			"--output", "template={{ .name }}",
 		})
 		checkpointName := strings.TrimSpace(out)
@@ -371,7 +401,6 @@ func TestInstanceCheckpoints(t *testing.T) {
 		// Take a checkpoint (counter=3).
 		out = r.Run(t, []string{
 			"unikraft", "instance", "checkpoint", "create", "test-" + instName,
-			"--set", "wait-timeout=30s",
 			"--output", "template={{ .name }}",
 		})
 		checkpointName := strings.TrimSpace(out)

--- a/cmd/unikraft/integration/instance_template_test.go
+++ b/cmd/unikraft/integration/instance_template_test.go
@@ -52,6 +52,32 @@ func TestInstanceTemplates(t *testing.T) {
 		r.Run(t, []string{"unikraft", "instance", "template", "delete", templateName})
 	})
 
+	t.Run("create-is-immediately-visible", func(t *testing.T) {
+		r := runner(t, true, []string{staging, stable})
+		instName := uniq()
+
+		r.Run(t, []string{
+			"unikraft", "instance", "create",
+			"--output", "quiet",
+			"--set", "name=test-" + instName,
+			"--set", "metro=" + r.Config.MetroName,
+			"--set", "image=nginx:latest",
+			"--set", "autostart=false",
+			"--set", "resources.memory=128",
+			"--set", "resources.vcpus=1",
+		})
+
+		// The create output itself must describe the template.
+		out := r.Run(t, []string{
+			"unikraft", "instance", "template", "create", "test-" + instName,
+		})
+		assert.NotContains(t, out, "references not found")
+		assert.Regexp(t, `state:\s+template`, out)
+		assert.Contains(t, out, "test-"+instName)
+
+		r.Run(t, []string{"unikraft", "instance", "template", "delete", "test-" + instName})
+	})
+
 	t.Run("create-from-template", func(t *testing.T) {
 		r := runner(t, true, []string{staging, stable})
 		instName := uniq()

--- a/cmd/unikraft/integration/instance_test.go
+++ b/cmd/unikraft/integration/instance_test.go
@@ -959,6 +959,25 @@ func TestInstances(t *testing.T) {
 		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName})
 	})
 
+	t.Run("create-waits-for-running", func(t *testing.T) {
+		r := runner(t, true, []string{staging, stable})
+		instName := uniq()
+
+		r.Run(t, []string{
+			"unikraft", "instance", "create",
+			"--output", "quiet",
+			"--set", "name=test-" + instName,
+			"--set", "metro=" + r.Config.MetroName,
+			"--set", "image=nginx:latest",
+			"--set", "autostart=true",
+			"--set", "resources.memory=128",
+			"--set", "resources.vcpus=1",
+		})
+		out := r.Run(t, []string{"unikraft", "instance", "inspect", "test-" + instName})
+		assert.Regexp(t, `state:\s+running`, out)
+		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName})
+	})
+
 	t.Run("suspend", func(t *testing.T) {
 		r := runner(t, true, []string{staging, stable})
 		instName := uniq()

--- a/cmd/unikraft/integration/instance_test.go
+++ b/cmd/unikraft/integration/instance_test.go
@@ -86,7 +86,10 @@ func tunnelProxyUUIDs(t *testing.T, cfg *config.Config, metro string) map[string
 
 func TestInstances(t *testing.T) {
 	t.Run("create", func(t *testing.T) {
-		r := runner(t, true, []string{staging, stable, prod})
+		// TODO: Add 'prod' back when it runs platform version 13. Older
+		// versions send a duplicate "status" member that breaks every wait.
+		// See https://github.com/unikraft-cloud/platform/pull/937
+		r := runner(t, true, []string{staging, stable})
 		instName := uniq()
 
 		out := r.Run(t, []string{"unikraft", "instance", "list", "--output", "quiet"})
@@ -244,7 +247,10 @@ func TestInstances(t *testing.T) {
 	})
 
 	t.Run("create-oom", func(t *testing.T) {
-		r := runner(t, true, []string{staging, stable})
+		// TODO: Add 'stable' back when it runs platform version 13. Older
+		// versions send a duplicate "status" member that breaks every wait.
+		// See https://github.com/unikraft-cloud/platform/pull/937
+		r := runner(t, true, []string{staging})
 		instName := uniq()
 
 		r.Run(t, []string{
@@ -266,7 +272,10 @@ func TestInstances(t *testing.T) {
 	})
 
 	t.Run("connect", func(t *testing.T) {
-		r := runner(t, true, []string{staging, stable, prod})
+		// TODO: Add 'prod' back when it runs platform version 13. Older
+		// versions send a duplicate "status" member that breaks every wait.
+		// See https://github.com/unikraft-cloud/platform/pull/937
+		r := runner(t, true, []string{staging, stable})
 		instName := uniq()
 		domainName := uniq()
 
@@ -300,7 +309,10 @@ func TestInstances(t *testing.T) {
 	})
 
 	t.Run("getting-started", func(t *testing.T) {
-		r := runner(t, true, []string{staging, stable, prod})
+		// TODO: Add 'prod' back when it runs platform version 13. Older
+		// versions send a duplicate "status" member that breaks every wait.
+		// See https://github.com/unikraft-cloud/platform/pull/937
+		r := runner(t, true, []string{staging, stable})
 		instName := uniq()
 
 		r.Run(t, []string{
@@ -421,7 +433,10 @@ func TestInstances(t *testing.T) {
 	})
 
 	t.Run("restart-follow", func(t *testing.T) {
-		r := runner(t, true, []string{staging, stable})
+		// TODO: Add 'stable' back when it runs platform version 13. Older
+		// versions send a duplicate "status" member that breaks every wait.
+		// See https://github.com/unikraft-cloud/platform/pull/937
+		r := runner(t, true, []string{staging})
 		instName := uniq()
 		volName := uniq()
 		baseImage := integ.Busybox.Build(t, r)

--- a/cmd/unikraft/testdata/TestHelp/instances
+++ b/cmd/unikraft/testdata/TestHelp/instances
@@ -81,7 +81,6 @@ Fields:
   sched-priority
   autostart
   replicas
-  wait-timeout
   features
   vsock
   template
@@ -154,7 +153,6 @@ Fields:
   sched-priority
   autostart
   replicas
-  wait-timeout
   features
   vsock
   template
@@ -235,7 +233,6 @@ Fields:
   sched-priority
   autostart
   replicas
-  wait-timeout
   features
   vsock
   template
@@ -318,7 +315,6 @@ Fields:
   sched-priority
   autostart
   replicas
-  wait-timeout
   features
   vsock
   template
@@ -425,7 +421,6 @@ Fields:
   sched-priority
   autostart
   replicas
-  wait-timeout
   features
   vsock
   template
@@ -617,7 +612,6 @@ Fields:
   sched-priority
   autostart
   replicas
-  wait-timeout
   features
   vsock
   template
@@ -818,7 +812,6 @@ Fields:
   sched-priority
   autostart
   replicas
-  wait-timeout
   features
   vsock
   template
@@ -1007,7 +1000,6 @@ Fields:
   sched-priority
   autostart
   replicas
-  wait-timeout
   features
   vsock
   template
@@ -1140,7 +1132,6 @@ Fields:
   sched-priority
   autostart
   replicas
-  wait-timeout
   features
   vsock
   template
@@ -1642,7 +1633,6 @@ Fields:
   zero.stateful, scale-to-zero.cooldown-time, scale-to-zero.notify-time
   restart, restart.policy
   instance
-  wait-timeout
 
 Global flags:
   -h, --help
@@ -1698,7 +1688,6 @@ Fields:
   zero.stateful, scale-to-zero.cooldown-time, scale-to-zero.notify-time
   restart, restart.policy
   instance
-  wait-timeout
 
 Flags:
   -w, --watch=<duration>
@@ -1762,7 +1751,6 @@ Fields:
   zero.stateful, scale-to-zero.cooldown-time, scale-to-zero.notify-time
   restart, restart.policy
   instance
-  wait-timeout
 
 Flags:
       --filter
@@ -1828,7 +1816,6 @@ Fields:
   zero.stateful, scale-to-zero.cooldown-time, scale-to-zero.notify-time
   restart, restart.policy
   instance
-  wait-timeout
 
 Flags:
       --until, --filter
@@ -1896,7 +1883,6 @@ Fields:
   zero.stateful, scale-to-zero.cooldown-time, scale-to-zero.notify-time
   restart, restart.policy
   instance
-  wait-timeout
 
 Flags:
       --set=<name>=<value> ..., --set-file=<name>=<filename> ...
@@ -1968,7 +1954,6 @@ Fields:
   zero.stateful, scale-to-zero.cooldown-time, scale-to-zero.notify-time
   restart, restart.policy
   instance
-  wait-timeout
 
 Flags:
       --set=<name>=<value> ..., --set-file=<name>=<filename> ...
@@ -2051,7 +2036,6 @@ Fields:
   zero.stateful, scale-to-zero.cooldown-time, scale-to-zero.notify-time
   restart, restart.policy
   instance
-  wait-timeout
 
 Flags:
       --all

--- a/cmd/unikraft/testdata/TestHelp/run
+++ b/cmd/unikraft/testdata/TestHelp/run
@@ -73,7 +73,6 @@ Fields:
   sched-priority
   autostart
   replicas
-  wait-timeout
   features
   vsock
   template

--- a/internal/cmd/instance_checkpoints.go
+++ b/internal/cmd/instance_checkpoints.go
@@ -25,6 +25,7 @@ import (
 	"unikraft.com/cli/internal/multimetro"
 	"unikraft.com/cli/internal/resource"
 	"unikraft.com/cli/internal/resource/cmd"
+	"unikraft.com/cli/internal/timeouts"
 	"unikraft.com/cli/internal/types"
 )
 
@@ -79,8 +80,7 @@ type InstanceCheckpoint struct {
 		Policy string `mirror:"instance.restart_policy"`
 	}
 
-	InstanceRef string          `field:"instance,invisible,valueless" create:"set,required" flag-arg:"instance" completion-predictor:"resource-key-instance" help:"Instance to create a checkpoint from."`
-	WaitTimeout types.DurationS `field:"wait-timeout,invisible,valueless" create:"set"`
+	InstanceRef string `field:"instance,invisible,valueless" create:"set,required" flag-arg:"instance" completion-predictor:"resource-key-instance" help:"Instance to create a checkpoint from."`
 
 	Instance platform.Instance `field:"-" json:"instance"`
 	Metro    *config.Metro     `field:"-" json:"metro"`
@@ -300,17 +300,12 @@ func instanceCheckpointPatchSpec(path string, op patchOp, value any) (platform.M
 
 func (InstanceCheckpoint) Create(ctx context.Context, fields []resource.Field) ([]resource.Resource, error) {
 	var instance string
-	var timeoutS *int64
 	for key, field := range resource.IterFields(fields) {
 		if field.Create == nil || field.Create.Set == nil {
 			continue
 		}
-		switch key.String() {
-		case "instance":
+		if key.String() == "instance" {
 			instance = field.Create.Set.(string)
-		case "wait-timeout":
-			timeout := field.Create.Set.(types.DurationS)
-			timeoutS = new(int64(timeout))
 		}
 	}
 	if instance == "" {
@@ -338,14 +333,20 @@ func (InstanceCheckpoint) Create(ctx context.Context, fields []resource.Field) (
 		return nil, err
 	}
 
+	// The checkpoint as the create call reported it, keyed by multimetro key.
+	createdData := make(map[string]createdResource[platform.Instance])
 	created, err := group.CollectMetro(ctx, g, inst.key.Metro, func(ctx context.Context, c multimetro.MetroClient) (multimetro.Keys, error) {
 		log.G(ctx).Trace().Str("ref", refStr).Msg("creating instance checkpoint")
 		req := platform.CreateCheckpointInstancesRequestItem{
 			From:     ref.NameOrUUID(),
-			TimeoutS: timeoutS,
+			TimeoutS: new(int64(-1)),
 		}
-		resp, err := c.CreateCheckpointInstances(ctx, []platform.CreateCheckpointInstancesRequestItem{req})
-		if err != nil {
+		resp, err := timeouts.TryWithFallback(
+			ctx,
+			[]platform.CreateCheckpointInstancesRequestItem{req},
+			c.CreateCheckpointInstances,
+		)
+		if _, err = timeouts.Tolerate(ctx, resp, err, "checkpoint create did not complete"); err != nil {
 			return nil, fmt.Errorf("failed to create checkpoint for %s: %w", refStr, err)
 		}
 		if resp == nil || resp.Data == nil || len(resp.Data.Instances) == 0 {
@@ -354,9 +355,11 @@ func (InstanceCheckpoint) Create(ctx context.Context, fields []resource.Field) (
 		var created multimetro.Keys
 		var errs []error
 		for _, cp := range resp.Data.Instances {
+			name := cmp.Or(cp.Name, cp.Uuid)
 			status := cp.Status
-			if status != "" && status != platform.ResponseStatusSuccess {
-				name := cmp.Or(cp.Name, cp.Uuid)
+			failed := status != "" && status != platform.ResponseStatusSuccess
+			// A UUID means the checkpoint exists
+			if cp.Uuid == "" && failed {
 				message := ptr.ZeroIfNil(cp.Message)
 				if message == "" {
 					message = "unknown error"
@@ -364,22 +367,55 @@ func (InstanceCheckpoint) Create(ctx context.Context, fields []resource.Field) (
 				errs = append(errs, fmt.Errorf("checkpoint create failed for %s: %s", name, message))
 				continue
 			}
-			created = append(created, multimetro.Key{
+			if failed {
+				log.G(ctx).Warn().
+					Str("checkpoint", name).
+					Str("state", string(cp.State)).
+					Str("reason", ptr.ZeroIfNil(cp.Message)).
+					Msg("checkpoint has not reached the checkpoint state yet")
+			}
+			key := multimetro.Key{
 				Metro: c.Metro.Name,
 				UUID:  cp.Uuid,
 				Name:  cp.Name,
-			})
+			}
+			createdData[key.String()] = createdResource[platform.Instance]{
+				data: platform.Instance{
+					Uuid:  cp.Uuid,
+					Name:  cp.Name,
+					State: cp.State,
+				},
+				metro: c.Metro,
+			}
+			created = append(created, key)
 		}
 		return created, errors.Join(errs...)
 	})
-	if err != nil {
+	if err != nil && len(created) == 0 {
 		return nil, err
 	}
 	if len(created) == 0 {
 		return nil, fmt.Errorf("no checkpoint created for %s", refStr)
 	}
 
-	return InstanceCheckpoint{}.Get(ctx, created.Strings())
+	var errs []error
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	results, err := InstanceCheckpoint{}.Get(ctx, created.Strings())
+	// Checkpoint creation is asynchronous, so a checkpoint that was just created
+	// may not be listed yet.
+	if notFound, ok := errors.AsType[group.ErrRefNotFound](err); ok {
+		recovered, missing := recoverCreated(ctx, notFound.Refs, createdData, InstanceCheckpoint{}.load)
+		results = append(results, recovered...)
+		if len(missing) > 0 {
+			errs = append(errs, group.ErrRefNotFound{Refs: missing})
+		}
+	} else if err != nil {
+		errs = append(errs, err)
+	}
+	return results, errors.Join(errs...)
 }
 
 func (InstanceCheckpoint) Examples() map[cmd.CmdType][]kingkong.Example {

--- a/internal/cmd/instance_templates.go
+++ b/internal/cmd/instance_templates.go
@@ -24,6 +24,7 @@ import (
 	"unikraft.com/cli/internal/multimetro"
 	"unikraft.com/cli/internal/resource"
 	"unikraft.com/cli/internal/resource/cmd"
+	"unikraft.com/cli/internal/timeouts"
 	"unikraft.com/cli/internal/types"
 )
 
@@ -333,6 +334,7 @@ func (InstanceTemplate) Create(ctx context.Context, fields []resource.Field) ([]
 		return nil, err
 	}
 
+	createdData := make(map[string]createdResource[platform.Instance])
 	created, err := group.CollectMetro(ctx, g, inst.key.Metro, func(ctx context.Context, c multimetro.MetroClient) (multimetro.Keys, error) {
 		var reqItem platform.CreateTemplateInstancesRequestItem
 		if ref.Name != "" {
@@ -341,13 +343,13 @@ func (InstanceTemplate) Create(ctx context.Context, fields []resource.Field) ([]
 			reqItem.Uuid = new(ref.UUID)
 		}
 		log.G(ctx).Trace().Str("ref", refStr).Msg("creating instance template")
-		resp, err := c.CreateTemplateInstances(
+		reqItem.TimeoutS = new(int64(-1))
+		resp, err := timeouts.TryWithFallback(
 			ctx,
-			[]platform.CreateTemplateInstancesRequestItem{
-				reqItem,
-			},
+			[]platform.CreateTemplateInstancesRequestItem{reqItem},
+			c.CreateTemplateInstances,
 		)
-		if err != nil {
+		if _, err = timeouts.Tolerate(ctx, resp, err, "template create did not complete"); err != nil {
 			return nil, fmt.Errorf("failed to create template for %s: %w", refStr, err)
 		}
 		if resp == nil || resp.Data == nil || len(resp.Data.Instances) == 0 {
@@ -356,9 +358,11 @@ func (InstanceTemplate) Create(ctx context.Context, fields []resource.Field) ([]
 		var created multimetro.Keys
 		var errs []error
 		for _, tmpl := range resp.Data.Instances {
+			name := cmp.Or(tmpl.Name, tmpl.Uuid)
 			status := tmpl.Status
-			if status != "" && status != platform.ResponseStatusSuccess {
-				name := cmp.Or(tmpl.Name, tmpl.Uuid)
+			failed := status != "" && status != platform.ResponseStatusSuccess
+			// A UUID means the template exists
+			if tmpl.Uuid == "" && failed {
 				message := ptr.ZeroIfNil(tmpl.Message)
 				if message == "" {
 					message = "unknown error"
@@ -366,22 +370,53 @@ func (InstanceTemplate) Create(ctx context.Context, fields []resource.Field) ([]
 				errs = append(errs, fmt.Errorf("template create failed for %s: %s", name, message))
 				continue
 			}
-			created = append(created, multimetro.Key{
+			if failed {
+				log.G(ctx).Warn().
+					Str("template", name).
+					Str("state", string(tmpl.State)).
+					Str("reason", ptr.ZeroIfNil(tmpl.Message)).
+					Msg("template has not reached the template state yet")
+			}
+			key := multimetro.Key{
 				Metro: c.Metro.Name,
 				UUID:  tmpl.Uuid,
 				Name:  tmpl.Name,
-			})
+			}
+			createdData[key.String()] = createdResource[platform.Instance]{
+				data: platform.Instance{
+					Uuid:  tmpl.Uuid,
+					Name:  tmpl.Name,
+					State: tmpl.State,
+				},
+				metro: c.Metro,
+			}
+			created = append(created, key)
 		}
 		return created, errors.Join(errs...)
 	})
-	if err != nil {
+	if err != nil && len(created) == 0 {
 		return nil, err
 	}
 	if len(created) == 0 {
 		return nil, fmt.Errorf("no template created for %s", refStr)
 	}
 
-	return InstanceTemplate{}.Get(ctx, created.Strings())
+	var errs []error
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	results, err := InstanceTemplate{}.Get(ctx, created.Strings())
+	if notFound, ok := errors.AsType[group.ErrRefNotFound](err); ok {
+		recovered, missing := recoverCreated(ctx, notFound.Refs, createdData, InstanceTemplate{}.load)
+		results = append(results, recovered...)
+		if len(missing) > 0 {
+			errs = append(errs, group.ErrRefNotFound{Refs: missing})
+		}
+	} else if err != nil {
+		errs = append(errs, err)
+	}
+	return results, errors.Join(errs...)
 }
 
 func (InstanceTemplate) Examples() map[cmd.CmdType][]kingkong.Example {

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -988,7 +988,11 @@ func instancePatchSpec(path string, op patchOp, value any) (platform.MutableInst
 		}
 		return platform.MutableInstancePropertyAnnotations, value.(map[string]string), nil
 	case "image":
-		return platform.MutableInstancePropertyImage, value.(types.ImageRef[reference.Named]).Reference.String(), nil
+		ref := value.(types.ImageRef[reference.Named]).Reference
+		if ref == nil {
+			return zero, nil, fmt.Errorf("image cannot be empty")
+		}
+		return platform.MutableInstancePropertyImage, ref.String(), nil
 	case "runtime.args":
 		return platform.MutableInstancePropertyArgs, []string(value.(InstanceArgs)), nil
 	case "runtime.env":
@@ -1098,7 +1102,9 @@ func (Instance) Create(ctx context.Context, fields []resource.Field) ([]resource
 		case "metro":
 			metro = string(field.Create.Set.(LinkName[Metro]))
 		case "image":
-			imageURL = field.Create.Set.(types.ImageRef[reference.Named]).Reference.String()
+			if ref := field.Create.Set.(types.ImageRef[reference.Named]).Reference; ref != nil {
+				imageURL = ref.String()
+			}
 		case "pull-policy":
 			pullPolicy = field.Create.Set.(*platform.PullPolicy)
 		case "type":

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -41,6 +41,7 @@ import (
 	"unikraft.com/cli/internal/resource"
 	"unikraft.com/cli/internal/resource/cmd"
 	"unikraft.com/cli/internal/resource/value"
+	"unikraft.com/cli/internal/timeouts"
 	"unikraft.com/cli/internal/tunnel"
 	"unikraft.com/cli/internal/types"
 )
@@ -152,7 +153,6 @@ type Instance struct {
 	SchedPriority *platform.SchedPriority `mirror:"instance.sched_priority" field:"sched-priority,long" create:"set" edit:"set" flag:"sched-priority" help:"Scheduling priority for the instance." placeholder:"priority" example:"normal,medium,high,admin"`
 	Autostart     bool                    `field:"autostart,invisible,valueless" create:"set" flag:"autostart" help:"Start instance automatically."`
 	Replicas      int64                   `field:"replicas,invisible,valueless" create:"set" flag:"replicas" help:"Number of replicas." placeholder:"n" example:"1,3"`
-	WaitTimeout   types.DurationS         `field:"wait-timeout,invisible,valueless" create:"set"`
 	Features      []string                `field:"features,invisible,valueless" create:"set" flag:"feature" sep:"none" help:"Instance feature." placeholder:"feature"`
 	Vsock         bool                    `field:"vsock,invisible,valueless" create:"set" edit:"set"`
 	Template      string                  `field:"template,invisible,valueless" create:"set" flag:"template" help:"Create from instance template." placeholder:"name"`
@@ -782,21 +782,24 @@ func (Instance) Delete(ctx context.Context, keys []string) error {
 				TimeoutS: new(int64(-1)),
 			}
 		}
-		instances, err := c.DeleteInstances(ctx, reqs)
-		if err != nil && strings.Contains(err.Error(), "timeout_s") && strings.Contains(err.Error(), "is not a valid member") {
-			// HACK: retry without timeout_s for metros that don't support it.
-			for i := range reqs {
-				reqs[i].TimeoutS = nil
-			}
-			instances, err = c.DeleteInstances(ctx, reqs)
-		}
+		instances, err := timeouts.TryWithFallback(ctx, reqs, c.DeleteInstances)
+		timedOut, err := timeouts.Tolerate(ctx, instances, err, "instance delete did not finish in time")
 		if err != nil && !platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
 			return nil, err
+		}
+		if instances == nil || instances.Data == nil {
+			return nil, nil
 		}
 		var deleted []group.Ref
 		for _, instance := range instances.Data.Instances {
 			if instance.Status != platform.ResponseStatusSuccess {
-				continue
+				if err != nil && !timedOut {
+					continue
+				}
+				log.G(ctx).Warn().
+					Str("instance", cmp.Or(instance.Name, instance.Uuid)).
+					Str("reason", ptr.ZeroIfNil(instance.Message)).
+					Msg("instance delete has not finished yet")
 			}
 			deleted = append(deleted, group.Ref{
 				Metro: c.Metro.Name,
@@ -1087,6 +1090,7 @@ func (Instance) Create(ctx context.Context, fields []resource.Field) ([]resource
 	var metro string
 	var imageURL string
 	var pullPolicy *platform.PullPolicy
+	var autostart bool
 	for key, field := range resource.IterFields(fields) {
 		if field.Create == nil || field.Create.Set == nil {
 			continue
@@ -1281,14 +1285,11 @@ func (Instance) Create(ctx context.Context, fields []resource.Field) ([]resource
 				req.ServiceGroup.HardLimit = &limit
 			}
 		case "autostart":
-			autostart := field.Create.Set.(bool)
+			autostart = field.Create.Set.(bool)
 			req.Autostart = &autostart
 		case "replicas":
 			replicas := field.Create.Set.(int64)
 			req.Replicas = &replicas
-		case "wait-timeout":
-			timeout := field.Create.Set.(types.DurationS)
-			req.TimeoutS = new(int64(timeout))
 		case "features":
 			features := field.Create.Set.([]string)
 			for _, f := range features {
@@ -1362,38 +1363,77 @@ func (Instance) Create(ctx context.Context, fields []resource.Field) ([]resource
 		return nil, fmt.Errorf("only one of --image, --template, --branch, or --checkpoint may be specified")
 	}
 
+	if autostart {
+		req.TimeoutS = new(int64(-1))
+	}
+
 	g, err := multimetro.NewClient(ctx)
 	if err != nil {
 		return nil, err
 	}
+	createdData := make(map[string]createdResource[platform.Instance])
 	keys, err := group.CollectMetro(ctx, g, metro, func(ctx context.Context, c multimetro.MetroClient) (multimetro.Keys, error) {
 		log.G(ctx).Trace().Msg("creating instance")
-		resp, err := c.CreateInstance(ctx, req)
-		if err != nil {
+		resp, err := timeouts.TryWithFallback(ctx, req, c.CreateInstance)
+		if _, err = timeouts.Tolerate(ctx, resp, err, "instance create did not complete in time"); err != nil {
 			return nil, err
 		}
 		if resp == nil || resp.Data == nil || len(resp.Data.Instances) == 0 {
 			return nil, fmt.Errorf("no instances created")
 		}
 		created := make(multimetro.Keys, 0, len(resp.Data.Instances))
+		var errs []error
 		for _, instance := range resp.Data.Instances {
+			name := cmp.Or(instance.Name, instance.Uuid)
+			failed := instance.Status != nil && *instance.Status != platform.ResponseStatusSuccess
+			// A UUID means the instance exists
+			if instance.Uuid == "" && failed {
+				message := ptr.ZeroIfNil(instance.Message)
+				if message == "" {
+					message = "unknown error"
+				}
+				errs = append(errs, fmt.Errorf("instance create failed for %s: %s", name, message))
+				continue
+			}
+			if failed {
+				log.G(ctx).Warn().
+					Str("instance", name).
+					Str("state", string(instance.State)).
+					Str("reason", ptr.ZeroIfNil(instance.Message)).
+					Msg("instance has not reached the running state yet")
+			}
 			key := multimetro.Key{
 				Metro: c.Metro.Name,
 				UUID:  instance.Uuid,
 				Name:  instance.Name,
 			}
+			createdData[key.String()] = createdResource[platform.Instance]{data: instance, metro: c.Metro}
 			created = append(created, key)
 		}
-		return created, nil
+		if len(created) == 0 {
+			return nil, errors.Join(errs...)
+		}
+		return created, errors.Join(errs...)
 	})
-	if err != nil {
+	if err != nil && len(keys) == 0 {
 		return nil, err
 	}
-	results, err := Instance{}.Get(ctx, keys.Strings())
+	var errs []error
 	if err != nil {
-		return nil, err
+		errs = append(errs, err)
 	}
-	return results, nil
+
+	results, getErr := Instance{}.Get(ctx, keys.Strings())
+	if notFound, ok := errors.AsType[group.ErrRefNotFound](getErr); ok {
+		recovered, missing := recoverCreated(ctx, notFound.Refs, createdData, Instance{}.load)
+		results = append(results, recovered...)
+		if len(missing) > 0 {
+			errs = append(errs, group.ErrRefNotFound{Refs: missing})
+		}
+	} else if getErr != nil {
+		errs = append(errs, getErr)
+	}
+	return results, errors.Join(errs...)
 }
 
 func (Instance) Examples() map[cmd.CmdType][]kingkong.Example {
@@ -1909,11 +1949,13 @@ func startInstances(ctx context.Context, g *group.Group[multimetro.MetroClient],
 		reqs := make([]platform.StartInstancesRequestItem, 0, len(refs))
 		for _, ref := range refs.NameOrUUIDs() {
 			reqs = append(reqs, platform.StartInstancesRequestItem{
-				Name: ref.Name,
-				Uuid: ref.Uuid,
+				Name:     ref.Name,
+				Uuid:     ref.Uuid,
+				TimeoutS: new(int64(-1)),
 			})
 		}
-		resp, err := c.StartInstances(ctx, reqs)
+		resp, err := timeouts.TryWithFallback(ctx, reqs, c.StartInstances)
+		timedOut, err := timeouts.Tolerate(ctx, resp, err, "instance start did not reach the running state in time")
 		if err != nil && !platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
 			return nil, nil, err
 		}
@@ -1923,7 +1965,13 @@ func startInstances(ctx context.Context, g *group.Group[multimetro.MetroClient],
 		}
 		for _, instance := range resp.Data.Instances {
 			if instance.Status != platform.ResponseStatusSuccess {
-				continue
+				if err != nil && !timedOut {
+					continue
+				}
+				log.G(ctx).Warn().
+					Str("instance", cmp.Or(instance.Name, instance.Uuid)).
+					Str("state", instance.State).
+					Msg("instance has not reached the running state yet")
 			}
 			started = append(started, multimetro.Key{
 				Metro: c.Metro.Name,

--- a/internal/cmd/testdata/TestOutput/instance-checkpoints
+++ b/internal/cmd/testdata/TestOutput/instance-checkpoints
@@ -316,12 +316,5 @@ fra    my-checkpoint  checkpoint  nginx  ["arg1", "arg2"]  256MiB  2      never
       "set": "",
       "required": true
     }
-  },
-  {
-    "name": "wait-timeout",
-    "verbosity": "invisible",
-    "create": {
-      "set": "0s"
-    }
   }
 ]

--- a/internal/cmd/testdata/TestOutput/instances
+++ b/internal/cmd/testdata/TestOutput/instances
@@ -938,13 +938,6 @@ fra    my-instance  running  nginx  ["arg1", "arg2"]  256MiB  2      example.uni
     }
   },
   {
-    "name": "wait-timeout",
-    "verbosity": "invisible",
-    "create": {
-      "set": "0s"
-    }
-  },
-  {
     "name": "features",
     "verbosity": "invisible",
     "create": {

--- a/internal/cmd/util.go
+++ b/internal/cmd/util.go
@@ -11,8 +11,10 @@ import (
 	"maps"
 
 	"unikraft.com/cloud/sdk/platform/group"
+	"unikraft.com/x/log"
 
 	"unikraft.com/cli/internal/config"
+	"unikraft.com/cli/internal/multimetro"
 	"unikraft.com/cli/internal/resource"
 )
 
@@ -82,6 +84,49 @@ func matchRef(refs group.Refs, name, uuid string) *group.Ref {
 	}
 
 	return nil
+}
+
+// createdResource is what a create call reported about a resource, kept so it
+// can still be shown if the resource is not yet visible to a listing.
+type createdResource[T any] struct {
+	data  T
+	metro config.Metro
+}
+
+// recoverCreated builds resources for refs that a listing could not find but
+// that a create call already reported. Refs with nothing to fall back on are
+// returned unchanged.
+func recoverCreated[R resource.Resource, T any](
+	ctx context.Context,
+	refs group.Refs,
+	createdData map[string]createdResource[T],
+	load func(*group.Ref, T, *config.Metro, *config.Profile) (R, error),
+) ([]resource.Resource, group.Refs) {
+	profile, err := config.G(ctx).CurrentProfile()
+	if err != nil {
+		return nil, refs
+	}
+
+	var recovered []resource.Resource
+	var missing group.Refs
+	for _, ref := range refs {
+		key := multimetro.Key(ref).String()
+		created, ok := createdData[key]
+		if !ok {
+			missing = append(missing, ref)
+			continue
+		}
+		result, err := load(&ref, created.data, &created.metro, profile)
+		if err != nil {
+			missing = append(missing, ref)
+			continue
+		}
+		log.G(ctx).Warn().
+			Str("resource", key).
+			Msg("not listed yet")
+		recovered = append(recovered, result)
+	}
+	return recovered, missing
 }
 
 type patchOp string

--- a/internal/cmd/util_test.go
+++ b/internal/cmd/util_test.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"unikraft.com/cloud/sdk/platform"
+	"unikraft.com/cloud/sdk/platform/group"
+
+	"unikraft.com/cli/internal/config"
+	"unikraft.com/cli/internal/multimetro"
+)
+
+func TestRecoverCreatedFallsBackToCreateResponse(t *testing.T) {
+	metro := config.Metro{Name: "fra", Endpoint: "https://api.fra.unikraft.cloud"}
+	ctx := config.WithConfig(t.Context(), &config.Config{
+		DefaultProfile: "default",
+		Profiles: map[string]config.Profile{
+			"default": {
+				Type:   config.ProfileTypeCloud,
+				Name:   "default",
+				Token:  "token",
+				Metros: []config.Metro{metro},
+			},
+		},
+	})
+
+	known := multimetro.Key{Metro: "fra", Name: "linuxssh", UUID: "u1"}
+	unknown := multimetro.Key{Metro: "fra", Name: "gone", UUID: "u2"}
+
+	createdData := map[string]createdResource[platform.Instance]{
+		known.String(): {
+			data: platform.Instance{
+				Uuid:  "u1",
+				Name:  "linuxssh",
+				State: platform.InstanceStateStopping,
+			},
+			metro: metro,
+		},
+	}
+
+	refs := group.Refs{group.Ref(known), group.Ref(unknown)}
+	recovered, missing := recoverCreated(ctx, refs, createdData, InstanceTemplate{}.load)
+
+	require.Len(t, recovered, 1, "the created template should be recovered")
+	tmpl, ok := recovered[0].(InstanceTemplate)
+	require.True(t, ok, "recovered resource should be an InstanceTemplate")
+	assert.Equal(t, "linuxssh", tmpl.Name)
+	assert.Equal(t, "u1", tmpl.UUID)
+	assert.Equal(t, known.String(), tmpl.Key().String())
+
+	require.Len(t, missing, 1, "a ref with nothing to fall back on stays missing")
+	assert.Equal(t, "gone", missing[0].Name)
+}
+
+// TestRecoverCreatedWithoutProfileReportsAllMissing ensures a broken config
+// cannot silently turn missing resources into recovered ones.
+func TestRecoverCreatedWithoutProfileReportsAllMissing(t *testing.T) {
+	key := multimetro.Key{Metro: "fra", Name: "linuxssh", UUID: "u1"}
+	createdData := map[string]createdResource[platform.Instance]{
+		key.String(): {data: platform.Instance{Uuid: "u1", Name: "linuxssh"}},
+	}
+
+	recovered, missing := recoverCreated(t.Context(), group.Refs{group.Ref(key)}, createdData, InstanceTemplate{}.load)
+
+	assert.Empty(t, recovered)
+	require.Len(t, missing, 1)
+	assert.Equal(t, "linuxssh", missing[0].Name)
+}

--- a/internal/timeouts/timeouts.go
+++ b/internal/timeouts/timeouts.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package timeouts
+
+import (
+	"context"
+	"reflect"
+	"strings"
+
+	"unikraft.com/cloud/sdk/platform"
+	"unikraft.com/x/log"
+)
+
+// Tolerate reports whether a call failed only because its wait ran out. If it
+// did, it warns with msg and returns no error, because the operation goes on.
+// Every other error is returned as it is.
+func Tolerate[T any](ctx context.Context, resp *platform.Response[T], err error, msg string) (bool, error) {
+	if err == nil || resp == nil || resp.Data == nil {
+		return false, err
+	}
+	// The platform puts this text at the top level of a response when a wait
+	// ran out.
+	if !platform.ErrorContains(err, platform.APIHTTPErrorTimedOut) &&
+		(resp.Message != "Operation timed out" ||
+			!platform.ErrorContainsOnly(err, platform.APIHTTPErrorUnknownError)) {
+		return false, err
+	}
+	log.G(ctx).Warn().Str("reason", resp.Message).Msg(msg)
+	return true, nil
+}
+
+// TryWithFallback runs a request and, when the metro rejects it for not knowing
+// the timeout_s field, asks for the same wait through the deprecated field and
+// runs it once more.
+//
+// HACK: only metros that predate timeout_s need this, so it can go once they
+// have all been bumped.
+func TryWithFallback[Req, Resp any](
+	ctx context.Context,
+	req Req,
+	call func(context.Context, Req) (*platform.Response[Resp], error),
+) (*platform.Response[Resp], error) {
+	resp, err := call(ctx, req)
+	if err == nil ||
+		!strings.Contains(err.Error(), "timeout_s") ||
+		!strings.Contains(err.Error(), "is not a valid member") {
+		return resp, err
+	}
+	if !downgrade(reflect.ValueOf(&req).Elem()) {
+		return resp, err
+	}
+	return call(ctx, req)
+}
+
+// downgrade rewrites a request in place to ask for its wait through the
+// deprecated wait field, reporting whether it found anything to rewrite.
+//
+// HACK: only metros that predate timeout_s need this, so it can go once they
+// have all been bumped.
+func downgrade(v reflect.Value) bool {
+	if v.Kind() != reflect.Slice {
+		return downgradeItem(v)
+	}
+	downgraded := false
+	for i := range v.Len() {
+		downgraded = downgradeItem(v.Index(i)) || downgraded
+	}
+	return downgraded
+}
+
+// downgradeItem swaps timeout_s for the deprecated wait field on a single
+// request item.
+//
+// HACK: only metros that predate timeout_s need this, so it can go once they
+// have all been bumped.
+func downgradeItem(v reflect.Value) bool {
+	if v.Kind() != reflect.Struct {
+		return false
+	}
+	timeoutS := v.FieldByName("TimeoutS")
+	if !timeoutS.IsValid() {
+		return false
+	}
+	timeoutS.SetZero()
+	for _, name := range []string{"WaitTimeoutMs", "TimeoutMs"} {
+		if field := v.FieldByName(name); field.IsValid() {
+			field.Set(reflect.ValueOf(new(int64(-1))))
+			break
+		}
+	}
+	return true
+}

--- a/internal/timeouts/timeouts_test.go
+++ b/internal/timeouts/timeouts_test.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package timeouts
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"unikraft.com/cloud/sdk/platform"
+)
+
+// timedOutResponse builds the response a metro returns when a create call was
+// accepted but the wait for the target state ran out
+func timedOutResponse(instances ...platform.Instance) *platform.Response[platform.CreateInstanceResponseData] {
+	return &platform.Response[platform.CreateInstanceResponseData]{
+		Status:  platform.ResponseStatusError,
+		Message: "Operation timed out",
+		Data:    &platform.CreateInstanceResponseData{Instances: instances},
+	}
+}
+
+// TestTimedOutResponseShape pins the platform behaviour that the create, start
+// and delete paths rely on when they keep a response that came back with an
+// error.
+func TestTimedOutResponseShape(t *testing.T) {
+	resp := timedOutResponse(platform.Instance{
+		Uuid:   "4a1f0c9e-0000-0000-0000-000000000001",
+		Name:   "demo",
+		State:  platform.InstanceStateStarting,
+		Status: new(platform.ResponseStatusError),
+	})
+	err := platform.NewFromResponse(resp)
+
+	require.Error(t, err)
+	assert.Equal(t, platform.ResponseStatusError, resp.Status)
+	assert.NotEqual(t, platform.ResponseStatusPartialSuccess, resp.Status)
+
+	require.NotNil(t, resp.Data)
+	require.Len(t, resp.Data.Instances, 1)
+	assert.NotEmpty(t, resp.Data.Instances[0].Uuid, "the UUID is the proof the resource exists")
+
+	assert.False(t, platform.ErrorContains(err, platform.APIHTTPErrorTimedOut),
+		"timeouts are not detectable by error code")
+	assert.Contains(t, err.Error(), "Operation timed out")
+}
+
+// rejectedResponse builds the response a metro returns when it refused the
+// operation outright.
+func rejectedResponse(code platform.APIHTTPError, message string) *platform.Response[platform.CreateInstanceResponseData] {
+	return &platform.Response[platform.CreateInstanceResponseData]{
+		Status:  platform.ResponseStatusError,
+		Message: "Failed to perform all operations",
+		Data: &platform.CreateInstanceResponseData{
+			Instances: []platform.Instance{{
+				Uuid:    "4a1f0c9e-0000-0000-0000-000000000001",
+				Name:    "demo",
+				Status:  new(platform.ResponseStatusError),
+				Message: &message,
+				Error:   new(int32(code)),
+			}},
+		},
+	}
+}
+
+// TestTolerateOnlyClearsTimeouts is the guard against a real failure being
+// reported as a success with a warning.
+func TestTolerateOnlyClearsTimeouts(t *testing.T) {
+	timedOut := timedOutResponse(platform.Instance{
+		Uuid:   "4a1f0c9e-0000-0000-0000-000000000001",
+		Name:   "demo",
+		State:  platform.InstanceStateStarting,
+		Status: new(platform.ResponseStatusError),
+	})
+	rejected := rejectedResponse(platform.APIHTTPErrorNotAllowed,
+		"Deletion protection enabled")
+
+	for _, tt := range []struct {
+		name string
+		resp *platform.Response[platform.CreateInstanceResponseData]
+		err  error
+		want bool
+	}{
+		{
+			name: "timeout",
+			resp: timedOut,
+			err:  platform.NewFromResponse(timedOut),
+			want: true,
+		},
+		{
+			name: "rejected operation",
+			resp: rejected,
+			err:  platform.NewFromResponse(rejected),
+		},
+		{
+			name: "no error",
+			resp: &platform.Response[platform.CreateInstanceResponseData]{
+				Status: platform.ResponseStatusSuccess,
+				Data:   &platform.CreateInstanceResponseData{},
+			},
+		},
+		{
+			name: "error without data",
+			resp: &platform.Response[platform.CreateInstanceResponseData]{
+				Status:  platform.ResponseStatusError,
+				Message: "Operation timed out",
+			},
+			err: errors.New("boom"),
+		},
+		{
+			name: "transport or decode failure",
+			resp: &platform.Response[platform.CreateInstanceResponseData]{
+				Data: &platform.CreateInstanceResponseData{},
+			},
+			err: errors.New("parsing response: unexpected EOF"),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			timedOut, err := Tolerate(t.Context(), tt.resp, tt.err, "did not finish in time")
+			assert.Equal(t, tt.want, timedOut)
+			if tt.want {
+				assert.NoError(t, err, "a timeout is cleared so the caller can carry on")
+			} else {
+				assert.Equal(t, tt.err, err, "every other error is returned untouched")
+			}
+		})
+	}
+}
+
+// TestDowngrade pins the field names the compatibility retry reaches by
+// reflection.
+func TestDowngrade(t *testing.T) {
+	create := platform.CreateInstanceRequest{TimeoutS: new(int64(-1))}
+	assert.True(t, downgrade(reflect.ValueOf(&create).Elem()))
+	assert.Nil(t, create.TimeoutS)
+	assert.Equal(t, new(int64(-1)), create.WaitTimeoutMs) //nolint:staticcheck // The deprecated field is what is being set.
+
+	starts := []platform.StartInstancesRequestItem{
+		{TimeoutS: new(int64(-1))},
+		{TimeoutS: new(int64(-1))},
+	}
+	assert.True(t, downgrade(reflect.ValueOf(&starts).Elem()))
+	for i, start := range starts {
+		assert.Nil(t, start.TimeoutS, "item %d", i)
+		assert.Equal(t, new(int64(-1)), start.WaitTimeoutMs, "item %d", i) //nolint:staticcheck // The deprecated field is what is being set.
+	}
+
+	deletes := []platform.DeleteInstanceRequestItem{{TimeoutS: new(int64(-1))}}
+	assert.True(t, downgrade(reflect.ValueOf(&deletes).Elem()))
+	assert.Nil(t, deletes[0].TimeoutS)
+
+	templates := []platform.CreateTemplateInstancesRequestItem{{TimeoutS: new(int64(-1))}}
+	assert.True(t, downgrade(reflect.ValueOf(&templates).Elem()))
+	assert.Nil(t, templates[0].TimeoutS)
+
+	checkpoints := []platform.CreateCheckpointInstancesRequestItem{{TimeoutS: new(int64(-1))}}
+	assert.True(t, downgrade(reflect.ValueOf(&checkpoints).Elem()))
+	assert.Nil(t, checkpoints[0].TimeoutS)
+
+	wait := platform.WaitInstanceByUUIDRequestBody{TimeoutS: new(int64(-1))}
+	assert.True(t, downgrade(reflect.ValueOf(&wait).Elem()))
+	assert.Nil(t, wait.TimeoutS)
+	assert.Equal(t, new(int64(-1)), wait.TimeoutMs) //nolint:staticcheck // The deprecated field is what is being set.
+
+	del := platform.DeleteInstanceByUUIDRequestBody{TimeoutS: new(int64(-1))}
+	assert.True(t, downgrade(reflect.ValueOf(&del).Elem()), "a body with no deprecated field just drops timeout_s")
+	assert.Nil(t, del.TimeoutS)
+
+	stops := []platform.StopInstancesRequestItem{{}}
+	assert.False(t, downgrade(reflect.ValueOf(&stops).Elem()))
+	assert.False(t, downgrade(reflect.ValueOf(new("not a request")).Elem()))
+}

--- a/internal/types/duration.go
+++ b/internal/types/duration.go
@@ -23,7 +23,15 @@ func (d *DurationS) UnmarshalText(text []byte) error {
 	if err != nil {
 		return err
 	}
-	*d = DurationS(dur.Seconds())
+	// Round to the next full second
+	secs := dur / time.Second
+	switch rem := dur % time.Second; {
+	case rem > 0:
+		secs++
+	case rem < 0:
+		secs--
+	}
+	*d = DurationS(secs)
 	return nil
 }
 

--- a/internal/types/duration_test.go
+++ b/internal/types/duration_test.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"unikraft.com/cli/internal/types"
+)
+
+// TestDurationSRoundsUp checks that a sub-second duration never collapses to
+// zero.
+func TestDurationSRoundsUp(t *testing.T) {
+	for _, tt := range []struct {
+		text string
+		want types.DurationS
+	}{
+		{"0", 0},
+		{"5", 5},
+		{"-1", -1},
+		{"0s", 0},
+		{"1s", 1},
+		{"1ms", 1},
+		{"200ms", 1},
+		{"999ms", 1},
+		{"1500ms", 2},
+		{"2s", 2},
+		{"1m", 60},
+		{"1m30s", 90},
+		{"-1s", -1},
+		{"-200ms", -1},
+	} {
+		t.Run(tt.text, func(t *testing.T) {
+			var got types.DurationS
+			require.NoError(t, got.UnmarshalText([]byte(tt.text)))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/types/image.go
+++ b/internal/types/image.go
@@ -54,6 +54,11 @@ func (ir ImageRef[T]) Value() any {
 }
 
 func (ir *ImageRef[T]) UnmarshalText(text []byte) error {
+	if len(text) == 0 {
+		var zero T
+		ir.Reference = zero
+		return nil
+	}
 	ref, err := images.ParseNormalizedNamed(string(text))
 	if err != nil {
 		return err

--- a/internal/volimport/volimport.go
+++ b/internal/volimport/volimport.go
@@ -14,15 +14,23 @@ import (
 	"strings"
 
 	"unikraft.com/cli/internal/multimetro"
+	"unikraft.com/cli/internal/timeouts"
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/x/log"
 )
 
+func deleteInstanceByUUID(ctx context.Context, c multimetro.MetroClient, instUUID string) error {
+	req := platform.DeleteInstanceByUUIDRequestBody{TimeoutS: new(int64(-1))}
+	_, err := timeouts.TryWithFallback(ctx, req,
+		func(ctx context.Context, req platform.DeleteInstanceByUUIDRequestBody) (*platform.Response[platform.DeleteInstancesResponseData], error) {
+			return c.DeleteInstanceByUUID(ctx, instUUID, req)
+		})
+	return err
+}
+
 const (
-	internalPort  = uint32(42069)
-	memoryMB      = int64(128)
-	stopTimeoutS  = int64(2)
-	startTimeoutS = int64(3)
+	internalPort = uint32(42069)
+	memoryMB     = int64(128)
 )
 
 // Start creates a short-lived Unikraft Cloud instance running the
@@ -36,14 +44,12 @@ func Start(ctx context.Context, c multimetro.MetroClient, image, volUUID, authSt
 		"-t", strconv.FormatUint(timeoutS, 10),
 	}
 	destPort := internalPort
-
-	log.G(ctx).Trace().Msg("creating volume data import instance")
-	resp, err := c.CreateInstance(ctx, platform.CreateInstanceRequest{
+	req := platform.CreateInstanceRequest{
 		Image:         &platform.ImageSpec{Url: image},
 		MemoryMb:      new(memoryMB),
 		Args:          args,
 		Autostart:     new(true),
-		TimeoutS:      new(startTimeoutS),
+		TimeoutS:      new(int64(-1)),
 		RestartPolicy: new(platform.InstanceRestartPolicyNever),
 		Features:      []platform.InstanceFeature{platform.InstanceFeatureDeleteOnStop},
 		Volumes: []platform.CreateInstanceRequestVolume{{
@@ -57,7 +63,10 @@ func Start(ctx context.Context, c multimetro.MetroClient, image, volUUID, authSt
 				Handlers:        []platform.ConnectionHandler{platform.ConnectionHandlerTls},
 			}},
 		},
-	})
+	}
+
+	log.G(ctx).Trace().Msg("creating volume data import instance")
+	resp, err := timeouts.TryWithFallback(ctx, req, c.CreateInstance)
 	if err != nil {
 		return "", "", fmt.Errorf("creating volume data import instance: %w", err)
 	}
@@ -71,7 +80,7 @@ func Start(ctx context.Context, c multimetro.MetroClient, image, volUUID, authSt
 	if inst.ServiceGroup == nil || len(inst.ServiceGroup.Domains) == 0 {
 		if instUUID != "" {
 			log.G(ctx).Trace().Str("uuid", instUUID).Msg("deleting instance: no service group domain returned")
-			_, _ = c.DeleteInstanceByUUID(ctx, instUUID, platform.DeleteInstanceByUUIDRequestBody{})
+			_ = deleteInstanceByUUID(ctx, c, instUUID)
 		}
 		return "", "", fmt.Errorf("import instance has no service group domain")
 	}
@@ -80,7 +89,7 @@ func Start(ctx context.Context, c multimetro.MetroClient, image, volUUID, authSt
 	if fqdn == "" {
 		if instUUID != "" {
 			log.G(ctx).Trace().Str("uuid", instUUID).Msg("deleting instance: empty FQDN returned")
-			_, _ = c.DeleteInstanceByUUID(ctx, instUUID, platform.DeleteInstanceByUUIDRequestBody{})
+			_ = deleteInstanceByUUID(ctx, c, instUUID)
 		}
 		return "", "", fmt.Errorf("import instance has an empty FQDN")
 	}
@@ -93,7 +102,7 @@ func Start(ctx context.Context, c multimetro.MetroClient, image, volUUID, authSt
 // Terminate deletes the given instance, ignoring "not found" errors.
 func Terminate(ctx context.Context, c multimetro.MetroClient, instUUID string) error {
 	log.G(ctx).Trace().Str("uuid", instUUID).Msg("deleting volume data import instance")
-	_, err := c.DeleteInstanceByUUID(ctx, instUUID, platform.DeleteInstanceByUUIDRequestBody{})
+	err := deleteInstanceByUUID(ctx, c, instUUID)
 	if err != nil && !platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
 		return fmt.Errorf("deleting volume data import instance: %w", err)
 	}
@@ -102,11 +111,14 @@ func Terminate(ctx context.Context, c multimetro.MetroClient, instUUID string) e
 
 // Wait waits for the given instance to reach the stopped state.
 func Wait(ctx context.Context, c multimetro.MetroClient, instUUID string) error {
-	state := platform.InstanceStateStopped
-	_, err := c.WaitInstanceByUUID(ctx, instUUID, platform.WaitInstanceByUUIDRequestBody{
-		State:    state,
-		TimeoutS: new(stopTimeoutS),
-	})
+	req := platform.WaitInstanceByUUIDRequestBody{
+		State:    platform.InstanceStateStopped,
+		TimeoutS: new(int64(-1)),
+	}
+	_, err := timeouts.TryWithFallback(ctx, req,
+		func(ctx context.Context, req platform.WaitInstanceByUUIDRequestBody) (*platform.Response[platform.WaitInstancesResponseData], error) {
+			return c.WaitInstanceByUUID(ctx, instUUID, req)
+		})
 	if err != nil && !platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
 		return fmt.Errorf("waiting for import instance to stop: %w", err)
 	}


### PR DESCRIPTION
Set timeouts in:
- `start`
- `delete`
- `volimport`
- instance template creation
The rest already had timeouts.

Also remove some hacks while refactoring.

Depends on: https://github.com/unikraft-cloud/platform/pull/937

Closes: TOOL-1134