### PR TITLE
feat: Add `--no-tls-verify` to `build` subcommand

### DIFF
--- a/internal/cmd/build.go
+++ b/internal/cmd/build.go
@@ -24,10 +24,11 @@ type BuildCmd struct {
 	Output string `short:"o" help:"Output destination"`
 
 	// similar to docker compose build
-	BuildArg []string `help:"Set build-time variables."`
-	NoCache  bool     `help:"Do not use cache when building the image."`
-	Secret   []string `help:"Secret to expose to the build (format: \"id=mysecret[,src=/local/secret]\")."`
-	SSH      []string `help:"SSH agent socket or keys to expose to the build (format: \"default|<id>[=<socket>|<key>[,<key>]]\")."`
+	BuildArg    []string `help:"Set build-time variables."`
+	NoCache     bool     `help:"Do not use cache when building the image."`
+	NoTLSVerify bool     `help:"Skip TLS certificate verification when pushing to a registry."`
+	Secret      []string `help:"Secret to expose to the build (format: \"id=mysecret[,src=/local/secret]\")."`
+	SSH         []string `help:"SSH agent socket or keys to expose to the build (format: \"default|<id>[=<socket>|<key>[,<key>]]\")."`
 }
 
 func (BuildCmd) Examples() []kingkong.Example {
@@ -134,7 +135,9 @@ func (c *BuildCmd) Run(ctx context.Context, cfg *config.Config) error {
 		return err
 	}
 
-	access, err := images.Accessor(ctx)
+	access, err := images.Accessor(ctx,
+		images.WithSkipTLSVerify(c.NoTLSVerify),
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -23,7 +23,27 @@ var defaultRegistries = []string{
 	"index.unikraft.io",
 }
 
-func Accessor(ctx context.Context) (*imagespec.Accessor, error) {
+// AccessorOpt is a functional option for configuring an Accessor.
+type AccessorOpt func(*accessorOpts)
+
+type accessorOpts struct {
+	skipTLSVerify bool
+}
+
+// WithSkipTLSVerify configures the accessor to skip TLS certificate
+// verification when communicating with registries.
+func WithSkipTLSVerify(skip bool) AccessorOpt {
+	return func(o *accessorOpts) {
+		o.skipTLSVerify = skip
+	}
+}
+
+func Accessor(ctx context.Context, opts ...AccessorOpt) (*imagespec.Accessor, error) {
+	var o accessorOpts
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	cfg := config.FromContextOrDefault(ctx)
 	profile, err := cfg.CurrentProfile()
 	if err != nil {
@@ -31,7 +51,7 @@ func Accessor(ctx context.Context) (*imagespec.Accessor, error) {
 	}
 
 	return imagespec.NewAccessor(
-		imagespec.WithResolver(Resolver(profile)),
+		imagespec.WithResolver(Resolver(profile, o.skipTLSVerify)),
 		imagespec.WithReferenceParser(ParseNormalizedNamed),
 	), nil
 }

--- a/internal/images/resolver.go
+++ b/internal/images/resolver.go
@@ -139,6 +139,18 @@ func hostCreds(profile *config.Profile, hostname string) (string, string, error)
 	if slices.Contains(defaultRegistries, hostname) {
 		return decodeAuth(profile.Token)
 	}
+
+	if len(profile.Metros) == 0 {
+		username := profile.Organization
+		if username == "" {
+			// organization may not be set on old or manually created
+			// profiles - so fall back to decoding the username from the
+			// token itself
+			username, _, _ = decodeAuth(profile.Token)
+		}
+		return username, profile.Token, nil
+	}
+
 	for _, metro := range profile.Metros {
 		if hostname == metro.Index().Host {
 			username := profile.Organization

--- a/internal/images/resolver.go
+++ b/internal/images/resolver.go
@@ -22,7 +22,7 @@ import (
 	"unikraft.com/cli/internal/version"
 )
 
-func Resolver(profile *config.Profile) remotes.Resolver {
+func Resolver(profile *config.Profile, skipTLSVerify bool) remotes.Resolver {
 	headers := http.Header{}
 	headers.Set("User-Agent", version.UserAgent())
 
@@ -43,6 +43,9 @@ func Resolver(profile *config.Profile) remotes.Resolver {
 		return false, nil
 	}
 	insecureHost := func(host string) (bool, error) {
+		if skipTLSVerify {
+			return true, nil
+		}
 		for _, index := range indexes {
 			if host == index.Host {
 				return index.Insecure, nil


### PR DESCRIPTION
- **fix(build): Allow returning credentials with no metros**
- **feat: Add `--no-tls-verify` to `build` subcommand**
