### PR TITLE
feat: Add volume filesystem field

### DIFF
--- a/cmd/unikraft/testdata/TestGolden/build/busybox
+++ b/cmd/unikraft/testdata/TestGolden/build/busybox
@@ -42,7 +42,7 @@ stdout:
 	test-<INST> │ == BEGIN status ==
 	test-<INST> │ UNIKRAFT_E2E_OK
 	test-<INST> │ == END status ==
-	test-<INST> │ Application exit with 0x0
+	test-<INST> │ Application exited with 0x0 (exit code: 0)
 	test-<INST> │ [    0.000000] reboot: Restarting system
 
 $ unikraft instance delete test-$UNIQ_INST

--- a/cmd/unikraft/testdata/TestGolden/resources/volume-flow
+++ b/cmd/unikraft/testdata/TestGolden/resources/volume-flow
@@ -1,32 +1,34 @@
 $ unikraft resource create --set type=volume --set name=test-$UNIQ_VOLUME --set size=10 --set metro=test
 
 stdout:
-	type:       volume
-	key:        volume:test/test-<VOLUME>
-	metro:      test
-	name:       test-<VOLUME>
-	uuid:       12345678-1234-1234-1234-123456789abc
-	state:      available
-	size:       10MiB
-	filesystem: virtiofs
-	persistent: true
+	type:         volume
+	key:          volume:test/test-<VOLUME>
+	metro:        test
+	name:         test-<VOLUME>
+	uuid:         12345678-1234-1234-1234-123456789abc
+	state:        available
+	size:         10MiB
+	filesystem:   virtiofs
+	quota-policy: static
+	persistent:   true
 	timestamps:
-	  created:  RELATIVE_TIME
+	  created:    RELATIVE_TIME
 
 $ unikraft resource get volume:test/test-$UNIQ_VOLUME
 
 stdout:
-	type:       volume
-	key:        volume:test/test-<VOLUME>
-	metro:      test
-	name:       test-<VOLUME>
-	uuid:       12345678-1234-1234-1234-123456789abc
-	state:      available
-	size:       10MiB
-	filesystem: virtiofs
-	persistent: true
+	type:         volume
+	key:          volume:test/test-<VOLUME>
+	metro:        test
+	name:         test-<VOLUME>
+	uuid:         12345678-1234-1234-1234-123456789abc
+	state:        available
+	size:         10MiB
+	filesystem:   virtiofs
+	quota-policy: static
+	persistent:   true
 	timestamps:
-	  created:  RELATIVE_TIME
+	  created:    RELATIVE_TIME
 
 $ unikraft resource list
 
@@ -37,46 +39,49 @@ stdout:
 $ unikraft resource edit volume:test/test-$UNIQ_VOLUME --set size=20
 
 stdout:
-	  type:       volume
-	  key:        volume:test/test-<VOLUME>
-	  metro:      test
-	  name:       test-<VOLUME>
-	  uuid:       12345678-1234-1234-1234-123456789abc
-	  state:      available
-	- size:       10MiB
-	+ size:       20MiB
-	  filesystem: virtiofs
-	  persistent: true
+	  type:         volume
+	  key:          volume:test/test-<VOLUME>
+	  metro:        test
+	  name:         test-<VOLUME>
+	  uuid:         12345678-1234-1234-1234-123456789abc
+	  state:        available
+	- size:         10MiB
+	+ size:         20MiB
+	  filesystem:   virtiofs
+	  quota-policy: static
+	  persistent:   true
 	  timestamps:
-	    created:  RELATIVE_TIME
+	    created:    RELATIVE_TIME
 
 $ unikraft resource get volume:test/test-$UNIQ_VOLUME
 
 stdout:
-	type:       volume
-	key:        volume:test/test-<VOLUME>
-	metro:      test
-	name:       test-<VOLUME>
-	uuid:       12345678-1234-1234-1234-123456789abc
-	state:      available
-	size:       20MiB
-	filesystem: virtiofs
-	persistent: true
+	type:         volume
+	key:          volume:test/test-<VOLUME>
+	metro:        test
+	name:         test-<VOLUME>
+	uuid:         12345678-1234-1234-1234-123456789abc
+	state:        available
+	size:         20MiB
+	filesystem:   virtiofs
+	quota-policy: static
+	persistent:   true
 	timestamps:
-	  created:  RELATIVE_TIME
+	  created:    RELATIVE_TIME
 
 $ unikraft volume get test-$UNIQ_VOLUME
 
 stdout:
-	metro:      test
-	name:       test-<VOLUME>
-	uuid:       12345678-1234-1234-1234-123456789abc
-	state:      available
-	size:       20MiB
-	filesystem: virtiofs
-	persistent: true
+	metro:        test
+	name:         test-<VOLUME>
+	uuid:         12345678-1234-1234-1234-123456789abc
+	state:        available
+	size:         20MiB
+	filesystem:   virtiofs
+	quota-policy: static
+	persistent:   true
 	timestamps:
-	  created:  RELATIVE_TIME
+	  created:    RELATIVE_TIME
 
 $ unikraft resource delete --all --force
 

--- a/cmd/unikraft/testdata/TestGolden/resources/volume-flow
+++ b/cmd/unikraft/testdata/TestGolden/resources/volume-flow
@@ -8,6 +8,7 @@ stdout:
 	uuid:       12345678-1234-1234-1234-123456789abc
 	state:      available
 	size:       10MiB
+	filesystem: virtiofs
 	persistent: true
 	timestamps:
 	  created:  RELATIVE_TIME
@@ -22,6 +23,7 @@ stdout:
 	uuid:       12345678-1234-1234-1234-123456789abc
 	state:      available
 	size:       10MiB
+	filesystem: virtiofs
 	persistent: true
 	timestamps:
 	  created:  RELATIVE_TIME
@@ -43,6 +45,7 @@ stdout:
 	  state:      available
 	- size:       10MiB
 	+ size:       20MiB
+	  filesystem: virtiofs
 	  persistent: true
 	  timestamps:
 	    created:  RELATIVE_TIME
@@ -57,6 +60,7 @@ stdout:
 	uuid:       12345678-1234-1234-1234-123456789abc
 	state:      available
 	size:       20MiB
+	filesystem: virtiofs
 	persistent: true
 	timestamps:
 	  created:  RELATIVE_TIME
@@ -69,6 +73,7 @@ stdout:
 	uuid:       12345678-1234-1234-1234-123456789abc
 	state:      available
 	size:       20MiB
+	filesystem: virtiofs
 	persistent: true
 	timestamps:
 	  created:  RELATIVE_TIME

--- a/cmd/unikraft/testdata/TestGolden/volumes/clone
+++ b/cmd/unikraft/testdata/TestGolden/volumes/clone
@@ -16,6 +16,7 @@ stdout:
 	uuid:       12345678-1234-1234-1234-123456789abc
 	state:      available
 	size:       10MiB
+	filesystem: virtiofs
 	persistent: true
 	timestamps:
 	  created:  RELATIVE_TIME
@@ -25,6 +26,7 @@ stdout:
 	uuid:       12345678-1234-1234-1234-123456789abc
 	state:      available
 	size:       10MiB
+	filesystem: virtiofs
 	persistent: true
 	timestamps:
 	  created:  RELATIVE_TIME

--- a/cmd/unikraft/testdata/TestGolden/volumes/clone
+++ b/cmd/unikraft/testdata/TestGolden/volumes/clone
@@ -11,25 +11,27 @@ stdout:
 $ unikraft volume inspect test-$UNIQ_VOLUME test-$UNIQ_VOLUME_CLONE
 
 stdout:
-	metro:      test
-	name:       test-<VOLUME>
-	uuid:       12345678-1234-1234-1234-123456789abc
-	state:      available
-	size:       10MiB
-	filesystem: virtiofs
-	persistent: true
+	metro:        test
+	name:         test-<VOLUME>
+	uuid:         12345678-1234-1234-1234-123456789abc
+	state:        available
+	size:         10MiB
+	filesystem:   virtiofs
+	quota-policy: static
+	persistent:   true
 	timestamps:
-	  created:  RELATIVE_TIME
+	  created:    RELATIVE_TIME
 
-	metro:      test
-	name:       test-<VOLUME_CLONE>
-	uuid:       12345678-1234-1234-1234-123456789abc
-	state:      available
-	size:       10MiB
-	filesystem: virtiofs
-	persistent: true
+	metro:        test
+	name:         test-<VOLUME_CLONE>
+	uuid:         12345678-1234-1234-1234-123456789abc
+	state:        available
+	size:         10MiB
+	filesystem:   virtiofs
+	quota-policy: static
+	persistent:   true
 	timestamps:
-	  created:  RELATIVE_TIME
+	  created:    RELATIVE_TIME
 
 $ unikraft volume delete test-$UNIQ_VOLUME test-$UNIQ_VOLUME_CLONE
 

--- a/cmd/unikraft/testdata/TestGolden/volumes/create
+++ b/cmd/unikraft/testdata/TestGolden/volumes/create
@@ -6,15 +6,16 @@ stdout:
 $ unikraft volume create --set name=test-$UNIQ_VOLUME --set size=10 --set metro=test
 
 stdout:
-	metro:      test
-	name:       test-<VOLUME>
-	uuid:       12345678-1234-1234-1234-123456789abc
-	state:      available
-	size:       10MiB
-	filesystem: virtiofs
-	persistent: true
+	metro:        test
+	name:         test-<VOLUME>
+	uuid:         12345678-1234-1234-1234-123456789abc
+	state:        available
+	size:         10MiB
+	filesystem:   virtiofs
+	quota-policy: static
+	persistent:   true
 	timestamps:
-	  created:  RELATIVE_TIME
+	  created:    RELATIVE_TIME
 
 $ unikraft volume list
 
@@ -25,15 +26,16 @@ stdout:
 $ unikraft volume inspect test-$UNIQ_VOLUME
 
 stdout:
-	metro:      test
-	name:       test-<VOLUME>
-	uuid:       12345678-1234-1234-1234-123456789abc
-	state:      available
-	size:       10MiB
-	filesystem: virtiofs
-	persistent: true
+	metro:        test
+	name:         test-<VOLUME>
+	uuid:         12345678-1234-1234-1234-123456789abc
+	state:        available
+	size:         10MiB
+	filesystem:   virtiofs
+	quota-policy: static
+	persistent:   true
 	timestamps:
-	  created:  RELATIVE_TIME
+	  created:    RELATIVE_TIME
 
 $ unikraft volume delete test-$UNIQ_VOLUME
 

--- a/cmd/unikraft/testdata/TestGolden/volumes/create
+++ b/cmd/unikraft/testdata/TestGolden/volumes/create
@@ -11,6 +11,7 @@ stdout:
 	uuid:       12345678-1234-1234-1234-123456789abc
 	state:      available
 	size:       10MiB
+	filesystem: virtiofs
 	persistent: true
 	timestamps:
 	  created:  RELATIVE_TIME
@@ -29,6 +30,7 @@ stdout:
 	uuid:       12345678-1234-1234-1234-123456789abc
 	state:      available
 	size:       10MiB
+	filesystem: virtiofs
 	persistent: true
 	timestamps:
 	  created:  RELATIVE_TIME

--- a/cmd/unikraft/testdata/TestGolden/volumes/edit
+++ b/cmd/unikraft/testdata/TestGolden/volumes/edit
@@ -11,15 +11,16 @@ stdout:
 $ unikraft volume inspect test-$UNIQ_VOLUME
 
 stdout:
-	metro:      test
-	name:       test-<VOLUME>
-	uuid:       12345678-1234-1234-1234-123456789abc
-	state:      available
-	size:       20MiB
-	filesystem: virtiofs
-	persistent: true
+	metro:        test
+	name:         test-<VOLUME>
+	uuid:         12345678-1234-1234-1234-123456789abc
+	state:        available
+	size:         20MiB
+	filesystem:   virtiofs
+	quota-policy: static
+	persistent:   true
 	timestamps:
-	  created:  RELATIVE_TIME
+	  created:    RELATIVE_TIME
 
 $ unikraft volume delete test-$UNIQ_VOLUME
 

--- a/cmd/unikraft/testdata/TestGolden/volumes/edit
+++ b/cmd/unikraft/testdata/TestGolden/volumes/edit
@@ -16,6 +16,7 @@ stdout:
 	uuid:       12345678-1234-1234-1234-123456789abc
 	state:      available
 	size:       20MiB
+	filesystem: virtiofs
 	persistent: true
 	timestamps:
 	  created:  RELATIVE_TIME

--- a/cmd/unikraft/testdata/TestGolden/volumes/help
+++ b/cmd/unikraft/testdata/TestGolden/volumes/help
@@ -30,6 +30,7 @@ stdout:
 	  state
 	  size
 	  filesystem
+	  quota-policy
 	  persistent
 	  timestamps, timestamps.created
 	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
@@ -77,6 +78,7 @@ stdout:
 	  state
 	  size
 	  filesystem
+	  quota-policy
 	  persistent
 	  timestamps, timestamps.created
 	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
@@ -132,6 +134,7 @@ stdout:
 	  state
 	  size
 	  filesystem
+	  quota-policy
 	  persistent
 	  timestamps, timestamps.created
 	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
@@ -187,6 +190,7 @@ stdout:
 	  state
 	  size
 	  filesystem
+	  quota-policy
 	  persistent
 	  timestamps, timestamps.created
 	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
@@ -247,6 +251,7 @@ stdout:
 	  state
 	  size
 	  filesystem
+	  quota-policy
 	  persistent
 	  timestamps, timestamps.created
 	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
@@ -298,6 +303,9 @@ stdout:
 	      --filesystem=<filesystem>
 	          Volume filesystem.
 	          [example: ext4]
+	      --quota-policy=<quota-policy>
+	          Volume quota policy.
+	          [examples: static, dynamic]
 
 $ unikraft volume clone --help
 
@@ -371,6 +379,7 @@ stdout:
 	  state
 	  size
 	  filesystem
+	  quota-policy
 	  persistent
 	  timestamps, timestamps.created
 	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
@@ -418,6 +427,9 @@ stdout:
 	      --size=<size>
 	          Volume size.
 	          [examples: 20GiB, 100MiB]
+	      --quota-policy=<quota-policy>
+	          Volume quota policy.
+	          [examples: static, dynamic]
 
 $ unikraft volume delete --help
 
@@ -443,6 +455,7 @@ stdout:
 	  state
 	  size
 	  filesystem
+	  quota-policy
 	  persistent
 	  timestamps, timestamps.created
 	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid

--- a/cmd/unikraft/testdata/TestGolden/volumes/help
+++ b/cmd/unikraft/testdata/TestGolden/volumes/help
@@ -29,6 +29,7 @@ stdout:
 	  tags
 	  state
 	  size
+	  filesystem
 	  persistent
 	  timestamps, timestamps.created
 	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
@@ -75,6 +76,7 @@ stdout:
 	  tags
 	  state
 	  size
+	  filesystem
 	  persistent
 	  timestamps, timestamps.created
 	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
@@ -129,6 +131,7 @@ stdout:
 	  tags
 	  state
 	  size
+	  filesystem
 	  persistent
 	  timestamps, timestamps.created
 	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
@@ -183,6 +186,7 @@ stdout:
 	  tags
 	  state
 	  size
+	  filesystem
 	  persistent
 	  timestamps, timestamps.created
 	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
@@ -242,6 +246,7 @@ stdout:
 	  tags
 	  state
 	  size
+	  filesystem
 	  persistent
 	  timestamps, timestamps.created
 	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
@@ -290,6 +295,9 @@ stdout:
 	      --size=<size>
 	          Volume size.
 	          [examples: 10GiB, 100MiB]
+	      --filesystem=<filesystem>
+	          Volume filesystem.
+	          [example: ext4]
 
 $ unikraft volume clone --help
 
@@ -362,6 +370,7 @@ stdout:
 	  tags
 	  state
 	  size
+	  filesystem
 	  persistent
 	  timestamps, timestamps.created
 	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
@@ -433,6 +442,7 @@ stdout:
 	  tags
 	  state
 	  size
+	  filesystem
 	  persistent
 	  timestamps, timestamps.created
 	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -8,6 +8,7 @@ package cmd
 import (
 	"cmp"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"slices"
@@ -50,9 +51,10 @@ type VolumesCmd struct {
 type VolumeCreateCmd struct {
 	cmd.ResourceCreateCmd[Volume]
 
-	Metro string              `group:"flag-create" shortcut:"metro" help:"Metro to create in." placeholder:"metro" example:"fra,sfo,nyc"`
-	Name  string              `group:"flag-create" shortcut:"name" short:"n" help:"Volume name." placeholder:"name"`
-	Size  types.SizeMebibytes `group:"flag-create" shortcut:"size" help:"Volume size." placeholder:"size" example:"10GiB,100MiB"`
+	Metro      string              `group:"flag-create" shortcut:"metro" help:"Metro to create in." placeholder:"metro" example:"fra,sfo,nyc"`
+	Name       string              `group:"flag-create" shortcut:"name" short:"n" help:"Volume name." placeholder:"name"`
+	Size       types.SizeMebibytes `group:"flag-create" shortcut:"size" help:"Volume size." placeholder:"size" example:"10GiB,100MiB"`
+	Filesystem string              `group:"flag-create" shortcut:"filesystem" help:"Volume filesystem." placeholder:"filesystem" example:"ext4"`
 }
 
 func (c *VolumeCreateCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox, kctx *kong.Context) error {
@@ -227,6 +229,7 @@ type Volume struct {
 
 	State      types.VolumeState   `mirror:"volume.state" field:",short"`
 	Size       types.SizeMebibytes `mirror:"volume.size_mb" field:",short" create:"set,required" edit:"set"`
+	Filesystem string              `mirror:"volume.filesystem" field:",long" create:"set"`
 	Persistent bool                `mirror:"volume.persistent" field:",long"`
 
 	Timestamps struct {
@@ -448,6 +451,19 @@ func (Volume) Create(ctx context.Context, fields []resource.Field) ([]resource.R
 			case "size":
 				size := field.Create.Set.(types.SizeMebibytes)
 				req.SizeMb = uint64(size)
+			case "filesystem":
+				filesystem := field.Create.Set.(string)
+				if filesystem != "" {
+					data, err := json.Marshal(filesystem)
+					if err != nil {
+						return nil, err
+					}
+					// HACK: set on additional properties, since we need an updated SDK
+					if req.AdditionalProperties == nil {
+						req.AdditionalProperties = make(map[string]json.RawMessage)
+					}
+					req.AdditionalProperties["filesystem"] = data
+				}
 			}
 		}
 	}

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -51,10 +51,11 @@ type VolumesCmd struct {
 type VolumeCreateCmd struct {
 	cmd.ResourceCreateCmd[Volume]
 
-	Metro      string              `group:"flag-create" shortcut:"metro" help:"Metro to create in." placeholder:"metro" example:"fra,sfo,nyc"`
-	Name       string              `group:"flag-create" shortcut:"name" short:"n" help:"Volume name." placeholder:"name"`
-	Size       types.SizeMebibytes `group:"flag-create" shortcut:"size" help:"Volume size." placeholder:"size" example:"10GiB,100MiB"`
-	Filesystem string              `group:"flag-create" shortcut:"filesystem" help:"Volume filesystem." placeholder:"filesystem" example:"ext4"`
+	Metro       string              `group:"flag-create" shortcut:"metro" help:"Metro to create in." placeholder:"metro" example:"fra,sfo,nyc"`
+	Name        string              `group:"flag-create" shortcut:"name" short:"n" help:"Volume name." placeholder:"name"`
+	Size        types.SizeMebibytes `group:"flag-create" shortcut:"size" help:"Volume size." placeholder:"size" example:"10GiB,100MiB"`
+	Filesystem  string              `group:"flag-create" shortcut:"filesystem" help:"Volume filesystem." placeholder:"filesystem" example:"ext4"`
+	QuotaPolicy string              `group:"flag-create" shortcut:"quota-policy" help:"Volume quota policy." placeholder:"quota-policy" example:"static,dynamic"`
 }
 
 func (c *VolumeCreateCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox, kctx *kong.Context) error {
@@ -71,7 +72,8 @@ func (c *VolumeCreateCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *
 type VolumeEditCmd struct {
 	cmd.ResourceEditCmd[Volume]
 
-	Size types.SizeMebibytes `group:"flag-edit" shortcut:"size" help:"Volume size." placeholder:"size" example:"20GiB,100MiB"`
+	Size        types.SizeMebibytes `group:"flag-edit" shortcut:"size" help:"Volume size." placeholder:"size" example:"20GiB,100MiB"`
+	QuotaPolicy string              `group:"flag-edit" shortcut:"quota-policy" help:"Volume quota policy." placeholder:"quota-policy" example:"static,dynamic"`
 }
 
 func (c *VolumeEditCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox, kctx *kong.Context) error {
@@ -227,10 +229,11 @@ type Volume struct {
 
 	Tags []string `mirror:"volume.tags"`
 
-	State      types.VolumeState   `mirror:"volume.state" field:",short"`
-	Size       types.SizeMebibytes `mirror:"volume.size_mb" field:",short" create:"set,required" edit:"set"`
-	Filesystem string              `mirror:"volume.filesystem" field:",long" create:"set"`
-	Persistent bool                `mirror:"volume.persistent" field:",long"`
+	State       types.VolumeState   `mirror:"volume.state" field:",short"`
+	Size        types.SizeMebibytes `mirror:"volume.size_mb" field:",short" create:"set,required" edit:"set"`
+	Filesystem  string              `mirror:"volume.filesystem" field:",long" create:"set"`
+	QuotaPolicy string              `mirror:"volume.quota_policy" field:"quota-policy,long" create:"set" edit:"set"`
+	Persistent  bool                `mirror:"volume.persistent" field:",long"`
 
 	Timestamps struct {
 		Created types.RelativeTime `mirror:"volume.created_at" field:",short"`
@@ -464,6 +467,19 @@ func (Volume) Create(ctx context.Context, fields []resource.Field) ([]resource.R
 					}
 					req.AdditionalProperties["filesystem"] = data
 				}
+			case "quota-policy":
+				quotaPolicy := field.Create.Set.(string)
+				if quotaPolicy != "" {
+					data, err := json.Marshal(quotaPolicy)
+					if err != nil {
+						return nil, err
+					}
+					// HACK: set on additional properties, since we need an updated SDK
+					if req.AdditionalProperties == nil {
+						req.AdditionalProperties = make(map[string]json.RawMessage)
+					}
+					req.AdditionalProperties["quota_policy"] = data
+				}
 			}
 		}
 	}
@@ -586,6 +602,8 @@ func volumePatchSpec(path string, _ patchOp, value any) (platform.UpdateVolumesR
 	switch path {
 	case "size":
 		return platform.UpdateVolumesRequestItemPropSize_mb, int64(value.(types.SizeMebibytes))
+	case "quota-policy":
+		return platform.UpdateVolumesRequestItemPropQuota_policy, value.(string)
 	default:
 		return zero, nil
 	}


### PR DESCRIPTION
We *should* be doing this via https://github.com/unikraft-cloud/proto/pull/235, but we can't update the go sdk for reasons: https://github.com/unikraft-cloud/go-sdk/pull/144#discussion_r3000624088.

But `AdditionalProperties` gives us a nice little hack that we can do here anyways!