### PR TITLE
fix: Use bulk methods instead of per-uuid methods

### DIFF
--- a/internal/cmd/certificates.go
+++ b/internal/cmd/certificates.go
@@ -205,13 +205,20 @@ func (Certificate) Delete(ctx context.Context, targets []resource.Resource) erro
 	}
 	return group.DoRefs(ctx, g, keys.Refs(), func(ctx context.Context, c multimetro.MetroClient, refs group.Refs) (group.Refs, error) {
 		log.G(ctx).Trace().Msg("deleting certificates")
+		resp, err := c.DeleteCertificates(ctx, refs.NameOrUUIDs())
+		if err != nil && !platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
+			return nil, err
+		}
 		var deleted []group.Ref
-		for _, key := range refs {
-			_, err := c.DeleteCertificateByUUID(ctx, key.UUID)
-			if err != nil && !platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
-				return nil, err
+		for _, certificate := range resp.Data.Certificates {
+			if certificate.Status == nil || *certificate.Status != platform.ResponseStatusSUCCESS {
+				continue
 			}
-			deleted = append(deleted, key)
+			deleted = append(deleted, group.Ref{
+				Metro: c.Metro.Name,
+				Name:  ptr.ZeroIfNil(certificate.Name),
+				UUID:  ptr.ZeroIfNil(certificate.Uuid),
+			})
 		}
 		return deleted, nil
 	})

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -64,7 +64,7 @@ func (c *VolumesCloneCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *
 	if err := c.Apply(&spec); err != nil {
 		return err
 	}
-	req := platform.CloneVolumeByUUIDRequestBody{}
+	req := platform.CloneVolumesRequest{}
 	var unknownFields []string
 	for key, values := range spec.Set {
 		switch key {
@@ -122,9 +122,11 @@ func (c *VolumesCloneCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *
 	if err != nil {
 		return err
 	}
+	req.Uuid = ptr.NilIfZero(volume.UUID)
+	req.Name = ptr.NilIfZero(volume.Name)
 	keys, opErr := group.CollectMetro(ctx, g, volume.Metro.Name, func(ctx context.Context, client multimetro.MetroClient) (multimetro.Keys, error) {
 		log.G(ctx).Trace().Msg("cloning volume")
-		resp, err := client.CloneVolumeByUUID(ctx, volume.UUID, req)
+		resp, err := client.CloneVolumes(ctx, req)
 		if err != nil {
 			return nil, err
 		}
@@ -363,13 +365,22 @@ func (Volume) Delete(ctx context.Context, targets []resource.Resource) error {
 	}
 	return group.DoRefs(ctx, g, keys.Refs(), func(ctx context.Context, c multimetro.MetroClient, refs group.Refs) (group.Refs, error) {
 		log.G(ctx).Trace().Msg("deleting volumes")
-		for _, key := range refs {
-			_, err := c.DeleteVolumeByUUID(ctx, key.UUID)
-			if err != nil && !platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
-				return nil, err
-			}
+		resp, err := c.DeleteVolumes(ctx, refs.NameOrUUIDs())
+		if err != nil && !platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
+			return nil, err
 		}
-		return refs, nil
+		var deleted []group.Ref
+		for _, volume := range resp.Data.Volumes {
+			if volume.Status == nil || *volume.Status != platform.ResponseStatusSUCCESS {
+				continue
+			}
+			deleted = append(deleted, group.Ref{
+				Metro: c.Metro.Name,
+				Name:  ptr.ZeroIfNil(volume.Name),
+				UUID:  ptr.ZeroIfNil(volume.Uuid),
+			})
+		}
+		return deleted, nil
 	})
 }
 


### PR DESCRIPTION
Since this doesn't always work when using keys - since the key might not contain it, it's what the user directly specified.

This was a regression (I think) introduced in https://github.com/unikraft/cli/pull/191.