### PR TITLE
feat: Determine default metro from profile

### DIFF
--- a/cmd/unikraft/testdata/TestGolden/build/busybox/erofs
+++ b/cmd/unikraft/testdata/TestGolden/build/busybox/erofs
@@ -2,7 +2,6 @@ $ unikraft build . --output test/busybox-e2e:$UNIQ_IMAGE
 
 stderr:
 	│ found buildkit addr=<docker> version=vX.Y.Z
-	│ compression is not supported for EROFS, ignoring compress option
 
 $ unikraft run --name test-$UNIQ_INST --metro test --output quiet --image test/busybox-e2e:$UNIQ_IMAGE
 

--- a/cmd/unikraft/testdata/TestGolden/config/get
+++ b/cmd/unikraft/testdata/TestGolden/config/get
@@ -25,6 +25,7 @@ stdout:
 	      "default": {
 	        "control-plane": "",
 	        "insecure": false,
+	        "metro-default": "",
 	        "metros": [
 	          {
 	            "country": "xx",
@@ -51,6 +52,7 @@ stdout:
 	    default:
 	      control-plane: ""
 	      insecure: false
+	      metro-default: ""
 	      metros:
 	      - country: xx
 	        endpoint: https://api.unikraft.test

--- a/cmd/unikraft/testdata/TestGolden/config/help
+++ b/cmd/unikraft/testdata/TestGolden/config/help
@@ -17,7 +17,7 @@ stdout:
 	  profiles.*.organization, profiles.*.control-plane, profiles.*.insecure,
 	  profiles.*.metros, profiles.*.metros.*, profiles.*.metros.*.name,
 	  profiles.*.metros.*.endpoint, profiles.*.metros.*.country,
-	  profiles.*.metros.*.insecure
+	  profiles.*.metros.*.insecure, profiles.*.metro-default
 
 	Global flags:
 	  -h, --help
@@ -59,7 +59,7 @@ stdout:
 	  profiles.*.organization, profiles.*.control-plane, profiles.*.insecure,
 	  profiles.*.metros, profiles.*.metros.*, profiles.*.metros.*.name,
 	  profiles.*.metros.*.endpoint, profiles.*.metros.*.country,
-	  profiles.*.metros.*.insecure
+	  profiles.*.metros.*.insecure, profiles.*.metro-default
 
 	Flags:
 	  -w, --watch

--- a/internal/cmd/any.go
+++ b/internal/cmd/any.go
@@ -153,7 +153,7 @@ func (a AnyResource) Key() resource.Key {
 	}
 }
 
-func (a AnyResource) Fields() ([]resource.Field, error) {
+func (a AnyResource) Fields(ctx context.Context) ([]resource.Field, error) {
 	fields, err := resource.FieldsFromStruct(a)
 	if err != nil {
 		return nil, err
@@ -165,7 +165,7 @@ func (a AnyResource) Fields() ([]resource.Field, error) {
 		}
 	}
 	if underlying != nil {
-		underlyingFields, err := underlying.Fields()
+		underlyingFields, err := underlying.Fields(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cmd/certificates.go
+++ b/internal/cmd/certificates.go
@@ -102,7 +102,7 @@ func (c Certificate) Raw() any {
 	return c.Certificate
 }
 
-func (c Certificate) Fields() ([]resource.Field, error) {
+func (c Certificate) Fields(ctx context.Context) ([]resource.Field, error) {
 	result, err := resource.FieldsFromStruct(c)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/certificates.go
+++ b/internal/cmd/certificates.go
@@ -103,6 +103,7 @@ func (c Certificate) Raw() any {
 }
 
 func (c Certificate) Fields(ctx context.Context) ([]resource.Field, error) {
+	c.MetroName = defaultMetro(ctx, c.MetroName)
 	result, err := resource.FieldsFromStruct(c)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -41,7 +41,7 @@ func (c Config) Raw() any {
 	return c.Config
 }
 
-func (c Config) Fields() ([]resource.Field, error) {
+func (c Config) Fields(ctx context.Context) ([]resource.Field, error) {
 	return resource.FieldsFromStruct(c.Config)
 }
 

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -94,7 +94,7 @@ func (i Image) Raw() any {
 	return nil // NOTE: no platform API response associated
 }
 
-func (i Image) Fields() ([]resource.Field, error) {
+func (i Image) Fields(ctx context.Context) ([]resource.Field, error) {
 	return resource.FieldsFromStruct(i)
 }
 
@@ -271,7 +271,7 @@ func (i ImageEntry) Raw() any {
 	return i.Image
 }
 
-func (i ImageEntry) Fields() ([]resource.Field, error) {
+func (i ImageEntry) Fields(ctx context.Context) ([]resource.Field, error) {
 	result, err := resource.FieldsFromStruct(i)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/instance_templates.go
+++ b/internal/cmd/instance_templates.go
@@ -130,7 +130,7 @@ func (i InstanceTemplate) Raw() any {
 	return i.Instance
 }
 
-func (i InstanceTemplate) Fields() ([]resource.Field, error) {
+func (i InstanceTemplate) Fields(ctx context.Context) ([]resource.Field, error) {
 	result, err := resource.FieldsFromStruct(i)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -411,6 +411,7 @@ func (i Instance) Raw() any {
 }
 
 func (i Instance) Fields(ctx context.Context) ([]resource.Field, error) {
+	i.MetroName = defaultMetro(ctx, i.MetroName)
 	result, err := resource.FieldsFromStruct(i)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -410,7 +410,7 @@ func (i Instance) Raw() any {
 	return i.Instance
 }
 
-func (i Instance) Fields() ([]resource.Field, error) {
+func (i Instance) Fields(ctx context.Context) ([]resource.Field, error) {
 	result, err := resource.FieldsFromStruct(i)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/metros.go
+++ b/internal/cmd/metros.go
@@ -52,7 +52,7 @@ func (i Metro) Raw() any {
 	return i
 }
 
-func (i Metro) Fields() ([]resource.Field, error) {
+func (i Metro) Fields(ctx context.Context) ([]resource.Field, error) {
 	fields, err := resource.FieldsFromStruct(i)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/profile.go
+++ b/internal/cmd/profile.go
@@ -52,7 +52,7 @@ func (i Profile) Raw() any {
 	return i
 }
 
-func (i Profile) Fields() ([]resource.Field, error) {
+func (i Profile) Fields(ctx context.Context) ([]resource.Field, error) {
 	return resource.FieldsFromStruct(i)
 }
 

--- a/internal/cmd/services.go
+++ b/internal/cmd/services.go
@@ -256,6 +256,7 @@ func (s ServiceGroup) Raw() any {
 }
 
 func (s ServiceGroup) Fields(ctx context.Context) ([]resource.Field, error) {
+	s.MetroName = defaultMetro(ctx, s.MetroName)
 	result, err := resource.FieldsFromStruct(s)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/services.go
+++ b/internal/cmd/services.go
@@ -255,7 +255,7 @@ func (s ServiceGroup) Raw() any {
 	return s.ServiceGroup
 }
 
-func (s ServiceGroup) Fields() ([]resource.Field, error) {
+func (s ServiceGroup) Fields(ctx context.Context) ([]resource.Field, error) {
 	result, err := resource.FieldsFromStruct(s)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/util.go
+++ b/internal/cmd/util.go
@@ -10,8 +10,22 @@ import (
 	"fmt"
 	"maps"
 
+	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/resource"
 )
+
+// defaultMetro returns the metro if non-empty, otherwise falls back to the
+// default metro from the current profile in the context.
+func defaultMetro(ctx context.Context, metro string) string {
+	if metro != "" {
+		return metro
+	}
+	profile, err := config.G(ctx).CurrentProfile()
+	if err != nil {
+		return ""
+	}
+	return profile.GetDefaultMetro()
+}
 
 func getFromListable(ctx context.Context, listable resource.ListableResource, keys []string) ([]resource.Resource, error) {
 	all, err := listable.List(ctx)

--- a/internal/cmd/volume_templates.go
+++ b/internal/cmd/volume_templates.go
@@ -113,7 +113,7 @@ func (v VolumeTemplate) Raw() any {
 	return v.Volume
 }
 
-func (v VolumeTemplate) Fields() ([]resource.Field, error) {
+func (v VolumeTemplate) Fields(ctx context.Context) ([]resource.Field, error) {
 	result, err := resource.FieldsFromStruct(v)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -272,7 +272,7 @@ func (i Volume) Raw() any {
 	return i.Volume
 }
 
-func (i Volume) Fields() ([]resource.Field, error) {
+func (i Volume) Fields(ctx context.Context) ([]resource.Field, error) {
 	result, err := resource.FieldsFromStruct(i)
 	if err != nil {
 		return nil, err

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -273,6 +273,7 @@ func (i Volume) Raw() any {
 }
 
 func (i Volume) Fields(ctx context.Context) ([]resource.Field, error) {
+	i.MetroName = defaultMetro(ctx, i.MetroName)
 	result, err := resource.FieldsFromStruct(i)
 	if err != nil {
 		return nil, err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -142,3 +142,66 @@ profiles:
 	assert.NotContains(t, content, "metros")
 	assert.Contains(t, content, "type: legacy")
 }
+
+func TestProfile_GetDefaultMetro(t *testing.T) {
+	tests := []struct {
+		name     string
+		profile  Profile
+		expected string
+	}{
+		{
+			name: "explicit default metro",
+			profile: Profile{
+				MetroDefault: "fra",
+				Metros: []Metro{
+					{Name: "lhr"},
+					{Name: "fra"},
+				},
+			},
+			expected: "fra",
+		},
+		{
+			name: "single configured metro",
+			profile: Profile{
+				Metros: []Metro{
+					{Name: "lhr"},
+				},
+			},
+			expected: "lhr",
+		},
+		{
+			name: "multiple metros without explicit default",
+			profile: Profile{
+				Metros: []Metro{
+					{Name: "lhr"},
+					{Name: "fra"},
+				},
+			},
+			expected: "",
+		},
+		{
+			name:     "no metros",
+			profile:  Profile{},
+			expected: "",
+		},
+		{
+			name: "explicit default takes precedence over single metro",
+			profile: Profile{
+				MetroDefault: "fra",
+				Metros: []Metro{
+					{Name: "lhr"},
+				},
+			},
+			expected: "fra",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.profile.GetDefaultMetro()
+			if got != tt.expected {
+				t.Errorf("GetDefaultMetro() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -74,6 +74,18 @@ type Profile struct {
 	Insecure bool `json:"controlplane_insecure,omitempty" field:",long"`
 	// Metros is a static list of metros.
 	Metros []Metro `json:"metros,omitempty" field:",long,embed"`
+	// MetroDefault is the default metro to use when creating resources.
+	MetroDefault string `json:"metro_default,omitempty"`
+}
+
+func (p Profile) GetDefaultMetro() string {
+	if p.MetroDefault != "" {
+		return p.MetroDefault
+	}
+	if len(p.Metros) == 1 {
+		return p.Metros[0].Name
+	}
+	return ""
 }
 
 func (p *Profile) populate() {

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -842,13 +842,13 @@ func (cmd *ResourceCreateCmd[R]) RunResources(ctx context.Context, stdio config.
 
 	patchedFields := patch.FilterCreateFields(patched)
 
-	if cmd.DryRun {
-		return nil, PrintPatches(stdio.Stdout, patchedFields, true)
-	}
-
-	// Validate required fields right before applying
+	// Validate required fields before printing/applying
 	if err := patch.ValidateRequired(fields, patched, true); err != nil {
 		return nil, err
+	}
+
+	if cmd.DryRun {
+		return nil, PrintPatches(stdio.Stdout, patchedFields, true)
 	}
 
 	resources, opErr := r.Create(ctx, patchedFields)

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -80,7 +80,7 @@ type CreatableResourceCmd[R resource.CreatableResource] struct {
 func (cmd ResourceCmd[R]) HelpSections() []kingkong.HelpSection {
 	var r R
 
-	fields, err := r.Fields()
+	fields, err := r.Fields(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -397,7 +397,7 @@ func filterResources(ctx context.Context, resources []resource.Resource, filter 
 	}
 
 	for _, res := range resolved {
-		fields, _ := res.Fields()
+		fields, _ := res.Fields(ctx)
 		if filter.Match(filters.AdapterFunc(func(key []string) (string, bool) {
 			matched := resource.GetFieldByPath(fields, key)
 			if matched == nil {
@@ -695,7 +695,7 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, stdio config.Stdio, sand
 		}
 	}
 
-	fields, err := res.Fields()
+	fields, err := res.Fields(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get fields: %w", err)
 	}
@@ -806,7 +806,7 @@ func (cmd *ResourceCreateCmd[R]) RunResources(ctx context.Context, stdio config.
 			fieldsResource = typed.WithType(values[0])
 		}
 	}
-	fields, err := fieldsResource.Fields()
+	fields, err := fieldsResource.Fields(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get fields: %w", err)
 	}

--- a/internal/resource/cmd/cmd_test.go
+++ b/internal/resource/cmd/cmd_test.go
@@ -703,7 +703,7 @@ func TestGet(t *testing.T) {
 	assert.Equal(t, 42, test.Settings.Foo)
 	assert.Equal(t, "hello", test.Settings.Bar)
 
-	fields, err := test.Fields()
+	fields, err := test.Fields(ctx)
 	require.NoError(t, err)
 	assert.NotEmpty(t, fields)
 
@@ -955,7 +955,7 @@ func TestCreate(t *testing.T) {
 	ctx := resourcet.WithTestEnv(context.Background(), env)
 
 	empty := env.NewResource()
-	templateFields, err := empty.Fields()
+	templateFields, err := empty.Fields(ctx)
 	require.NoError(t, err)
 
 	for key, field := range resource.IterFields(templateFields) {
@@ -1228,7 +1228,7 @@ func TestEdit(t *testing.T) {
 	require.Len(t, resources, 1)
 
 	target := resources[0]
-	templateFields, err := target.Fields()
+	templateFields, err := target.Fields(ctx)
 	require.NoError(t, err)
 
 	for key, field := range resource.IterFields(templateFields) {

--- a/internal/resource/cmd/printers.go
+++ b/internal/resource/cmd/printers.go
@@ -154,7 +154,7 @@ func printKV(ctx context.Context, out io.Writer, specs []string, resources ...re
 	eg := joinerrgroup.Group{}
 	for i, res := range resources {
 		eg.Go(func() error {
-			fields, err := res.Fields()
+			fields, err := res.Fields(ctx)
 			if err != nil {
 				return err
 			}
@@ -262,7 +262,7 @@ func printKVValue(out io.Writer, v any, indent int) error {
 }
 
 func printTable(ctx context.Context, out io.Writer, fieldSpecs []string, base resource.Resource, resources ...resource.Resource) error {
-	headers, err := base.Fields()
+	headers, err := base.Fields(ctx)
 	if err != nil {
 		return err
 	}
@@ -316,7 +316,7 @@ func printTable(ctx context.Context, out io.Writer, fieldSpecs []string, base re
 	}
 
 	for _, res := range resolved {
-		fields, err := res.Fields()
+		fields, err := res.Fields(ctx)
 		if err != nil {
 			return err
 		}
@@ -413,7 +413,7 @@ func printQuiet(ctx context.Context, out io.Writer, specs []string, resources ..
 	eg := joinerrgroup.Group{}
 	for i, res := range resources {
 		eg.Go(func() error {
-			fields, err := res.Fields()
+			fields, err := res.Fields(ctx)
 			if err != nil {
 				return err
 			}
@@ -461,7 +461,7 @@ func printJSON(ctx context.Context, out io.Writer, resources ...resource.Resourc
 
 	input := make([]any, len(resolved))
 	for i, res := range resolved {
-		fields, err := res.Fields()
+		fields, err := res.Fields(ctx)
 		if err != nil {
 			return err
 		}
@@ -483,7 +483,7 @@ func printYAML(ctx context.Context, out io.Writer, resources ...resource.Resourc
 
 	input := make([]any, len(resolved))
 	for i, res := range resolved {
-		fields, err := res.Fields()
+		fields, err := res.Fields(ctx)
 		if err != nil {
 			return err
 		}
@@ -524,7 +524,7 @@ func printTemplate(ctx context.Context, out io.Writer, tmplStr string, resources
 	}
 
 	for _, res := range resolved {
-		fields, err := res.Fields()
+		fields, err := res.Fields(ctx)
 		if err != nil {
 			return err
 		}
@@ -552,7 +552,7 @@ func printDebug(ctx context.Context, out io.Writer, resources ...resource.Resour
 	}
 
 	for _, res := range resolved {
-		fields, err := res.Fields()
+		fields, err := res.Fields(ctx)
 		if err != nil {
 			return err
 		}

--- a/internal/resource/cmd/resolve.go
+++ b/internal/resource/cmd/resolve.go
@@ -17,7 +17,7 @@ type resolvedResource struct {
 	fields []resource.Field
 }
 
-func (r resolvedResource) Fields() ([]resource.Field, error) {
+func (r resolvedResource) Fields(ctx context.Context) ([]resource.Field, error) {
 	return resource.CloneFields(r.fields), nil
 }
 
@@ -45,7 +45,7 @@ func resolveResources(ctx context.Context, resources []resource.Resource, paths 
 }
 
 func resolveResource(ctx context.Context, res resource.Resource, paths []resource.FieldPath) (resource.Resource, error) {
-	fields, err := res.Fields()
+	fields, err := res.Fields(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func resolveAllResources(ctx context.Context, resources []resource.Resource) ([]
 }
 
 func resolveAllResource(ctx context.Context, res resource.Resource) (resource.Resource, error) {
-	fields, err := res.Fields()
+	fields, err := res.Fields(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/resource/cmd/sort.go
+++ b/internal/resource/cmd/sort.go
@@ -74,7 +74,7 @@ func sortResources(ctx context.Context, resources []resource.Resource, specs []S
 	}
 
 	// Validate all sort paths up-front against the resource's field schema.
-	schemaFields, err := resources[0].Fields()
+	schemaFields, err := resources[0].Fields(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get fields for validation: %w", err)
 	}
@@ -107,7 +107,7 @@ func sortResources(ctx context.Context, resources []resource.Resource, specs []S
 		items[i].res = res
 		items[i].values = make([]any, len(specs))
 
-		fields, err := res.Fields()
+		fields, err := res.Fields(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get fields for resource %s: %w", res.Key(), err)
 		}

--- a/internal/resource/patch/patch.go
+++ b/internal/resource/patch/patch.go
@@ -82,6 +82,8 @@ func PatchedFields(fields []resource.Field, spec PatchSpec) ([]resource.Field, e
 			} else {
 				setForbiddenFields[keyStr] = struct{}{}
 			}
+		} else if spec.Create && original.Set != nil && !value.IsZero(original.Set) {
+			*patch = &resource.Patch{Set: original.Set}
 		}
 		if vs, ok := spec.Add[keyStr]; ok {
 			if original.Add != nil {
@@ -93,6 +95,8 @@ func PatchedFields(fields []resource.Field, spec PatchSpec) ([]resource.Field, e
 			} else {
 				addForbiddenFields[keyStr] = struct{}{}
 			}
+		} else if spec.Create && original.Add != nil && !value.IsZero(original.Add) {
+			*patch = &resource.Patch{Add: original.Add}
 		}
 		if vs, ok := spec.Del[keyStr]; ok {
 			if original.Del != nil {
@@ -104,6 +108,8 @@ func PatchedFields(fields []resource.Field, spec PatchSpec) ([]resource.Field, e
 			} else {
 				delForbiddenFields[keyStr] = struct{}{}
 			}
+		} else if spec.Create && original.Del != nil && !value.IsZero(original.Del) {
+			*patch = &resource.Patch{Del: original.Del}
 		}
 	}
 

--- a/internal/resource/patch/visual.go
+++ b/internal/resource/patch/visual.go
@@ -227,7 +227,7 @@ func loadFieldPatches(fields []resource.Field, data []byte, create bool) ([]reso
 		deleteNestedValue(obj, key)
 
 		if !found {
-			// Field not in YAML - clear the patch
+			// Field not in YAML
 			patch.Set = nil
 			continue
 		}
@@ -238,12 +238,15 @@ func loadFieldPatches(fields []resource.Field, data []byte, create bool) ([]reso
 			return nil, fmt.Errorf("failed to convert value for field %s: %w", key, err)
 		}
 
-		if originalValue := field.Value; originalValue != nil {
-			convertedOriginal, err := convertValue(originalValue, reflect.TypeOf(patch.Set))
-			if err == nil && valuesEqual(convertedOriginal, convertedValue) {
-				// Value is same as original - no patch needed
-				patch.Set = nil
-				continue
+		// In edit mode, skip fields that haven't changed from the original value.
+		// In create mode, there is no prior state, so we always keep the value.
+		if !create {
+			if originalValue := field.Value; originalValue != nil {
+				convertedOriginal, err := convertValue(originalValue, reflect.TypeOf(patch.Set))
+				if err == nil && valuesEqual(convertedOriginal, convertedValue) {
+					patch.Set = nil
+					continue
+				}
 			}
 		}
 

--- a/internal/resource/patch/visual_test.go
+++ b/internal/resource/patch/visual_test.go
@@ -39,7 +39,7 @@ func (m mockResource) Key() resource.Key {
 	return mockKey(m.name)
 }
 
-func (m mockResource) Fields() ([]resource.Field, error) {
+func (m mockResource) Fields(ctx context.Context) ([]resource.Field, error) {
 	return nil, nil
 }
 
@@ -371,7 +371,7 @@ func TestEdit_WithTestResource(t *testing.T) {
 	require.Len(t, resources, 1)
 
 	res := resources[0].(resourcet.TestResource)
-	fields, err := res.Fields()
+	fields, err := res.Fields(ctx)
 	require.NoError(t, err)
 
 	// Editor that changes settings
@@ -419,7 +419,7 @@ settings:
 func TestCreate_WithTestResource(t *testing.T) {
 	// Get template fields from empty resource
 	res := resourcet.TestResource{}
-	fields, err := res.Fields()
+	fields, err := res.Fields(context.Background())
 	require.NoError(t, err)
 
 	// Editor that sets creation values

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -27,7 +27,7 @@ type Key interface {
 type Resource interface {
 	Type() Type
 	Key() Key
-	Fields() ([]Field, error)
+	Fields(ctx context.Context) ([]Field, error)
 	Raw() any
 }
 

--- a/internal/resource/sandbox.go
+++ b/internal/resource/sandbox.go
@@ -180,7 +180,7 @@ func (s *Sandbox) add(ctx context.Context, r Resource, visited map[string]struct
 	visited[visitKey] = struct{}{}
 	s.Keys[typeName][key] = struct{}{}
 
-	fields, err := r.Fields()
+	fields, err := r.Fields(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get fields for resource %s: %w", r.Key(), err)
 	}

--- a/internal/resource/testing/resource.go
+++ b/internal/resource/testing/resource.go
@@ -118,7 +118,7 @@ func (t TestResource) Raw() any {
 	return t
 }
 
-func (t TestResource) Fields() ([]resource.Field, error) {
+func (t TestResource) Fields(ctx context.Context) ([]resource.Field, error) {
 	// Note: ValueCallback receives context and can access TestEnv from there
 	return []resource.Field{
 		{

--- a/internal/resource/tui/panel_detail.go
+++ b/internal/resource/tui/panel_detail.go
@@ -158,7 +158,7 @@ func (p *detailPanel) View() tea.View {
 }
 
 func (p *detailPanel) renderResource(res resource.Resource) {
-	fields, err := res.Fields()
+	fields, err := res.Fields(p.ctx)
 	if err != nil {
 		p.err = err
 		p.table.SetRows(nil)

--- a/internal/resource/tui/panel_list.go
+++ b/internal/resource/tui/panel_list.go
@@ -153,7 +153,7 @@ func (p *listPanel) applyResources(resources []resource.Resource) {
 		p.table.SetRows(nil)
 		return
 	}
-	fields, err := p.desc.List.Fields()
+	fields, err := p.desc.List.Fields(p.ctx)
 	if err != nil {
 		p.err = err
 		p.table.SetRows(nil)
@@ -240,7 +240,7 @@ func (p *listPanel) layout() {
 }
 
 func (p *listPanel) renderField(res resource.Resource, path resource.FieldPath) string {
-	fields, err := res.Fields()
+	fields, err := res.Fields(p.ctx)
 	if err != nil {
 		return ""
 	}

--- a/internal/resource/value/compare.go
+++ b/internal/resource/value/compare.go
@@ -12,6 +12,14 @@ import (
 	"time"
 )
 
+// IsZero reports whether v is a zero value for its type.
+func IsZero(v any) bool {
+	if v == nil {
+		return true
+	}
+	return reflect.ValueOf(v).IsZero()
+}
+
 // Compare compares two values in a type-aware manner.
 //
 // It returns -1 if a < b, 0 if a == b, and 1 if a > b.

--- a/tools/gendocs/man.go
+++ b/tools/gendocs/man.go
@@ -282,7 +282,7 @@ func manPrintFields(buf *bytes.Buffer, node *kong.Node) error {
 	}
 
 	src := target.Underlying()
-	fields, err := src.Fields()
+	fields, err := src.Fields(context.Background())
 	if err != nil {
 		return fmt.Errorf("could not get fields for %s: %w", NodePath(node), err)
 	}

--- a/tools/gendocs/mdx.go
+++ b/tools/gendocs/mdx.go
@@ -104,7 +104,7 @@ func generateMarkdown(ctx context.Context, node *kong.Node, dir string) error {
 
 	if target, ok := node.Target.Interface().(cmd.ResourceCmdInterface); ok {
 		src := target.Underlying()
-		fields, err := src.Fields()
+		fields, err := src.Fields(ctx)
 		if err != nil {
 			return fmt.Errorf("could not get fields for %s: %w", name, err)
 		}


### PR DESCRIPTION
So it needs to be manually specified *less* on create.

The best mechanism for doing with was allowing `context.Context` on the `Fields` calls.