### PR TITLE
feat: Add 'volume import' command

### DIFF
--- a/cmd/unikraft/testdata/TestGolden/volumes/help
+++ b/cmd/unikraft/testdata/TestGolden/volumes/help
@@ -21,6 +21,8 @@ stdout:
 	          Edit a volume.
 	  clone
 	          Clone a volume.
+	  import
+	          Import data into a volume.
 
 	Templates:
 	  template, templates
@@ -358,6 +360,54 @@ stdout:
 	      --tags=<tag>
 	          Volume tags.
 	          [examples: env=prod, team=platform]
+
+$ unikraft volume import --help
+
+stdout:
+	Import data into a volume.
+
+	Usage:
+	  unikraft volumes import <volume> [flags]
+
+	Arguments:
+	  <volume>
+	          Name or UUID of the volume to import into.
+
+	Examples:
+	  # Import the current directory into a volume
+	  unikraft volume import my-volume --source .
+
+	  # Import a local directory into a volume
+	  unikraft volume import my-volume --source ./data
+
+	  # Import a CPIO archive into a volume
+	  unikraft volume import my-volume --source rootfs.cpio
+
+	  # Import a Dockerfile context into a volume
+	  unikraft volume import my-volume --source ./Dockerfile
+
+	Flags:
+	  -s, --source=<path>
+	          Data source: local directory, CPIO archive, or Dockerfile.
+	  -f, --force
+	          Force import even if the data might exceed volume capacity.
+
+	Global flags:
+	  -h, --help
+	          Show context-sensitive help.
+	      --config=<file> ($UNIKRAFT_CONFIG)
+	          Path to the configuration file.
+	      --log-level=<level> ($UNIKRAFT_LOG_LEVEL)
+	          Set the logging level.
+	          [default: info, choices: trace, debug, info, warn, error, fatal]
+	      --log-type=<type> ($UNIKRAFT_LOG_TYPE)
+	          Set the log type.
+	          [default: text, choices: text, json]
+	      --profile=<name> ($UNIKRAFT_PROFILE)
+	          Set the current profile.
+	      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+	          Toggle anonymous usage analytics.
+	          [default: true]
 
 $ unikraft volume edit --help
 

--- a/cmd/unikraft/testdata/TestGolden/volumes/import/dir
+++ b/cmd/unikraft/testdata/TestGolden/volumes/import/dir
@@ -1,0 +1,29 @@
+$ unikraft volume create --output quiet --set name=test-$UNIQ_VOLUME --set size=10 --set metro=test
+
+stdout:
+	test/test-<VOLUME>
+
+$ unikraft volume import test-$UNIQ_VOLUME --source .
+
+stderr:
+	│ importing data into volume size=276B volume=test-<VOLUME>
+	│ import complete free=10MiB total=10MiB volume=test-<VOLUME>
+
+$ unikraft volume inspect test-$UNIQ_VOLUME
+
+stdout:
+	metro:        test
+	name:         test-<VOLUME>
+	uuid:         12345678-1234-1234-1234-123456789abc
+	state:        available
+	size:         10MiB
+	filesystem:   virtiofs
+	quota-policy: static
+	persistent:   true
+	timestamps:
+	  created:    RELATIVE_TIME
+
+$ unikraft volume delete test-$UNIQ_VOLUME
+
+stdout:
+	test-<VOLUME>

--- a/cmd/unikraft/testdata/TestGolden/volumes/import/invalid-port
+++ b/cmd/unikraft/testdata/TestGolden/volumes/import/invalid-port
@@ -1,0 +1,9 @@
+$ unikraft volume import my-volume --source . --port 80
+
+stderr:
+	│  
+	│ error:
+	│   port must be between 1024 and 65535
+	│
+
+exit code: 1

--- a/cmd/unikraft/testdata/TestGolden/volumes/import/invalid-port-high
+++ b/cmd/unikraft/testdata/TestGolden/volumes/import/invalid-port-high
@@ -1,0 +1,9 @@
+$ unikraft volume import my-volume --source . --port 99999
+
+stderr:
+	│  
+	│ error:
+	│   port must be between 1024 and 65535
+	│
+
+exit code: 1

--- a/cmd/unikraft/testdata/TestGolden/volumes/import/missing-source
+++ b/cmd/unikraft/testdata/TestGolden/volumes/import/missing-source
@@ -1,0 +1,9 @@
+$ unikraft volume import my-volume
+
+stderr:
+	│  
+	│ error:
+	│   source path is required
+	│
+
+exit code: 1

--- a/cmd/unikraft/testdata/TestGolden/volumes/import/serve
+++ b/cmd/unikraft/testdata/TestGolden/volumes/import/serve
@@ -1,0 +1,79 @@
+$ unikraft volume create --output quiet --set name=test-$UNIQ_VOL --set size=50 --set metro=test
+
+stdout:
+	test/test-<VOL>
+
+$ unikraft volume import test-$UNIQ_VOL --source .
+
+stderr:
+	│ importing data into volume size=300B volume=test-<VOL>
+	│ import complete free=50MiB total=50MiB volume=test-<VOL>
+
+$ unikraft instance create --set name=test-$UNIQ_INST --set metro=test --set image=test/nginx-compat:latest --set autostart=true --set resources.memory=256 --set resources.vcpus=1 --set volumes=test-$UNIQ_VOL:/wwwroot:ro --set service.services=443:8080/tls+http --set service.domains=name=$UNIQ_DOMAIN
+
+stdout:
+	metro:        test
+	name:         test-<INST>
+	uuid:         12345678-1234-1234-1234-123456789abc
+	state:        running
+	image:        test/nginx-compat
+	resources:
+	  memory:     256MiB
+	  vcpus:      1
+	service:
+	  uuid:       12345678-1234-1234-1234-123456789abc
+	  name:       <SERVICE_NAME>
+	  domains:
+	  - fqdn:     <DOMAIN>.unikraft.internal
+	volumes:
+	- test-<VOL>:/wwwroot:ro
+	networks:
+	- uuid:       12345678-1234-1234-1234-123456789abc
+	  private-ip: 10.X.X.X
+	  mac:        aa:bb:cc:dd:ee:ff
+	timestamps:
+	  created:    RELATIVE_TIME
+
+$ FQDN=$(unikraft instance inspect test-$UNIQ_INST --output 'template={{ (index .service.domains 0).fqdn }}')
+
+$ unikraft instance wait --until state==running --timeout 30s test-$UNIQ_INST
+
+stdout:
+	metro:        test
+	name:         test-<INST>
+	uuid:         12345678-1234-1234-1234-123456789abc
+	state:        running
+	image:        test/nginx-compat
+	resources:
+	  memory:     256MiB
+	  vcpus:      1
+	service:
+	  uuid:       12345678-1234-1234-1234-123456789abc
+	  name:       <SERVICE_NAME>
+	  domains:
+	  - fqdn:     <DOMAIN>.unikraft.internal
+	volumes:
+	- test-<VOL>:/wwwroot:ro
+	networks:
+	- uuid:       12345678-1234-1234-1234-123456789abc
+	  private-ip: 10.X.X.X
+	  mac:        aa:bb:cc:dd:ee:ff
+	timestamps:
+	  created:    RELATIVE_TIME
+
+$ curl -k --fail --silent --show-error --output response.html --retry 10 --retry-delay 2 --retry-all-errors --connect-timeout 5 --max-time 10 https://$FQDN
+
+$ grep 'hello from volume import' response.html
+
+stdout:
+	<html><body>hello from volume import</body></html>
+
+$ unikraft instance delete test-$UNIQ_INST
+
+stdout:
+	test-<INST>
+
+$ unikraft volume delete test-$UNIQ_VOL
+
+stdout:
+	test-<VOL>

--- a/cmd/unikraft/volumes_test.go
+++ b/cmd/unikraft/volumes_test.go
@@ -5,7 +5,11 @@
 
 package main
 
-import "testing"
+import (
+	"regexp"
+	"slices"
+	"testing"
+)
 
 func volumesTests(t *testing.T, r *testRunner) {
 	t.Run("help", func(t *testing.T) {
@@ -16,6 +20,7 @@ func volumesTests(t *testing.T, r *testRunner) {
 			{args: []string{unikraftCmd, "volume", "wait", "--help"}},
 			{args: []string{unikraftCmd, "volume", "create", "--help"}},
 			{args: []string{unikraftCmd, "volume", "clone", "--help"}},
+			{args: []string{unikraftCmd, "volume", "import", "--help"}},
 			{args: []string{unikraftCmd, "volume", "edit", "--help"}},
 			{args: []string{unikraftCmd, "volume", "delete", "--help"}},
 		})
@@ -58,5 +63,120 @@ func volumesTests(t *testing.T, r *testRunner) {
 				{args: []string{unikraftCmd, "volume", "inspect", "test-$UNIQ_VOLUME", "test-$UNIQ_VOLUME_CLONE"}},
 				{args: []string{unikraftCmd, "volume", "delete", "test-$UNIQ_VOLUME", "test-$UNIQ_VOLUME_CLONE"}},
 			})
+	})
+
+	t.Run("import", func(t *testing.T) {
+		// Offline: missing --source errors before any network call.
+		t.Run("missing-source", func(t *testing.T) {
+			r.run(t, []command{
+				{args: []string{unikraftCmd, "volume", "import", "my-volume"}, allowErr: true},
+			})
+		})
+
+		// Offline: port below the allowed range errors before any network call.
+		t.Run("invalid-port", func(t *testing.T) {
+			r.run(t, []command{
+				{args: []string{unikraftCmd, "volume", "import", "my-volume", "--source", ".", "--port", "80"}, allowErr: true},
+			})
+		})
+
+		// Offline: port above the allowed range errors before any network call.
+		t.Run("invalid-port-high", func(t *testing.T) {
+			r.run(t, []command{
+				{args: []string{unikraftCmd, "volume", "import", "my-volume", "--source", ".", "--port", "99999"}, allowErr: true},
+			})
+		})
+
+		// Import a small directory into a freshly created volume.
+		t.Run("dir", func(t *testing.T) {
+			r.
+				online().
+				withCleaners(
+					[]cleaner{
+						// free size differs on every run
+						{
+							pattern: regexp.MustCompile(`free=[0-9]+.?[0-9]*MiB`),
+							repl:    "free=10MiB",
+						},
+					},
+				).
+				withContext(map[string]string{
+					"hello.txt": "hello from volume import\n",
+				}).
+				run(t, []command{
+					{args: []string{unikraftCmd, "volume", "create", "--output", "quiet", "--set", "name=test-$UNIQ_VOLUME", "--set", "size=10", "--set", "metro=" + metroName}},
+					{args: []string{unikraftCmd, "volume", "import", "test-$UNIQ_VOLUME", "--source", "."}},
+					{args: []string{unikraftCmd, "volume", "inspect", "test-$UNIQ_VOLUME"}},
+					{args: []string{unikraftCmd, "volume", "delete", "test-$UNIQ_VOLUME"}},
+				})
+		})
+
+		// Import a file into a freshly created volume and test connection.
+		t.Run("serve", func(t *testing.T) {
+			r.
+				online().
+				withCleaners(
+					append(slices.Clone(instanceCleaners), cleaner{
+						// free size differs on every run
+						pattern: regexp.MustCompile(`free=[0-9]+.?[0-9]*MiB`),
+						repl:    "free=50MiB",
+					}),
+				).
+				withContext(map[string]string{
+					"index.html": "<html><body>hello from volume import</body></html>\n",
+				}).
+				run(t, []command{
+					// Create a volume to hold the custom web content
+					{args: []string{
+						unikraftCmd, "volume", "create",
+						"--output", "quiet",
+						"--set", "name=test-$UNIQ_VOL",
+						"--set", "size=50",
+						"--set", "metro=" + metroName,
+					}},
+					// Import the custom index.html into the volume
+					{args: []string{unikraftCmd, "volume", "import", "test-$UNIQ_VOL", "--source", "."}},
+					{args: []string{
+						unikraftCmd, "instance", "create",
+						"--set", "name=test-$UNIQ_INST",
+						"--set", "metro=" + metroName,
+						"--set", "image=test/nginx-compat:latest",
+						"--set", "autostart=true",
+						"--set", "resources.memory=256",
+						"--set", "resources.vcpus=1",
+						"--set", "volumes=test-$UNIQ_VOL:/wwwroot:ro",
+						"--set", "service.services=443:8080/tls+http",
+						"--set", "service.domains=name=$UNIQ_DOMAIN",
+					}},
+					// Capture the assigned FQDN
+					{
+						args: []string{
+							unikraftCmd, "instance", "inspect", "test-$UNIQ_INST",
+							"--output", "template=" + `{{ (index .service.domains 0).fqdn }}`,
+						},
+						captureEnv: "FQDN",
+					},
+					{args: []string{unikraftCmd, "instance", "wait", "--until", "state==running", "--timeout", "30s", "test-$UNIQ_INST"}},
+					// Curl the instance and write the body to a file for content verification.
+					{args: []string{
+						"curl",
+						"-k",
+						"--fail",
+						"--silent",
+						"--show-error",
+						"--output", "response.html",
+						"--retry", "10",
+						"--retry-delay", "2",
+						"--retry-all-errors",
+						"--connect-timeout", "5",
+						"--max-time", "10",
+						"https://$FQDN",
+					}},
+					// Assert the imported content is served.
+					{args: []string{"grep", "hello from volume import", "response.html"}},
+					{args: []string{unikraftCmd, "instance", "delete", "test-$UNIQ_INST"}},
+					{args: []string{unikraftCmd, "volume", "delete", "test-$UNIQ_VOL"}},
+				})
+		})
 	})
 }

--- a/cmd/unikraft/volumes_test.go
+++ b/cmd/unikraft/volumes_test.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"regexp"
-	"slices"
 	"testing"
 )
 
@@ -91,15 +90,13 @@ func volumesTests(t *testing.T, r *testRunner) {
 		t.Run("dir", func(t *testing.T) {
 			r.
 				online().
-				withCleaners(
-					[]cleaner{
-						// free size differs on every run
-						{
-							pattern: regexp.MustCompile(`free=[0-9]+.?[0-9]*MiB`),
-							repl:    "free=10MiB",
-						},
+				withCleaners([]cleaner{
+					// free size differs on every run
+					{
+						pattern: regexp.MustCompile(`free=[0-9]+.?[0-9]*MiB`),
+						repl:    "free=10MiB",
 					},
-				).
+				}).
 				withContext(map[string]string{
 					"hello.txt": "hello from volume import\n",
 				}).
@@ -115,13 +112,14 @@ func volumesTests(t *testing.T, r *testRunner) {
 		t.Run("serve", func(t *testing.T) {
 			r.
 				online().
-				withCleaners(
-					append(slices.Clone(instanceCleaners), cleaner{
+				withCleaners(instanceCleaners).
+				withCleaners([]cleaner{
+					{
 						// free size differs on every run
 						pattern: regexp.MustCompile(`free=[0-9]+.?[0-9]*MiB`),
 						repl:    "free=50MiB",
-					}),
-				).
+					},
+				}).
 				withContext(map[string]string{
 					"index.html": "<html><body>hello from volume import</body></html>\n",
 				}).

--- a/go.mod
+++ b/go.mod
@@ -35,8 +35,8 @@ require (
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0
-	github.com/unikraft/go-archivefs v0.0.0-20260414073833-365b9a2f34bd
-	github.com/unikraft/go-cpio v0.0.0-20260209140144-8e02f12b23e0
+	github.com/unikraft/go-archivefs v0.0.0-20260416145000-5840b16b2c08
+	github.com/unikraft/go-cpio v0.0.0-20260415131742-4f1984ca41f3
 	golang.org/x/net v0.53.0
 	golang.org/x/sync v0.20.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -372,10 +372,10 @@ github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea h1:SXhTLE6pb6eld/
 github.com/tonistiigi/units v0.0.0-20180711220420-6950e57a87ea/go.mod h1:WPnis/6cRcDZSUvVmezrxJPkiO87ThFYsoUiMwWNDJk=
 github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab h1:H6aJ0yKQ0gF49Qb2z5hI1UHxSQt4JMyxebFR15KnApw=
 github.com/tonistiigi/vt100 v0.0.0-20240514184818-90bafcd6abab/go.mod h1:ulncasL3N9uLrVann0m+CDlJKWsIAP34MPcOJF6VRvc=
-github.com/unikraft/go-archivefs v0.0.0-20260414073833-365b9a2f34bd h1:J3+GCdIQOYNOBVf+lAMpZPXBqRHIHa665OnahbGsND4=
-github.com/unikraft/go-archivefs v0.0.0-20260414073833-365b9a2f34bd/go.mod h1:NLWtSTdsTRLGQN87zqm9+vN01Ei9JX+FWwuOme2wJXw=
-github.com/unikraft/go-cpio v0.0.0-20260209140144-8e02f12b23e0 h1:RNkUuza8WzrA3FL5aTmmO/IGXFppbevPVc2TSRPLsgg=
-github.com/unikraft/go-cpio v0.0.0-20260209140144-8e02f12b23e0/go.mod h1:OFJWAQVOq1qppx75rzF7qDoE5TqGjM1oCXW5N06Lftg=
+github.com/unikraft/go-archivefs v0.0.0-20260416145000-5840b16b2c08 h1:jXNZRYJ2Zq0xi9C9mEltqImgXmTRodK2la18uIoyIH0=
+github.com/unikraft/go-archivefs v0.0.0-20260416145000-5840b16b2c08/go.mod h1:NLWtSTdsTRLGQN87zqm9+vN01Ei9JX+FWwuOme2wJXw=
+github.com/unikraft/go-cpio v0.0.0-20260415131742-4f1984ca41f3 h1:C8GONmMNDK3spdZEHBIffmq1b1hjCm9nZrquv3+4H+U=
+github.com/unikraft/go-cpio v0.0.0-20260415131742-4f1984ca41f3/go.mod h1:OFJWAQVOq1qppx75rzF7qDoE5TqGjM1oCXW5N06Lftg=
 github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CPa4=
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=

--- a/internal/builder/build.go
+++ b/internal/builder/build.go
@@ -31,6 +31,7 @@ type BuildOpts struct {
 
 type RootfsOpts struct {
 	Path string
+	Type RootfsType
 
 	// Output params
 	Format     kraftfile.FsType
@@ -51,6 +52,9 @@ type RootfsType string
 
 const (
 	RootfsTypeDockerfile RootfsType = "dockerfile"
+	RootfsTypeCpio       RootfsType = "cpio"
+	RootfsTypeErofs      RootfsType = "erofs"
+	RootfsTypeDir        RootfsType = "dir"
 )
 
 // Build a unikraft image based on the provided build options.

--- a/internal/builder/build_test.go
+++ b/internal/builder/build_test.go
@@ -261,8 +261,9 @@ func integrationContext(t *testing.T) context.Context {
 func writeDockerfile(t *testing.T, dockerfile string) string {
 	t.Helper()
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte(dockerfile), 0o644))
-	return dir
+	dockerfilePath := filepath.Join(dir, "Dockerfile")
+	require.NoError(t, os.WriteFile(dockerfilePath, []byte(dockerfile), 0o644))
+	return dockerfilePath
 }
 
 func writeSecretFile(t *testing.T, contents string) string {

--- a/internal/builder/cpio/cpio.go
+++ b/internal/builder/cpio/cpio.go
@@ -40,6 +40,7 @@ func CreateFSFromDirectory(ctx context.Context, w io.Writer, source string, opts
 	}
 
 	cw := cpio.NewWriter(w)
+	defer cw.Close()
 
 	type hardlinkKey struct {
 		device int

--- a/internal/builder/kraftfile.go
+++ b/internal/builder/kraftfile.go
@@ -8,8 +8,6 @@ package builder
 import (
 	"fmt"
 	"path/filepath"
-	"slices"
-	"strings"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
@@ -59,14 +57,18 @@ func KraftfileToBuildOpts(dir string, kf *kraftfile.Kraftfile) (BuildOpts, error
 
 	if kf.Rootfs != nil {
 		opts.Rootfs.Format = kf.Rootfs.Format
-		base := filepath.Base(kf.Rootfs.Source)
-		if base == "Dockerfile" || slices.Contains(strings.Split(base, "."), "Dockerfile") {
-			opts.Rootfs.Path = filepath.Dir(kf.Rootfs.Source)
-		} else {
-			return BuildOpts{}, fmt.Errorf("unable to determine rootfs type for source %q", kf.Rootfs.Source)
+		sourcePath := filepath.Join(dir, kf.Rootfs.Source)
+		typ, err := DetectRootfsType(sourcePath)
+		if err != nil {
+			return BuildOpts{}, fmt.Errorf("detecting rootfs type for %q: %w", kf.Rootfs.Source, err)
 		}
-
-		opts.Rootfs.Path = filepath.Join(dir, opts.Rootfs.Path)
+		opts.Rootfs.Type = typ
+		switch typ {
+		case RootfsTypeDockerfile:
+			opts.Rootfs.Path = filepath.Dir(sourcePath)
+		default:
+			opts.Rootfs.Path = sourcePath
+		}
 	}
 
 	return opts, nil

--- a/internal/builder/rootfs.go
+++ b/internal/builder/rootfs.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -26,25 +27,174 @@ import (
 	"github.com/moby/buildkit/util/progress/progresswriter"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	imagespec "unikraft.com/x/image-spec"
-	"unikraft.com/x/log"
 
+	goerofs "github.com/unikraft/go-archivefs/erofs"
+	gocpio "github.com/unikraft/go-cpio"
 	"unikraft.com/cli/internal/builder/cpio"
 	"unikraft.com/cli/internal/builder/erofs"
 	"unikraft.com/cli/internal/buildkit"
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/images"
 	"unikraft.com/x/kraftfile"
+	"unikraft.com/x/log"
 )
 
-type Rootfs struct {
-	File *os.File
+// buildImageConfig constructs a minimal OCI image config from build options.
+// Used when a BuildKit solve is not performed.
+func buildImageConfig(opts BuildOpts) ocispec.ImageConfig {
+	var cfg ocispec.ImageConfig
+	if opts.Cmd != nil {
+		cfg.Cmd = opts.Cmd
+	}
+	if opts.Env != nil {
+		env := make([]string, 0, len(opts.Env))
+		for _, kv := range opts.Env {
+			env = append(env, fmt.Sprintf("%s=%s", kv.Key, kv.Value))
+		}
+		cfg.Env = env
+	}
+	cfg.Labels = opts.Labels
+	return cfg
 }
 
+// DetectRootfsType inspects path and returns the detected RootfsType.
+func DetectRootfsType(path string) (RootfsType, error) {
+	if path == "" {
+		return "", fmt.Errorf("empty rootfs path")
+	}
+
+	base := filepath.Base(path)
+	if base == "Dockerfile" || slices.Contains(strings.Split(base, "."), "Dockerfile") {
+		return RootfsTypeDockerfile, nil
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("rootfs path does not exist")
+		}
+		return "", fmt.Errorf("checking rootfs source %q: %w", path, err)
+	}
+
+	switch {
+	case fi.IsDir():
+		return RootfsTypeDir, nil
+	case fi.Mode().IsRegular(), fi.Mode()&os.ModeSymlink != 0:
+		if gocpio.IsValidPath(path) {
+			return RootfsTypeCpio, nil
+		}
+		if goerofs.IsValidPath(path) {
+			return RootfsTypeErofs, nil
+		}
+		return "", fmt.Errorf("could not detect file rootfs type %q", path)
+	default:
+		return "", fmt.Errorf("could not detect rootfs type %q", path)
+	}
+}
+
+// BuildRootfs builds a rootfs for each platform in opts.Platform from the
+// source at opts.Rootfs.Path. The source is detected in this order:
+//
+//  1. A pre-packaged rootfs file - returned as-is.
+//  2. A directory - walked and archived.
+//  3. Anything else - treated as a Dockerfile context and built with BuildKit.
 func BuildRootfs(ctx context.Context, opts BuildOpts) (_ []*imagespec.Image, rerr error) {
 	if len(opts.Platform) == 0 {
 		return nil, fmt.Errorf("at least one platform must be specified")
 	}
 
+	if opts.Rootfs.Type == "" {
+		typ, err := DetectRootfsType(opts.Rootfs.Path)
+		if err != nil {
+			return nil, err
+		}
+		opts.Rootfs.Type = typ
+	}
+
+	switch opts.Rootfs.Type {
+	case RootfsTypeCpio, RootfsTypeErofs:
+		return buildRootfsPackaged(ctx, opts)
+	case RootfsTypeDir:
+		return buildRootfsDirectory(ctx, opts)
+	case RootfsTypeDockerfile:
+		if f, err := os.Stat(opts.Rootfs.Path); err != nil {
+			if os.IsNotExist(err) {
+				return nil, fmt.Errorf("dockerfile does not exist")
+			}
+			return nil, fmt.Errorf("checking dockerfile path %q: %w", opts.Rootfs.Path, err)
+		} else if !f.IsDir() {
+			opts.Rootfs.Path = filepath.Dir(opts.Rootfs.Path)
+		}
+		return buildRootfsDockerfile(ctx, opts)
+	default:
+		return nil, fmt.Errorf("unknown rootfs type %q", opts.Rootfs.Type)
+	}
+}
+
+// buildRootfsFromPackaged returns images backed by an already-packaged rootfs
+// file. The file is opened read-only per platform.
+// The caller must not delete it.
+func buildRootfsPackaged(_ context.Context, opts BuildOpts) (_ []*imagespec.Image, rerr error) {
+	cfg := buildImageConfig(opts)
+
+	var imgs []*imagespec.Image
+	for _, p := range opts.Platform {
+		f, err := os.Open(opts.Rootfs.Path)
+		if err != nil {
+			return nil, fmt.Errorf("opening pre-packaged rootfs: %w", err)
+		}
+		defer func() {
+			if rerr != nil {
+				f.Close()
+			}
+		}()
+
+		imgs = append(imgs, imagespec.NewImage(
+			imagespec.WithImageConfig(cfg),
+			imagespec.WithPlatform(p),
+			imagespec.WithInitrd(imagespec.NewOSFile(f)),
+		))
+	}
+	return imgs, nil
+}
+
+// buildRootfsFromDirectory archives the source directory into a temporary
+// rootfs file (CPIO or EroFS, based on opts.Rootfs.Format) for each platform.
+func buildRootfsDirectory(ctx context.Context, opts BuildOpts) (_ []*imagespec.Image, rerr error) {
+	cfg := buildImageConfig(opts)
+
+	format := opts.Rootfs.Format
+	if format == "" {
+		format = kraftfile.FsTypeErofs
+	}
+
+	var imgs []*imagespec.Image
+	for _, p := range opts.Platform {
+		f, err := os.CreateTemp("", "unikraft-rootfs-*."+string(format))
+		if err != nil {
+			return nil, fmt.Errorf("could not create temporary file: %w", err)
+		}
+		defer func() {
+			if rerr != nil && f != nil {
+				f.Close()
+				os.Remove(f.Name())
+			}
+		}()
+
+		if err := packageRootfs(ctx, format, f, opts.Rootfs.Path, opts); err != nil {
+			return nil, err
+		}
+
+		imgs = append(imgs, imagespec.NewImage(
+			imagespec.WithImageConfig(cfg),
+			imagespec.WithPlatform(p),
+			imagespec.WithInitrd(imagespec.NewTempOSFile(f)),
+		))
+	}
+	return imgs, nil
+}
+
+func buildRootfsDockerfile(ctx context.Context, opts BuildOpts) (_ []*imagespec.Image, rerr error) {
 	dockerConfig := dockerconfig.LoadDefaultConfigFile(os.Stderr)
 
 	profile, err := config.G(ctx).CurrentProfile()
@@ -164,44 +314,8 @@ func BuildRootfs(ctx context.Context, opts BuildOpts) (_ []*imagespec.Image, rer
 			}
 		}()
 
-		switch opts.Rootfs.Format {
-		case kraftfile.FsTypeCpio:
-			var gw *gzip.Writer
-			var w io.Writer = f
-			if opts.Rootfs.Compress {
-				gw = gzip.NewWriter(w)
-				w = gw
-			}
-
-			err = cpio.CreateFSFromDirectory(ctx, w, path,
-				cpio.WithAllRoot(!opts.Rootfs.KeepOwners),
-			)
-			if err != nil {
-				return nil, fmt.Errorf("could not create CPIO archive: %w", err)
-			}
-
-			if gw != nil {
-				if err := gw.Close(); err != nil {
-					return nil, fmt.Errorf("could not close gzip writer: %w", err)
-				}
-			}
-		case kraftfile.FsTypeErofs:
-			if opts.Rootfs.Compress {
-				log.G(ctx).Warn().Msg("compression is not supported for EROFS, ignoring compress option")
-			}
-
-			err = erofs.CreateFSFromDirectory(ctx, f, path,
-				erofs.WithAllRoot(!opts.Rootfs.KeepOwners),
-			)
-			if err != nil {
-				return nil, fmt.Errorf("could not create EroFS archive: %w", err)
-			}
-		default:
-			return nil, fmt.Errorf("unknown filesystem type %q", opts.Rootfs.Format)
-		}
-
-		if err := f.Sync(); err != nil {
-			return nil, fmt.Errorf("could not sync file: %w", err)
+		if err := packageRootfs(ctx, opts.Rootfs.Format, f, path, opts); err != nil {
+			return nil, err
 		}
 
 		if opts.Cmd != nil {
@@ -224,6 +338,48 @@ func BuildRootfs(ctx context.Context, opts BuildOpts) (_ []*imagespec.Image, rer
 	}
 
 	return imgs, nil
+}
+
+func packageRootfs(ctx context.Context, format kraftfile.FsType, rootfs *os.File, path string, opts BuildOpts) error {
+	switch format {
+	case kraftfile.FsTypeCpio:
+		var gw *gzip.Writer
+		var w io.Writer = rootfs
+		if opts.Rootfs.Compress {
+			gw = gzip.NewWriter(w)
+			w = gw
+		}
+
+		if err := cpio.CreateFSFromDirectory(ctx, w, path,
+			cpio.WithAllRoot(!opts.Rootfs.KeepOwners),
+		); err != nil {
+			return fmt.Errorf("could not create CPIO archive: %w", err)
+		}
+
+		if gw != nil {
+			if err := gw.Close(); err != nil {
+				return fmt.Errorf("could not close gzip writer: %w", err)
+			}
+		}
+	case kraftfile.FsTypeErofs:
+		if opts.Rootfs.Compress {
+			log.G(ctx).Warn().Msg("compression is not supported for EROFS, ignoring compress option")
+		}
+
+		if err := erofs.CreateFSFromDirectory(ctx, rootfs, path,
+			erofs.WithAllRoot(!opts.Rootfs.KeepOwners),
+		); err != nil {
+			return fmt.Errorf("could not create EroFS archive: %w", err)
+		}
+	default:
+		return fmt.Errorf("unknown filesystem type %q", format)
+	}
+
+	if err := rootfs.Sync(); err != nil {
+		return fmt.Errorf("could not sync file: %w", err)
+	}
+
+	return nil
 }
 
 func applyBuildOpts(attrs map[string]string, localDirs map[string]string, sessions *[]session.Attachable, opts BuildOpts) error {

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -8,19 +8,26 @@ package cmd
 import (
 	"cmp"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"slices"
+	"strconv"
 
 	"github.com/alecthomas/kong"
+	"github.com/docker/go-units"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/cloud/sdk/platform/group"
 	"unikraft.com/x/kingkong"
+	"unikraft.com/x/kraftfile"
 	"unikraft.com/x/log"
 	"unikraft.com/x/ptr"
 
+	"unikraft.com/cli/internal/builder"
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/mirror"
 	"unikraft.com/cli/internal/multimetro"
@@ -29,6 +36,7 @@ import (
 	"unikraft.com/cli/internal/resource/patch"
 	"unikraft.com/cli/internal/resource/value"
 	"unikraft.com/cli/internal/types"
+	"unikraft.com/cli/internal/volimport"
 )
 
 type VolumesCmd struct {
@@ -42,7 +50,8 @@ type VolumesCmd struct {
 	Edit     VolumeEditCmd      `cmd:"" help:"Edit a volume."`
 	Template VolumeTemplatesCmd `cmd:"" group:"cmd-templates" help:"Manage volume templates." aliases:"templates" set:"name=volume-template" set:"names=volume-templates"`
 
-	Clone VolumesCloneCmd `cmd:"" help:"Clone a volume."`
+	Clone  VolumesCloneCmd `cmd:"" help:"Clone a volume."`
+	Import VolumeImportCmd `cmd:"" help:"Import data into a volume."`
 }
 
 // VolumeCreateCmd extends the generic resource create command with shortcut
@@ -609,4 +618,171 @@ func volumePatchSpec(path string, _ patchOp, value any) (platform.UpdateVolumesR
 	default:
 		return zero, nil
 	}
+}
+
+// VolumeImportCmd imports data from a local source into a volume by
+// temporarily spinning up a volimport instance, streaming a CPIO archive
+// over TLS, and cleaning up the instance afterwards.
+type VolumeImportCmd struct {
+	Volume  string `arg:"" completion-predictor:"resource-key-volume" help:"Name or UUID of the volume to import into." create:"set,required"`
+	Source  string `short:"s" help:"Data source: local directory, CPIO archive, or Dockerfile." placeholder:"path" create:"set,required"`
+	Force   bool   `short:"f" help:"Force import even if the data might exceed volume capacity."`
+	Port    int    `short:"p" default:"42069" help:"Port to connect to the volume import service on." placeholder:"port" hidden:"true"`
+	Image   string `default:"official/utils/volimport:1.0" help:"Volume import image to use." placeholder:"image" hidden:"true"`
+	Timeout uint64 `short:"t" default:"10" help:"Inactivity timeout in seconds for the import service." placeholder:"seconds" hidden:"true"`
+}
+
+func (VolumeImportCmd) Examples() []kingkong.Example {
+	return []kingkong.Example{
+		{
+			Description: "Import the current directory into a volume",
+			Commands:    []string{"unikraft volume import my-volume --source ."},
+		},
+		{
+			Description: "Import a local directory into a volume",
+			Commands:    []string{"unikraft volume import my-volume --source ./data"},
+		},
+		{
+			Description: "Import a CPIO archive into a volume",
+			Commands:    []string{"unikraft volume import my-volume --source rootfs.cpio"},
+		},
+		{
+			Description: "Import a Dockerfile context into a volume",
+			Commands:    []string{"unikraft volume import my-volume --source ./Dockerfile"},
+		},
+	}
+}
+
+func (c *VolumeImportCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox) error {
+	if c.Source == "" {
+		return fmt.Errorf("source path is required")
+	}
+
+	// Resolve source to an absolute path.
+	abs, err := filepath.Abs(c.Source)
+	if err != nil {
+		return fmt.Errorf("resolving source path: %w", err)
+	}
+	c.Source = abs
+
+	if c.Port < 1024 || c.Port > 65535 {
+		return fmt.Errorf("port must be between 1024 and 65535")
+	}
+
+	// Resolve the target volume.
+	gettable := sandbox.WrapGettable(Volume{})
+	resources, err := gettable.Get(ctx, []string{c.Volume})
+	if err != nil {
+		return err
+	}
+	if len(resources) == 0 {
+		return fmt.Errorf("volume not found: %s", c.Volume)
+	}
+	if len(resources) > 1 {
+		keys := make([]string, 0, len(resources))
+		for _, res := range resources {
+			keys = append(keys, res.Key().String())
+		}
+		return fmt.Errorf("ambiguous volume: %s (found %v)", c.Volume, keys)
+	}
+	vol, ok := resources[0].(Volume)
+	if !ok {
+		return fmt.Errorf("unexpected resource type %T", resources[0])
+	}
+
+	importOpts := &builder.BuildOpts{
+		Rootfs: builder.RootfsOpts{
+			Path: c.Source,
+			// Set format to CPIO as volimport expects a CPIO archive
+			Format: kraftfile.FsTypeCpio,
+		},
+		// Set platform as volimport makes sense only on UnikraftCloud
+		Platform: []ocispec.Platform{{OS: "kraftcloud", Architecture: "x86_64"}},
+	}
+
+	// Build an import archive from the data source.
+	log.G(ctx).Trace().Str("source", c.Source).Msg("packaging source as import archive")
+	images, err := builder.BuildRootfs(ctx, *importOpts)
+	if err != nil {
+		return fmt.Errorf("packaging source as import archive: %w", err)
+	}
+	if len(images) == 0 {
+		return fmt.Errorf("no images were built from the provided source")
+	}
+	if len(images) > 1 {
+		return fmt.Errorf("multiple images were built from the provided source; expected exactly one")
+	}
+	initrd := images[0].Initrd
+	if initrd == nil {
+		return fmt.Errorf("built image has no initrd")
+	}
+	defer func() {
+		if err := initrd.Cleanup(); err != nil {
+			log.G(ctx).Error().Err(err).Msg("cleaning up initrd")
+		}
+	}()
+
+	cpioReader, cpioSize, err := initrd.Open(ctx)
+	if err != nil {
+		return fmt.Errorf("opening import archive: %w", err)
+	}
+	defer cpioReader.Close()
+
+	authStr, err := volimport.GenRandAuth()
+	if err != nil {
+		return fmt.Errorf("generating authentication token: %w", err)
+	}
+
+	// Spawn a temporary volimport instance in the volume's metro.
+	g, err := multimetro.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+	var instUUID, instFQDN string
+	if err := group.DoMetro(ctx, g, vol.Metro.Name, func(ctx context.Context, mc multimetro.MetroClient) error {
+		var merr error
+		instUUID, instFQDN, merr = volimport.Start(ctx, mc, c.Image, vol.UUID, authStr, c.Timeout, c.Port)
+		return merr
+	}); err != nil {
+		return fmt.Errorf("spawning volume data import instance: %w", err)
+	}
+
+	defer func() {
+		if err := group.DoMetro(ctx, g, vol.Metro.Name, func(ctx context.Context, mc multimetro.MetroClient) error {
+			return volimport.Terminate(ctx, mc, instUUID)
+		}); err != nil {
+			log.G(ctx).Error().Err(err).Msg("terminating volume data import instance")
+		}
+	}()
+
+	// Open a TLS connection to the instance and stream the CPIO archive.
+	instAddr := instFQDN + ":" + strconv.Itoa(c.Port)
+	log.G(ctx).Info().
+		Str("size", units.BytesSize(float64(cpioSize))).
+		Str("volume", c.Volume).
+		Msg("importing data into volume")
+
+	conn, err := tls.Dial("tcp", instAddr, &tls.Config{
+		InsecureSkipVerify: ptr.ZeroIfNil(vol.Metro.Insecure),
+	})
+	if err != nil {
+		return fmt.Errorf("connecting to volume import service at %s: %w", instAddr, err)
+	}
+	defer conn.Close()
+
+	freeSpace, totalSpace, err := volimport.Copy(ctx, conn, authStr, cpioReader, c.Force, uint64(cpioSize))
+	if err != nil {
+		return fmt.Errorf("importing data: %w", err)
+	}
+
+	log.G(ctx).Info().
+		Str("volume", c.Volume).
+		Str("free", units.BytesSize(float64(freeSpace))).
+		Str("total", units.BytesSize(float64(totalSpace))).
+		Msg("import complete")
+
+	// Wait for the import instance to stop; it auto-deletes via delete-on-stop.
+	return group.DoMetro(ctx, g, vol.Metro.Name, func(ctx context.Context, mc multimetro.MetroClient) error {
+		return volimport.Wait(ctx, mc, instUUID)
+	})
 }

--- a/internal/volimport/copy.go
+++ b/internal/volimport/copy.go
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package volimport
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/docker/go-units"
+	"github.com/unikraft/go-cpio"
+	"unikraft.com/x/log"
+)
+
+const (
+	// msgMaxSize is the maximum number of bytes written per send to the
+	// volimport service, matching its internal socket read buffer size.
+	msgMaxSize = 64 * 1024 // 64 KiB
+)
+
+// startResponse is the message sent by the volimport service immediately after
+// the auth token is accepted.
+// Each field is an 8-byte little-endian unsigned integer.
+type startResponse struct {
+	Free   uint64
+	Total  uint64
+	Maxlen uint64
+}
+
+// stopResponse is the final message sent by the volimport service once all
+// archive entries have been processed.  Its layout is identical to
+// startResponse.
+type stopResponse struct {
+	Free   uint64
+	Total  uint64
+	Maxlen uint64
+}
+
+// okResponse represents an acknowledgement frame from the volimport service.
+//
+// Status codes:
+//
+//	 1  — entry processed successfully (no payload)
+//	 2  — final stop frame with 24-byte payload
+//	 0  — server closed (clean end or error accumulation terminator)
+//	<0  — server-side error message
+type okResponse struct {
+	status  int32
+	msglen  uint32
+	message []byte
+}
+
+func (r *okResponse) clear() {
+	r.status = 0
+	r.msglen = 0
+	r.message = nil
+}
+
+func (r *okResponse) parseMetadata(raw []byte) error {
+	r.clear()
+	if err := binary.Read(bytes.NewReader(raw[:4]), binary.LittleEndian, &r.status); err != nil {
+		return err
+	}
+	if r.status == 1 {
+		return nil
+	}
+	return binary.Read(bytes.NewReader(raw[4:8]), binary.LittleEndian, &r.msglen)
+}
+
+func (r *okResponse) parse(raw []byte) error {
+	if err := r.parseMetadata(raw); err != nil {
+		return err
+	}
+	r.message = raw[8 : 8+r.msglen]
+	return nil
+}
+
+// waitForOK blocks on conn, consuming acknowledgement frames until a terminal
+// status is received.  It returns any payload bytes attached to the terminal
+// frame, or an error if the server reported a failure.
+func (r *okResponse) waitForOK(conn *tls.Conn, errMsg string) ([]byte, error) {
+	retErr := fmt.Errorf("%s", errMsg)
+	for {
+		var headBuf, bodyBuf []byte
+		headRaw := bytes.NewBuffer(headBuf)
+		bodyRaw := bytes.NewBuffer(bodyBuf)
+
+		if _, err := io.CopyN(headRaw, conn, 8); err != nil {
+			return nil, fmt.Errorf("%w: reading header: %s", retErr, err)
+		}
+		if err := r.parseMetadata(headRaw.Bytes()); err != nil {
+			return nil, fmt.Errorf("%w: parsing header: %s", retErr, err)
+		}
+		if r.msglen != 0 {
+			if _, err := io.CopyN(bodyRaw, conn, int64(r.msglen)); err != nil {
+				return nil, fmt.Errorf("%w: reading body: %s", retErr, err)
+			}
+		}
+		raw := append(headRaw.Bytes(), bodyRaw.Bytes()...)
+		if err := r.parse(raw); err != nil {
+			return nil, fmt.Errorf("%w: parsing body: %s", retErr, err)
+		}
+
+		switch {
+		case r.status == 0:
+			// If retErr is still the initial sentinel, the server closed cleanly.
+			if retErr.Error() == errMsg {
+				return r.message, nil
+			}
+			return nil, retErr
+		case r.status == 1:
+			return nil, nil
+		case r.status == 2:
+			return r.message, nil
+		case r.status < 0:
+			var msg string
+			if len(r.message) > 0 {
+				msg = strings.TrimSuffix(string(r.message[:len(r.message)-1]), "\n")
+			}
+			retErr = fmt.Errorf("%w: %s", retErr, msg)
+		default:
+			return nil, fmt.Errorf("unexpected response status: %d", r.status)
+		}
+	}
+}
+
+// waitForOKs runs on a goroutine, consuming per-entry acknowledgement frames
+// from the volimport service until the final stop frame arrives or an error
+// occurs.  It signals completion by sending to result and waitErr.
+func waitForOKs(conn *tls.Conn, auth string, result chan *stopResponse, waitErr chan *error) {
+	var err error
+	var final *stopResponse
+	resp := okResponse{}
+
+	defer func() {
+		waitErr <- &err
+		result <- final
+	}()
+
+	for {
+		stopRespRaw, e := resp.waitForOK(conn, "transmission failed")
+		if e != nil {
+			if strings.Contains(e.Error(), "EOF") ||
+				strings.Contains(e.Error(), "use of closed network connection") ||
+				strings.Contains(e.Error(), "i/o timeout") ||
+				strings.Contains(e.Error(), "broken pipe") {
+				return
+			}
+			err = e
+			// Signal the server to terminate.
+			_, _ = io.Copy(conn, strings.NewReader(auth))
+			_ = conn.SetWriteDeadline(immediateNetCancel)
+			_ = conn.SetReadDeadline(immediateNetCancel)
+			return
+		}
+		if len(stopRespRaw) > 0 {
+			sr := &stopResponse{}
+			if binErr := binary.Read(bytes.NewReader(stopRespRaw), binary.LittleEndian, sr); binErr != nil {
+				err = fmt.Errorf("parsing stop response: %w", binErr)
+				return
+			}
+			final = sr
+			// Signal the server that we are done.
+			_, _ = io.Copy(conn, strings.NewReader(auth))
+			return
+		}
+	}
+}
+
+var (
+	// noNetTimeout disables I/O deadlines on the connection (zero time = no deadline).
+	noNetTimeout = time.Time{}
+	// immediateNetCancel is set to a time far in the past to immediately
+	// cancel pending network I/O when applied as a deadline.
+	immediateNetCancel = time.Unix(1, 0)
+)
+
+// Copy streams the CPIO archive from r to the volimport service over conn.
+// size is the byte length of the archive, used for the capacity check.
+// Returns the free and total volume bytes as reported by the service after
+// the import completes.
+func Copy(ctx context.Context, conn *tls.Conn, auth string, r io.Reader, force bool, size uint64) (free, total uint64, err error) {
+	var resp okResponse
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Allow context cancellation to interrupt pending network I/O.
+	_ = conn.SetWriteDeadline(noNetTimeout)
+	_ = conn.SetReadDeadline(noNetTimeout)
+	go func() {
+		<-ctx.Done()
+		_ = conn.SetWriteDeadline(immediateNetCancel)
+		_ = conn.SetReadDeadline(immediateNetCancel)
+	}()
+
+	// Authenticate.
+	if _, err := io.Copy(conn, strings.NewReader(auth)); err != nil {
+		return 0, 0, fmt.Errorf("sending auth token: %w", err)
+	}
+
+	startRespRaw, err := resp.waitForOK(conn, "authentication failed")
+	if err != nil {
+		return 0, 0, err
+	}
+
+	var sr startResponse
+	if err := binary.Read(bytes.NewReader(startRespRaw), binary.LittleEndian, &sr); err != nil {
+		return 0, 0, fmt.Errorf("parsing start response: %w", err)
+	}
+
+	if size > sr.Free {
+		if force {
+			log.G(ctx).Warn().
+				Str("free", units.BytesSize(float64(sr.Free))).
+				Str("required", units.BytesSize(float64(size))).
+				Str("total", units.BytesSize(float64(sr.Total))).
+				Msg("import might exceed volume capacity")
+		} else {
+			return 0, 0, fmt.Errorf("not enough free space on volume: need %s, have %s free",
+				units.BytesSize(float64(size)),
+				units.BytesSize(float64(sr.Free)))
+		}
+	}
+
+	resultCh := make(chan *stopResponse, 1)
+	waitErrCh := make(chan *error, 1)
+	go waitForOKs(conn, auth, resultCh, waitErrCh)
+	defer func() {
+		_ = conn.SetWriteDeadline(immediateNetCancel)
+		_ = conn.SetReadDeadline(immediateNetCancel)
+		if retErr := <-waitErrCh; retErr != nil && *retErr != nil {
+			err = *retErr
+		}
+	}()
+
+	reader := cpio.NewReader(r)
+	shouldStop := false
+
+	var loopErr error
+cpioLoop:
+	for {
+		hdr, raw, nextErr := reader.NextRaw()
+		if nextErr == io.EOF {
+			if raw == nil {
+				break cpioLoop
+			}
+			shouldStop = true
+		} else if nextErr != nil {
+			return 0, 0, fmt.Errorf("reading CPIO entry: %w", nextErr)
+		}
+
+		// Send the raw 110-byte CPIO header.
+		rawBytes := raw.Bytes()
+		if _, err := io.CopyN(conn, bytes.NewReader(rawBytes), int64(len(rawBytes))); err != nil {
+			loopErr = err
+			break cpioLoop
+		}
+
+		// Send the NUL-terminated entry name.
+		name := append([]byte(hdr.Name), 0x00)
+		if _, err := io.CopyN(conn, bytes.NewReader(name), int64(len(name))); err != nil {
+			loopErr = err
+			break cpioLoop
+		}
+
+		// TRAILER!!! signals the end of the archive; nothing more to send.
+		if shouldStop {
+			break cpioLoop
+		}
+
+		// Send file content or symlink/hardlink destination.
+		if hdr.Linkname == "" {
+			// Regular file: stream in msgMaxSize chunks.
+			for {
+				toSend := msgMaxSize
+				if hdr.Size < int64(toSend) {
+					toSend = int(hdr.Size)
+				}
+				buf := make([]byte, toSend)
+				n, readErr := reader.Read(buf)
+				if readErr == io.EOF {
+					break
+				} else if readErr != nil {
+					return 0, 0, fmt.Errorf("reading CPIO content for %q: %w", hdr.Name, readErr)
+				}
+				if _, sendErr := io.CopyN(conn, bytes.NewReader(buf[:n]), int64(n)); sendErr != nil {
+					loopErr = sendErr
+					break cpioLoop
+				}
+			}
+		} else {
+			// Symlink or hardlink: send the link target as content.
+			link := []byte(hdr.Linkname)
+			if _, err := io.CopyN(conn, bytes.NewReader(link), int64(len(link))); err != nil {
+				loopErr = err
+				break cpioLoop
+			}
+		}
+	}
+	if loopErr != nil {
+		return 0, 0, fmt.Errorf("sending CPIO entry: %w", loopErr)
+	}
+
+	final := <-resultCh
+	if final == nil {
+		return 0, 0, fmt.Errorf("no stop response received from import service")
+	}
+	return final.Free, final.Total, nil
+}

--- a/internal/volimport/volimport.go
+++ b/internal/volimport/volimport.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package volimport
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"strconv"
+	"strings"
+
+	"unikraft.com/cli/internal/multimetro"
+	"unikraft.com/cloud/sdk/platform"
+	"unikraft.com/x/log"
+	"unikraft.com/x/ptr"
+)
+
+const (
+	internalPort  = uint32(42069)
+	memoryMB      = int64(128)
+	stopTimeoutMs = int64(1100)
+	startTimeoutS = int64(3)
+)
+
+// Start creates a short-lived Unikraft Cloud instance running the
+// volimport service with the given volume attached at /mnt, and returns the
+// instance UUID and the public FQDN on which the import service listens.
+func Start(ctx context.Context, c multimetro.MetroClient, image, volUUID, authStr string, timeoutS uint64, servicePort int) (instUUID, fqdn string, err error) {
+	args := []string{
+		"volimport",
+		"-p", strconv.FormatUint(uint64(internalPort), 10),
+		"-a", authStr,
+		"-t", strconv.FormatUint(timeoutS, 10),
+	}
+	destPort := internalPort
+
+	log.G(ctx).Trace().Msg("creating volume data import instance")
+	resp, err := c.CreateInstance(ctx, platform.CreateInstanceRequest{
+		Image:         new(image),
+		MemoryMb:      new(memoryMB),
+		Args:          args,
+		Autostart:     new(true),
+		TimeoutS:      new(startTimeoutS),
+		RestartPolicy: new(platform.CreateInstanceRequestRestartPolicyNever),
+		Features:      []platform.CreateInstanceRequestFeatures{platform.CreateInstanceRequestFeaturesDelete_on_stop},
+		Volumes: []platform.CreateInstanceRequestVolume{{
+			Uuid: &volUUID,
+			At:   "/mnt",
+		}},
+		ServiceGroup: &platform.CreateInstanceRequestServiceGroup{
+			Services: []platform.Service{{
+				Port:            uint32(servicePort),
+				DestinationPort: &destPort,
+				Handlers:        []platform.ServiceHandlers{platform.ServiceHandlersTls},
+			}},
+		},
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("creating volume data import instance: %w", err)
+	}
+	if len(resp.Data.Instances) == 0 {
+		return "", "", fmt.Errorf("no instance created by the API")
+	}
+
+	inst := resp.Data.Instances[0]
+	instUUID = ptr.ZeroIfNil(inst.Uuid)
+
+	if inst.ServiceGroup == nil || len(inst.ServiceGroup.Domains) == 0 {
+		if instUUID != "" {
+			log.G(ctx).Trace().Str("uuid", instUUID).Msg("deleting instance: no service group domain returned")
+			_, _ = c.DeleteInstanceByUUID(ctx, instUUID, platform.DeleteInstanceByUUIDRequestBody{}, nil)
+		}
+		return "", "", fmt.Errorf("import instance has no service group domain")
+	}
+
+	fqdn = ptr.ZeroIfNil(inst.ServiceGroup.Domains[0].Fqdn)
+	if fqdn == "" {
+		if instUUID != "" {
+			log.G(ctx).Trace().Str("uuid", instUUID).Msg("deleting instance: empty FQDN returned")
+			_, _ = c.DeleteInstanceByUUID(ctx, instUUID, platform.DeleteInstanceByUUIDRequestBody{}, nil)
+		}
+		return "", "", fmt.Errorf("import instance has an empty FQDN")
+	}
+	// Strip trailing dot if present (DNS FQDNs conventionally end with ".").
+	fqdn = strings.TrimSuffix(fqdn, ".")
+
+	return instUUID, fqdn, nil
+}
+
+// Terminate deletes the given instance, ignoring "not found" errors.
+func Terminate(ctx context.Context, c multimetro.MetroClient, instUUID string) error {
+	log.G(ctx).Trace().Str("uuid", instUUID).Msg("deleting volume data import instance")
+	_, err := c.DeleteInstanceByUUID(ctx, instUUID, platform.DeleteInstanceByUUIDRequestBody{}, nil)
+	if err != nil && !platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
+		return fmt.Errorf("deleting volume data import instance: %w", err)
+	}
+	return nil
+}
+
+// Wait waits for the given instance to reach the stopped state.
+func Wait(ctx context.Context, c multimetro.MetroClient, instUUID string) error {
+	state := platform.WaitInstanceByUUIDRequestBodyStateStopped
+	_, err := c.WaitInstanceByUUID(ctx, instUUID, platform.WaitInstanceByUUIDRequestBody{
+		State:     &state,
+		TimeoutMs: new(stopTimeoutMs),
+	})
+	if err != nil && !platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
+		return fmt.Errorf("waiting for import instance to stop: %w", err)
+	}
+	return nil
+}
+
+// GenRandAuth generates a 32-character cryptographically random alphanumeric
+// token used to authenticate with the volimport unikernel.
+func GenRandAuth() (string, error) {
+	const charset = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	const length = 32
+	maxIdx := big.NewInt(int64(len(charset)))
+	var buf strings.Builder
+	buf.Grow(length)
+	for range length {
+		idx, err := rand.Int(rand.Reader, maxIdx)
+		if err != nil {
+			return "", err
+		}
+		buf.WriteByte(charset[idx.Int64()])
+	}
+	return buf.String(), nil
+}


### PR DESCRIPTION
This adds initial support for volume importing. As before, only CPIO files are supported for importing due to how the "backend" of this is built.

~To add to this, only files and directories are supported right now. I could not figure out how to correctly split the `dockerfile` implementation to make it stop before creating the OCI archive using `imagespec`, as I needed it to give me a `.cpio` file.~
Dockerfiles also work now.

~To make this fully work, `proto` needs to be updated and the `delete_on_stop` flag needs to be renamed to `delete-on-stop`.~
~Switched to new way of providing features that works.~
Sdk fixed.

~Finally, I don't really like how things sit but I couldn't find a better way to break things apart whilst also keeping the general repo structure (aka not refactoring everything 😈)~
I did the refactoring hehe.

~tldr: if you give it no `--source` it will use the workdir and assume it's a Kraftfile in there (or fail if not)~
Removed.

If you give it a `--source` it uses that, be it a CPIO (directly uses it), or Directory (Packages it), or Dockerfile (Builds it).

TODO: Regenerate tests before merging

Blocked on: https://github.com/unikraft-cloud/platform/pull/705
Closes: TOOL-694