### PR TITLE
feat(internal/cmd): Add 'instance tunnel' command

### DIFF
--- a/cmd/unikraft/help_test.go
+++ b/cmd/unikraft/help_test.go
@@ -124,6 +124,7 @@ func instancesHelpTests(t *testing.T, unikraftPath string) {
 		[]string{"unikraft", "instance", "stop", "--help"},
 		[]string{"unikraft", "instance", "suspend", "--help"},
 		[]string{"unikraft", "instance", "restart", "--help"},
+		[]string{"unikraft", "instance", "tunnel", "--help"},
 		[]string{"unikraft", "instance", "history", "--help"},
 	)
 }

--- a/cmd/unikraft/integration/instance_test.go
+++ b/cmd/unikraft/integration/instance_test.go
@@ -6,6 +6,7 @@
 package integration
 
 import (
+	"context"
 	_ "embed"
 	"strings"
 	"testing"
@@ -15,11 +16,47 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"unikraft.com/cloud/sdk/platform"
+	"unikraft.com/cloud/sdk/platform/group"
+
+	"unikraft.com/cli/internal/config"
 	integ "unikraft.com/cli/internal/integration"
+	"unikraft.com/cli/internal/multimetro"
 )
 
 //go:embed testdata/counter_server.py
 var counterServerPy []byte
+
+// tunnelProxyUUIDs queries the platform directly (bypassing the CLI's
+// resource sandbox, which never tracks the tunnel command's internal proxy
+// instance since it's created via the raw platform client rather than
+// through a sandboxed resource) for every currently-running tunnel-service
+// instance in the given metro.
+func tunnelProxyUUIDs(t *testing.T, cfg *config.Config, metro string) map[string]struct{} {
+	t.Helper()
+	ctx := config.WithConfig(t.Context(), cfg)
+	g, err := multimetro.NewClient(ctx)
+	require.NoError(t, err)
+
+	uuids := make(map[string]struct{})
+	err = group.DoMetro(ctx, g, metro, func(ctx context.Context, c multimetro.MetroClient) error {
+		resp, err := c.GetInstances(ctx, nil, platform.GetInstancesOpts{Details: new(true)})
+		if err != nil {
+			return err
+		}
+		if resp == nil || resp.Data == nil {
+			return nil
+		}
+		for _, inst := range resp.Data.Instances {
+			if strings.Contains(inst.Image, "utils/tunnel") {
+				uuids[inst.Uuid] = struct{}{}
+			}
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	return uuids
+}
 
 func TestInstances(t *testing.T) {
 	t.Run("create", func(t *testing.T) {
@@ -1087,6 +1124,75 @@ cmd: ["cat", "/marker.txt"]
 		case <-time.After(10 * time.Second):
 			// Command still running
 		}
+	})
+
+	t.Run("tunnel", func(t *testing.T) {
+		r := runner(t, true, []string{staging, stable})
+		instName := uniq()
+		instName2 := uniq()
+
+		// Create two nginx instances without a public service, in the same
+		// metro, so a single tunnel invocation with two targets exercises the
+		// proxy's port-grouping/sequential-assignment logic for real.
+		for _, name := range []string{instName, instName2} {
+			r.Run(t, []string{
+				"unikraft", "instance", "create",
+				"--output", "quiet",
+				"--set", "name=test-" + name,
+				"--set", "metro=" + r.Config.MetroName,
+				"--set", "image=nginx:latest",
+				"--set", "autostart=true",
+				"--set", "resources.memory=128",
+				"--set", "resources.vcpus=1",
+			})
+		}
+		r.Run(t, []string{
+			"unikraft", "instance", "wait", "--until", "state==running", "--timeout", "60s",
+			"test-" + instName, "test-" + instName2,
+		})
+
+		before := tunnelProxyUUIDs(t, r.Config.Config, r.Config.MetroName)
+
+		// Use metro/instance:port/tcp syntax for the tunnel targets.
+		tunnel := r.StartBackground(t,
+			[]string{
+				"unikraft", "instance", "tunnel",
+				"18081:" + r.Config.MetroName + "/test-" + instName + ":8080/tcp",
+				"18082:" + r.Config.MetroName + "/test-" + instName2 + ":8080/tcp",
+			},
+			"127.0.0.1:18081",
+			0,
+		)
+
+		// Verify that we can reach both instances through the tunnel.
+		body := integ.HTTPGet(t, "http://127.0.0.1:18081")
+		assert.Regexp(t, "Thank you for using nginx.", body)
+		body = integ.HTTPGet(t, "http://127.0.0.1:18082")
+		assert.Regexp(t, "Thank you for using nginx.", body)
+
+		// Identify the proxy instance the tunnel command created, so we can
+		// confirm below that tearing down the tunnel actually deletes it
+		// (a regression in Close() would otherwise go unnoticed, since the
+		// CLI's own sandboxed "instance list"/"inspect" never see this
+		// instance either way).
+		during := tunnelProxyUUIDs(t, r.Config.Config, r.Config.MetroName)
+		var proxyUUID string
+		for u := range during {
+			if _, ok := before[u]; ok {
+				continue
+			}
+			require.Empty(t, proxyUUID, "expected exactly one new tunnel proxy instance, found multiple")
+			proxyUUID = u
+		}
+		require.NotEmpty(t, proxyUUID, "expected a new tunnel proxy instance to appear while the tunnel is running")
+
+		tunnel.Stop()
+
+		after := tunnelProxyUUIDs(t, r.Config.Config, r.Config.MetroName)
+		_, stillThere := after[proxyUUID]
+		assert.False(t, stillThere, "tunnel proxy instance %s was not deleted after the tunnel was torn down", proxyUUID)
+
+		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName, "test-" + instName2})
 	})
 
 	t.Run("branch", func(t *testing.T) {

--- a/cmd/unikraft/testdata/TestHelp/instances
+++ b/cmd/unikraft/testdata/TestHelp/instances
@@ -30,6 +30,8 @@ Resources:
           Suspend one or more instances.
   restart
           Restart one or more instances.
+  tunnel, port-forward
+          Forward a local port to an unexposed instance.
   history
           Show checkpoint history for an instance.
 
@@ -2220,6 +2222,59 @@ Flags:
           Specify which fields to include in the output.
   -o, --output
           Output format. One of: kv, table, json, yaml, raw, quiet, template.
+
+Global flags:
+  -h, --help
+          Show context-sensitive help.
+      --config=<file> ($UNIKRAFT_CONFIG)
+          Path to the configuration file.
+      --log-level=<level> ($UNIKRAFT_LOG_LEVEL)
+          Set the logging level.
+          [default: info, choices: trace, debug, info, warn, error, fatal]
+      --log-type=<type> ($UNIKRAFT_LOG_TYPE)
+          Set the log type.
+          [default: text, choices: text, json]
+      --profile=<name> ($UNIKRAFT_PROFILE)
+          Set the current profile.
+      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+          Toggle anonymous usage analytics.
+          [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
+
+$ unikraft instance tunnel --help
+
+Forward a local port to an unexposed instance through an intermediate
+TLS tunnel service.
+
+When you need to access an instance on Unikraft Cloud which is not
+publicly exposed to the internet, you can use the
+`unikraft instance tunnel` subcommand to forward from a local
+port to a port which the instance listens on.
+
+Usage:
+  unikraft instances tunnel <target> ... [flags]
+
+Arguments:
+  <target> ...
+          Forwarding target(s) in the form [LOCAL_PORT:]<INSTANCE>:DEST_PORT[/TYPE].
+
+Examples:
+  # Forward local port 8080 to instance "nginx" port 8080
+  unikraft instance tunnel nginx:8080
+
+  # Forward local port 8333 to instance "nginx" port 8080
+  unikraft instance tunnel 8333:nginx:8080
+
+  # Forward multiple ports from multiple instances
+  unikraft instance tunnel 8080:my-instance1:8080/tcp 8443:my-instance2:8080/tcp
+
+  # Forward local port 8080 to instance "my-instance1" port 8080 on fra metro
+  # using TCP
+  unikraft instance tunnel 8080:fra/my-instance1:8080/tcp
+
+  # Use a custom relay port to avoid collisions
+  unikraft instance tunnel -p 5500 my-instance:8080
 
 Global flags:
   -h, --help

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -19,7 +19,9 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/alecthomas/kong"
 	"github.com/distribution/reference"
 	"github.com/go-json-experiment/json/jsontext"
@@ -39,6 +41,7 @@ import (
 	"unikraft.com/cli/internal/resource"
 	"unikraft.com/cli/internal/resource/cmd"
 	"unikraft.com/cli/internal/resource/value"
+	"unikraft.com/cli/internal/tunnel"
 	"unikraft.com/cli/internal/types"
 )
 
@@ -60,6 +63,7 @@ type InstancesCmd struct {
 	Stop    InstancesStopCmd    `cmd:"" help:"Stop one or more instances."`
 	Suspend InstancesSuspendCmd `cmd:"" help:"Suspend one or more instances."`
 	Restart InstancesRestartCmd `cmd:"" help:"Restart one or more instances."`
+	Tunnel  InstancesTunnelCmd  `cmd:"" aliases:"port-forward" help:"Forward a local port to an unexposed instance."`
 	History InstanceHistoryCmd  `cmd:"" help:"Show checkpoint history for an instance."`
 }
 
@@ -1956,4 +1960,79 @@ func suspendInstances(ctx context.Context, g *group.Group[multimetro.MetroClient
 		return suspended, suspended.Refs(), nil
 	})
 	return multimetro.Keys(suspended), err
+}
+
+type InstancesTunnelCmd struct {
+	Targets []string `arg:"" name:"target" min:"1" help:"Forwarding target(s) in the form [LOCAL_PORT:]<INSTANCE>:DEST_PORT[/TYPE]." placeholder:"<target>"`
+
+	TunnelProxyPorts   []string `short:"p" name:"tunnel-proxy-port"   help:"Remote port(s) exposed by the tunnel service. When a single value is given it is used as the starting port for multiple targets." default:"4444" hidden:""`
+	ProxyControlPort   uint     `short:"P" name:"tunnel-control-port" help:"Command-and-control port of the tunnel service." default:"4443" hidden:""`
+	TunnelServiceImage string   `          name:"tunnel-image"        help:"Image to use for the tunnel service." default:"official/utils/tunnel:1.0" hidden:""`
+}
+
+func (InstancesTunnelCmd) Help() string {
+	return heredoc.Docf(`
+		Forward a local port to an unexposed instance through an intermediate
+		TLS tunnel service.
+
+		When you need to access an instance on Unikraft Cloud which is not
+		publicly exposed to the internet, you can use the
+		%[1]sunikraft instance tunnel%[1]s subcommand to forward from a local
+		port to a port which the instance listens on.
+	`, "`")
+}
+
+func (cmd InstancesTunnelCmd) Examples() []kingkong.Example {
+	return []kingkong.Example{
+		{
+			Description: "Forward local port 8080 to instance \"nginx\" port 8080",
+			Commands:    []string{"unikraft instance tunnel nginx:8080"},
+		},
+		{
+			Description: "Forward local port 8333 to instance \"nginx\" port 8080",
+			Commands:    []string{"unikraft instance tunnel 8333:nginx:8080"},
+		},
+		{
+			Description: "Forward multiple ports from multiple instances",
+			Commands:    []string{"unikraft instance tunnel 8080:my-instance1:8080/tcp 8443:my-instance2:8080/tcp"},
+		},
+		{
+			Description: "Forward local port 8080 to instance \"my-instance1\" port 8080 on fra metro using TCP",
+			Commands:    []string{"unikraft instance tunnel 8080:fra/my-instance1:8080/tcp"},
+		},
+		{
+			Description: "Use a custom relay port to avoid collisions",
+			Commands:    []string{"unikraft instance tunnel -p 5500 my-instance:8080"},
+		},
+	}
+}
+
+func (cmd *InstancesTunnelCmd) Run(ctx context.Context, stdio config.Stdio) error {
+	targets, err := tunnel.ParseTargets(cmd.Targets, cmd.TunnelProxyPorts)
+	if err != nil {
+		return fmt.Errorf("could not parse targets: %w", err)
+	}
+
+	tun, err := tunnel.New(ctx, targets)
+	if err != nil {
+		return fmt.Errorf("could not create tunnel: %w", err)
+	}
+
+	g, err := multimetro.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		// Detach from ctx so cleanup survives the same Ctrl-C that triggered
+		// it, but bound it so a stuck API call can't leave a still-billed
+		// proxy instance orphaned.
+		closeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		if err := tun.Close(closeCtx, g); err != nil {
+			log.G(ctx).Error().Err(err).Msg("could not terminate tunnel proxy")
+		}
+	}()
+
+	return tun.Run(ctx, g, cmd.ProxyControlPort, cmd.TunnelServiceImage)
 }

--- a/internal/integration/env.go
+++ b/internal/integration/env.go
@@ -8,11 +8,13 @@ package integration
 import (
 	"bytes"
 	"context"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -145,4 +147,89 @@ func (env *TestEnv) Run(t *testing.T, args []string, opts ...CmdOption) string {
 		require.NoError(t, err, "command %q failed\n%s", strings.Join(args, " "), out)
 	}
 	return out
+}
+
+// BackgroundProcess is a handle to a process started by StartBackground.
+type BackgroundProcess struct {
+	cmd    *exec.Cmd
+	output *bytes.Buffer
+	t      *testing.T
+	once   sync.Once
+}
+
+// Stop terminates the background process, waiting for it to exit. It is safe
+// to call multiple times, and is registered automatically as test cleanup by
+// StartBackground, so it only needs to be called explicitly for early
+// termination.
+func (p *BackgroundProcess) Stop() {
+	p.once.Do(func() {
+		p.t.Helper()
+		p.t.Logf("stopping background process")
+		_ = p.cmd.Cancel()
+		err := p.cmd.Wait()
+		if err != nil && p.output.Len() > 0 {
+			p.t.Logf("background process output:\n%s", p.output.String())
+		}
+	})
+}
+
+// StartBackground starts a command in the background and registers cleanup to
+// stop it when the test ends. If waitAddr is non-empty, it polls that TCP
+// address until it is reachable or the timeout (default 90s) expires.
+// The returned handle's Stop method can be called for early termination.
+func (env *TestEnv) StartBackground(t *testing.T, args []string, waitAddr string, timeout time.Duration) *BackgroundProcess {
+	t.Helper()
+	t.Logf("starting background: %s", strings.Join(args, " "))
+
+	var c *exec.Cmd
+	if args[0] == "unikraft" {
+		c = exec.CommandContext(t.Context(), env.unikraftPath, args[1:]...)
+	} else {
+		c = exec.CommandContext(t.Context(), args[0], args[1:]...)
+	}
+
+	c.Env = os.Environ()
+	c.Env = slices.DeleteFunc(c.Env, func(s string) bool {
+		return strings.HasPrefix(s, "UNIKRAFT_")
+	})
+	c.Env = append(c.Env, "NO_COLOR=1")
+	c.Env = append(c.Env, "UNIKRAFT_CONFIG="+env.configPath)
+	c.Env = append(c.Env, "BUILDKIT_PROGRESS=quiet")
+	c.Env = append(c.Env, resource.UnikraftSandboxEnv+"="+env.sandboxPath)
+	c.Cancel = func() error {
+		return c.Process.Signal(os.Interrupt)
+	}
+	c.WaitDelay = 30 * time.Second
+
+	var output bytes.Buffer
+	c.Stdout = &output
+	c.Stderr = &output
+
+	require.NoError(t, c.Start(), "failed to start background command %q", strings.Join(args, " "))
+
+	proc := &BackgroundProcess{cmd: c, output: &output, t: t}
+	t.Cleanup(proc.Stop)
+
+	if waitAddr != "" {
+		waitForAddr(t, waitAddr, timeout)
+	}
+
+	return proc
+}
+
+func waitForAddr(t *testing.T, addr string, timeout time.Duration) {
+	t.Helper()
+	if timeout == 0 {
+		timeout = 90 * time.Second
+	}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, time.Second)
+		if err == nil {
+			conn.Close()
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s to become reachable", addr)
 }

--- a/internal/tunnel/conn.go
+++ b/internal/tunnel/conn.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package tunnel
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"strings"
+
+	"unikraft.com/x/log"
+)
+
+// tunnelConnection represents an accepted local connection being relayed to a
+// remote host through the tunnel service.
+type tunnelConnection struct {
+	relay *tunnelRelay
+	conn  net.Conn
+}
+
+// handle relays data between the local connection and the remote host.
+func (c *tunnelConnection) handle(ctx context.Context, auth []byte, instance, instanceRaw string) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.G(ctx).Error().Interface("panic", r).Str("for", instanceRaw).Msg("recovered from panic while handling tunnel connection")
+		}
+	}()
+	defer func() {
+		c.conn.Close()
+		log.G(ctx).Info().Str("for", instanceRaw).Msg("closed connection")
+	}()
+
+	rc, err := c.relay.dialRemote(ctx)
+	if err != nil {
+		log.G(ctx).Error().Err(err).Msg("failed to connect to remote host")
+		return
+	}
+	defer rc.Close()
+
+	// Force both ends closed as soon as ctx is cancelled (e.g. on Ctrl-C), so
+	// this connection can't block the io.Copy calls below indefinitely and
+	// Run/Close can proceed once every in-flight connection has drained.
+	stop := context.AfterFunc(ctx, func() {
+		c.conn.Close()
+		rc.Close()
+	})
+	defer stop()
+
+	log.G(ctx).Debug().
+		Str("for", c.conn.RemoteAddr().String()).
+		Str("from", rc.LocalAddr().String()).
+		Str("to", rc.RemoteAddr().String()).
+		Msg("opened connection")
+	log.G(ctx).Info().Str("to", instanceRaw).Msg("accepted connection")
+
+	_ = rc.SetDeadline(tunnelNoNetTimeout)
+	_ = c.conn.SetDeadline(tunnelNoNetTimeout)
+
+	defer func() {
+		_ = c.conn.SetDeadline(tunnelImmediateNetCancel)
+	}()
+
+	if len(auth) > 0 {
+		_, err = rc.Write(auth)
+		if err != nil {
+			log.G(ctx).Error().Err(err).Msg("failed to write auth to remote host")
+			return
+		}
+
+		statusRaw := bytes.NewBuffer(nil)
+		n, err := io.CopyN(statusRaw, rc, 2)
+		if err != nil {
+			log.G(ctx).Error().Err(err).Msg("failed to read auth status from remote host")
+			return
+		}
+		if n != 2 {
+			log.G(ctx).Error().Msg("invalid auth status from remote host")
+			return
+		}
+
+		var status int16
+		if err = binary.Read(statusRaw, binary.LittleEndian, &status); err != nil {
+			log.G(ctx).Error().Err(err).Msg("failed to parse auth status from remote host")
+			return
+		}
+
+		if status == 0 {
+			log.G(ctx).Error().Msg("no available connections to remote host, try again later")
+			return
+		} else if status < 0 {
+			log.G(ctx).Error().Msgf("internal tunnel error (C=%d), to view logs run:", status)
+			log.G(ctx).Error().Msgf("    unikraft instance logs %s\n", instance)
+			return
+		}
+	}
+
+	writerDone := make(chan struct{})
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.G(ctx).Error().Interface("panic", r).Msg("recovered from panic while copying tunnel data")
+			}
+		}()
+		defer func() {
+			_ = rc.SetDeadline(tunnelImmediateNetCancel)
+			close(writerDone)
+		}()
+		_, werr := io.Copy(rc, c.conn)
+		if werr != nil && !isNetClosedError(werr) && !isNetTimeoutError(werr) {
+			log.G(ctx).Error().Err(werr).Msg("failed to copy data from client to remote host")
+		}
+	}()
+
+	_, err = io.Copy(c.conn, rc)
+	if err != nil {
+		if !isNetTimeoutError(err) && !isNetClosedError(err) {
+			log.G(ctx).Error().Err(err).Msg("failed to copy data from remote host to client")
+		}
+	} else {
+		// Remote closed the connection cleanly; return to close our side.
+		return
+	}
+
+	<-writerDone
+}
+
+func isNetTimeoutError(err error) bool {
+	var neterr net.Error
+	return errors.As(err, &neterr) && neterr.Timeout()
+}
+
+func isNetClosedError(err error) bool {
+	return errors.Is(err, net.ErrClosed) ||
+		strings.Contains(err.Error(), "connection reset by peer")
+}

--- a/internal/tunnel/parse.go
+++ b/internal/tunnel/parse.go
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package tunnel
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"unikraft.com/cli/internal/multimetro"
+	"unikraft.com/cloud/sdk/platform"
+	"unikraft.com/cloud/sdk/platform/group"
+	"unikraft.com/x/log"
+)
+
+// proxyInfo holds the metadata for a running tunnel proxy instance.
+type proxyInfo struct {
+	uuid string
+	fqdn string
+	// closed indicates whether this proxy instance has been closed.
+	closed bool
+}
+
+// ParseTargets parses raw target strings and proxy port specifications into
+// structured target objects.
+// proxyPorts configures which ports the tunnel service exposes:
+// if a single port is given it is used as the starting port for sequential
+// assignment; otherwise there must be exactly one port per target.
+func ParseTargets(rawTargets []string, proxyPorts []string) ([]Target, error) {
+	if len(rawTargets) == 0 {
+		return nil, fmt.Errorf("at least one target must be specified")
+	}
+
+	if len(proxyPorts) == 0 {
+		return nil, fmt.Errorf("at least one proxy port must be specified")
+	}
+
+	targets := make([]Target, len(rawTargets))
+	for i, raw := range rawTargets {
+		t, err := parseTarget(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parsing target %q: %w", raw, err)
+		}
+		targets[i] = t
+	}
+
+	parsedPorts, err := parseProxyPorts(proxyPorts)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(parsedPorts) > 1 && len(parsedPorts) != len(targets) {
+		return nil, fmt.Errorf("number of proxy ports must be either 1 or equal to the number of targets")
+	}
+
+	if len(parsedPorts) == 1 {
+		if int(parsedPorts[0])+len(targets)-1 > 65535 {
+			return nil, fmt.Errorf("starting proxy port %d does not leave enough room for %d target(s)", parsedPorts[0], len(targets))
+		}
+	} else {
+		seen := make(map[uint16]struct{}, len(parsedPorts))
+		for _, p := range parsedPorts {
+			if _, dup := seen[p]; dup {
+				return nil, fmt.Errorf("duplicate proxy port %d", p)
+			}
+			seen[p] = struct{}{}
+		}
+	}
+
+	// Assign exposed proxy ports.
+	for i := range targets {
+		if len(parsedPorts) == 1 {
+			targets[i].exposedProxyPort = parsedPorts[0] + uint16(i)
+		} else {
+			targets[i].exposedProxyPort = parsedPorts[i]
+		}
+	}
+	return targets, nil
+}
+
+func parseProxyPorts(ports []string) ([]uint16, error) {
+	parsed := make([]uint16, 0, len(ports))
+	for _, port := range ports {
+		p, err := strconv.ParseUint(port, 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("%q is not a valid port number", port)
+		}
+		parsed = append(parsed, uint16(p))
+	}
+	return parsed, nil
+}
+
+// formatProxyArgs formats the arguments to pass to a tunnel service instance
+// for the given set of targets.
+// NOTE(craciunoiuc): Proxy arguments can be found at:
+// https://github.com/unikraft-cloud/catalog/tree/prod-staging/library/official/utils/tunlr/1.0
+func formatProxyArgs(targets []resolvedTarget, authStr string, proxyControlPort uint) []string {
+	connections := make([]string, 0, len(targets))
+	for _, tgt := range targets {
+		connections = append(connections, fmt.Sprintf("TCP2%s:%s:%d:%d:%d",
+			strings.ToUpper(tgt.network),
+			tgt.ip,
+			tgt.dest,
+			tgt.exposedProxyPort,
+			27,
+		))
+	}
+	return []string{
+		// HEARTBEAT_PORT:CTLR_AUTH_TIMEOUT
+		fmt.Sprintf("%d:%d", proxyControlPort, 5),
+		// AUTH_TIMEOUT:AUTH_COOKIE
+		fmt.Sprintf("%d:%s", 5, authStr),
+		// EVS_TIMEOUT
+		"600",
+		// [CONNSTR0|CONNSTR1|...]
+		"[" + strings.Join(connections, "|") + "]",
+	}
+}
+
+// parseTarget parses a single CLI forwarding target string of the form
+// [LOCAL_PORT:][METRO/]INSTANCE:DEST_PORT[/TYPE].
+func parseTarget(raw string) (Target, error) {
+	rest := raw
+	network := "tcp"
+
+	// Split connection type from the last "/" — but only if the suffix looks
+	// like a protocol name rather than a metro/instance path component.
+	if idx := strings.LastIndex(rest, "/"); idx >= 0 {
+		suffix := rest[idx+1:]
+		if strings.EqualFold(suffix, "tcp") || strings.EqualFold(suffix, "udp") {
+			network = strings.ToLower(suffix)
+			rest = rest[:idx]
+		}
+	}
+
+	if network != "tcp" {
+		return Target{}, fmt.Errorf("unsupported connection type %q: only tcp is supported", network)
+	}
+
+	segments := strings.SplitN(rest, ":", 3)
+	switch len(segments) {
+	case 2:
+		// INSTANCE:DEST_PORT — no local port override, use 0 for random port.
+		rport64, parseErr := strconv.ParseUint(segments[1], 10, 16)
+		if parseErr != nil {
+			return Target{}, fmt.Errorf("%q is not a valid port number", segments[1])
+		}
+		return Target{host: segments[0], source: 0, dest: uint16(rport64), network: network}, nil
+	case 3:
+		// LOCAL_PORT:INSTANCE:DEST_PORT
+		lport64, parseErr := strconv.ParseUint(segments[0], 10, 16)
+		if parseErr != nil {
+			return Target{}, fmt.Errorf("%q is not a valid port number", segments[0])
+		}
+		rport64, parseErr := strconv.ParseUint(segments[2], 10, 16)
+		if parseErr != nil {
+			return Target{}, fmt.Errorf("%q is not a valid port number", segments[2])
+		}
+		return Target{host: segments[1], source: uint16(lport64), dest: uint16(rport64), network: network}, nil
+	default:
+		return Target{}, fmt.Errorf("%q is not a valid forwarding target (expected [LOCAL_PORT:]INSTANCE:DEST_PORT[/TYPE])", raw)
+	}
+}
+
+// createProxy creates a single tunnel proxy instance in the given metro for
+// the provided targets.
+func createProxy(ctx context.Context, g *group.Group[multimetro.MetroClient], metro string, targets []resolvedTarget, authStr string, proxyControlPort uint, tunnelImage string) (proxyInfo, error) {
+	args := formatProxyArgs(targets, authStr, proxyControlPort)
+
+	services := make([]platform.Service, 0, len(targets)+1)
+	for _, tgt := range targets {
+		p := uint32(tgt.exposedProxyPort)
+		services = append(services, platform.Service{
+			Port:            p,
+			DestinationPort: &p,
+			Handlers:        []platform.ConnectionHandler{platform.ConnectionHandlerTls},
+		})
+	}
+	ctrlPort := uint32(proxyControlPort)
+	services = append(services, platform.Service{
+		Port:            ctrlPort,
+		DestinationPort: &ctrlPort,
+		Handlers:        []platform.ConnectionHandler{platform.ConnectionHandlerTls},
+	})
+
+	req := platform.CreateInstanceRequest{
+		Image:    &platform.ImageSpec{Url: tunnelImage},
+		MemoryMb: new(int64(128)),
+		Args:     args,
+		ServiceGroup: &platform.CreateInstanceRequestServiceGroup{
+			Services: services,
+		},
+		Autostart: new(bool(true)),
+		TimeoutS:  new(int64(-1)),
+		Features:  []platform.InstanceFeature{platform.InstanceFeatureDeleteOnStop},
+	}
+
+	return group.CollectMetro(ctx, g, metro, func(ctx context.Context, c multimetro.MetroClient) (proxyInfo, error) {
+		log.G(ctx).Trace().Msg("creating tunnel proxy instance")
+		resp, err := c.CreateInstance(ctx, req)
+		if err != nil {
+			return proxyInfo{}, fmt.Errorf("creating proxy instance: %w", err)
+		}
+		if resp.Data == nil || len(resp.Data.Instances) == 0 {
+			return proxyInfo{}, fmt.Errorf("no instance returned after creation")
+		}
+		inst := resp.Data.Instances[0]
+		uuid := inst.Uuid
+
+		var fqdn string
+		if inst.ServiceGroup != nil && len(inst.ServiceGroup.Domains) > 0 {
+			fqdn = inst.ServiceGroup.Domains[0].Fqdn
+		}
+		if fqdn == "" {
+			// The instance is already provisioned and billing even though we
+			// can't relay through it; return its uuid so the caller can still
+			// track (and delete) it.
+			return proxyInfo{uuid: uuid}, fmt.Errorf("tunnel proxy has no service group domain")
+		}
+		return proxyInfo{uuid: uuid, fqdn: fqdn}, nil
+	})
+}

--- a/internal/tunnel/parse_test.go
+++ b/internal/tunnel/parse_test.go
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package tunnel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    Target
+		wantErr string
+	}{
+		{
+			name: "2-segment form",
+			raw:  "my-instance:8080",
+			want: Target{host: "my-instance", source: 0, dest: 8080, network: "tcp"},
+		},
+		{
+			name: "2-segment form with metro prefix",
+			raw:  "fra/my-instance:8080",
+			want: Target{host: "fra/my-instance", source: 0, dest: 8080, network: "tcp"},
+		},
+		{
+			name: "2-segment form with explicit tcp suffix",
+			raw:  "my-instance:8080/tcp",
+			want: Target{host: "my-instance", source: 0, dest: 8080, network: "tcp"},
+		},
+		{
+			// Numeric instance names are unambiguous in the 2-segment form
+			// (it's always INSTANCE:DEST_PORT), so they must be accepted
+			// regardless of magnitude.
+			name: "2-segment form with numeric instance name below 65535",
+			raw:  "12345:8080",
+			want: Target{host: "12345", source: 0, dest: 8080, network: "tcp"},
+		},
+		{
+			name: "2-segment form with numeric instance name above 65535",
+			raw:  "123456:8080",
+			want: Target{host: "123456", source: 0, dest: 8080, network: "tcp"},
+		},
+		{
+			name: "2-segment form with metro-prefixed numeric instance name",
+			raw:  "fra/12345:8080",
+			want: Target{host: "fra/12345", source: 0, dest: 8080, network: "tcp"},
+		},
+		{
+			name: "3-segment form",
+			raw:  "9000:my-instance:8080",
+			want: Target{host: "my-instance", source: 9000, dest: 8080, network: "tcp"},
+		},
+		{
+			name: "3-segment form with metro prefix",
+			raw:  "9000:fra/my-instance:8080",
+			want: Target{host: "fra/my-instance", source: 9000, dest: 8080, network: "tcp"},
+		},
+		{
+			name: "3-segment form with explicit tcp suffix",
+			raw:  "9000:my-instance:8080/tcp",
+			want: Target{host: "my-instance", source: 9000, dest: 8080, network: "tcp"},
+		},
+		{
+			name: "3-segment form with auto local port",
+			raw:  "0:my-instance:8080",
+			want: Target{host: "my-instance", source: 0, dest: 8080, network: "tcp"},
+		},
+		{
+			name:    "udp suffix rejected",
+			raw:     "my-instance:8080/udp",
+			wantErr: `unsupported connection type "udp": only tcp is supported`,
+		},
+		{
+			// "/foo" doesn't look like a protocol name, so it's treated as
+			// part of the destination-port segment rather than stripped.
+			name:    "unrecognized suffix is not treated as a protocol",
+			raw:     "my-instance:8080/foo",
+			wantErr: `"8080/foo" is not a valid port number`,
+		},
+		{
+			name:    "no colon at all",
+			raw:     "my-instance-only",
+			wantErr: "not a valid forwarding target",
+		},
+		{
+			name:    "4+ segments",
+			raw:     "1:2:3:4",
+			wantErr: `"3:4" is not a valid port number`,
+		},
+		{
+			name:    "invalid dest port in 2-segment form",
+			raw:     "my-instance:not-a-port",
+			wantErr: `"not-a-port" is not a valid port number`,
+		},
+		{
+			name:    "invalid local port in 3-segment form",
+			raw:     "not-a-port:my-instance:8080",
+			wantErr: `"not-a-port" is not a valid port number`,
+		},
+		{
+			name:    "invalid dest port in 3-segment form",
+			raw:     "9000:my-instance:not-a-port",
+			wantErr: `"not-a-port" is not a valid port number`,
+		},
+		{
+			name:    "empty string",
+			raw:     "",
+			wantErr: "not a valid forwarding target",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseTarget(tt.raw)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseProxyPorts(t *testing.T) {
+	tests := []struct {
+		name    string
+		ports   []string
+		want    []uint16
+		wantErr string
+	}{
+		{name: "single valid port", ports: []string{"4444"}, want: []uint16{4444}},
+		{name: "multiple valid ports", ports: []string{"4444", "4445"}, want: []uint16{4444, 4445}},
+		{name: "not a number", ports: []string{"abc"}, wantErr: `"abc" is not a valid port number`},
+		{name: "negative", ports: []string{"-1"}, wantErr: `"-1" is not a valid port number`},
+		{name: "overflows uint16", ports: []string{"65536"}, wantErr: `"65536" is not a valid port number`},
+		{name: "empty input", ports: nil, want: []uint16{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseProxyPorts(tt.ports)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseTargets(t *testing.T) {
+	t.Run("no targets", func(t *testing.T) {
+		_, err := ParseTargets(nil, []string{"4444"})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "at least one target must be specified")
+	})
+
+	t.Run("no proxy ports", func(t *testing.T) {
+		_, err := ParseTargets([]string{"a:80"}, nil)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "at least one proxy port must be specified")
+	})
+
+	t.Run("invalid target propagates parse error", func(t *testing.T) {
+		_, err := ParseTargets([]string{"not-a-valid-target"}, []string{"4444"})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, `parsing target "not-a-valid-target"`)
+	})
+
+	t.Run("invalid proxy port propagates parse error", func(t *testing.T) {
+		_, err := ParseTargets([]string{"a:80"}, []string{"not-a-port"})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, `"not-a-port" is not a valid port number`)
+	})
+
+	t.Run("port count mismatch", func(t *testing.T) {
+		_, err := ParseTargets([]string{"a:80", "b:80"}, []string{"4444", "5555", "6666"})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "number of proxy ports must be either 1 or equal to the number of targets")
+	})
+
+	t.Run("sequential assignment overflows uint16", func(t *testing.T) {
+		_, err := ParseTargets([]string{"a:80", "b:80"}, []string{"65535"})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "does not leave enough room")
+	})
+
+	t.Run("sequential assignment at the boundary succeeds", func(t *testing.T) {
+		got, err := ParseTargets([]string{"a:80", "b:80"}, []string{"65534"})
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		assert.EqualValues(t, 65534, got[0].exposedProxyPort)
+		assert.EqualValues(t, 65535, got[1].exposedProxyPort)
+	})
+
+	t.Run("sequential assignment", func(t *testing.T) {
+		got, err := ParseTargets([]string{"a:80", "b:80", "c:80"}, []string{"4444"})
+		require.NoError(t, err)
+		require.Len(t, got, 3)
+		assert.EqualValues(t, 4444, got[0].exposedProxyPort)
+		assert.EqualValues(t, 4445, got[1].exposedProxyPort)
+		assert.EqualValues(t, 4446, got[2].exposedProxyPort)
+	})
+
+	t.Run("explicit per-target ports", func(t *testing.T) {
+		got, err := ParseTargets([]string{"a:80", "b:80"}, []string{"5000", "6000"})
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		assert.EqualValues(t, 5000, got[0].exposedProxyPort)
+		assert.EqualValues(t, 6000, got[1].exposedProxyPort)
+	})
+
+	t.Run("duplicate explicit per-target ports rejected", func(t *testing.T) {
+		_, err := ParseTargets([]string{"a:80", "b:80"}, []string{"5000", "5000"})
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "duplicate proxy port 5000")
+	})
+}
+
+func TestFormatProxyArgs(t *testing.T) {
+	targets := []resolvedTarget{
+		{Target: Target{dest: 80, exposedProxyPort: 4444, network: "tcp"}, ip: "10.0.0.1"},
+		{Target: Target{dest: 8080, exposedProxyPort: 4445, network: "tcp"}, ip: "10.0.0.2"},
+	}
+	args := formatProxyArgs(targets, "authcookie", 4443)
+	require.Len(t, args, 4)
+	assert.Equal(t, "4443:5", args[0])
+	assert.Equal(t, "5:authcookie", args[1])
+	assert.Equal(t, "600", args[2])
+	assert.Equal(t, "[TCP2TCP:10.0.0.1:80:4444:27|TCP2TCP:10.0.0.2:8080:4445:27]", args[3])
+}

--- a/internal/tunnel/relay.go
+++ b/internal/tunnel/relay.go
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package tunnel
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"unikraft.com/x/log"
+)
+
+// tunnelRelay relays connections from a local listener to a remote host over TLS.
+// NOTE(craciunoiuc): Protocol and heartbeat encoding can be found at:
+// https://github.com/unikraft-cloud/catalog/tree/prod-staging/library/official/utils/tunlr/1.0
+type tunnelRelay struct {
+	localAddr      string
+	remoteAddr     string
+	connectionType string
+	auth           string
+	name           string
+	nameAddr       string
+	insecure       bool
+}
+
+const tunnelHeartbeat = "\xf0\x9f\x91\x8b\xf0\x9f\x90\x92\x00"
+
+var (
+	tunnelNoNetTimeout       = time.Time{}
+	tunnelImmediateNetCancel = time.Unix(1, 0)
+)
+
+// up starts a local listener and relays accepted connections to the remote host.
+func (r *tunnelRelay) up(ctx context.Context) error {
+	var lc net.ListenConfig
+	l, err := lc.Listen(ctx, r.connectionType+"4", r.localAddr)
+	if err != nil {
+		return err
+	}
+	stop := context.AfterFunc(ctx, func() { l.Close() })
+	defer func() {
+		stop()
+		l.Close()
+	}()
+
+	log.G(ctx).Info().Str("from", l.Addr().String()).Str("to", r.nameAddr).Msg("tunnelling")
+	log.G(ctx).Debug().Str("via", r.remoteAddr).Msg("tunnelling")
+
+	// Track every accepted connection's handler goroutine so this function
+	// only returns once they've all drained (they are ctx-aware and close
+	// promptly on cancellation; see tunnelConnection.handle).
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return fmt.Errorf("accepting incoming connection: %w", err)
+		}
+		c := &tunnelConnection{relay: r, conn: conn}
+		wg.Go(func() {
+			c.handle(ctx, []byte(r.auth), r.name, r.nameAddr)
+		})
+	}
+}
+
+// controlUp dials the remote control port, signals ready, then sends periodic
+// heartbeats to keep the tunnel service alive.
+func (r *tunnelRelay) controlUp(ctx context.Context, ready chan struct{}) error {
+	rc, err := r.dialRemote(ctx)
+	if err != nil {
+		return err
+	}
+	stop := context.AfterFunc(ctx, func() { rc.Close() })
+	defer func() {
+		stop()
+		rc.Close()
+	}()
+
+	ready <- struct{}{} // signal that the control connection is established
+
+	// Send auth and initial heartbeat.
+	_, err = io.CopyN(rc, bytes.NewReader([]byte(r.auth+tunnelHeartbeat)), int64(len(r.auth)+len(tunnelHeartbeat)))
+	if err != nil {
+		return err
+	}
+	// Send a heartbeat every minute to keep the connection alive.
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Minute):
+		}
+		_, err := io.CopyN(rc, bytes.NewReader([]byte(tunnelHeartbeat)), int64(len(tunnelHeartbeat)))
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (r *tunnelRelay) dialRemote(ctx context.Context) (net.Conn, error) {
+	var d tls.Dialer
+	d.Config = &tls.Config{
+		InsecureSkipVerify: r.insecure, //nolint:gosec // insecure connections are allowed if wanted
+	}
+	return d.DialContext(ctx, "tcp4", r.remoteAddr)
+}

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+
+	"golang.org/x/sync/errgroup"
+
+	"unikraft.com/cli/internal/config"
+	"unikraft.com/cli/internal/multimetro"
+	"unikraft.com/cli/internal/volimport"
+	"unikraft.com/cloud/sdk/platform"
+	"unikraft.com/cloud/sdk/platform/group"
+	"unikraft.com/x/log"
+	"unikraft.com/x/ptr"
+)
+
+// Target describes a single forwarding destination parsed from the CLI
+// argument format [LOCAL_PORT:][METRO/]INSTANCE:DEST_PORT[/TYPE].
+type Target struct {
+	// host is the instance identifier (possibly including a metro prefix like
+	// "fra/my-instance").
+	host string
+	// source is the local port to listen on. 0 means the OS picks a free port.
+	source uint16
+	// dest is the port on the remote instance to forward to.
+	dest uint16
+	// network is the connection type, e.g. "tcp" (like in net.Dial).
+	network string
+	// exposedProxyPort is the port exposed by the tunnel service for this
+	// target. It is computed from the proxy port configuration.
+	exposedProxyPort uint16
+}
+
+// resolvedTarget is a Target once its instance has been looked up on the
+// platform, recording its private IP and the metro it lives in.
+type resolvedTarget struct {
+	Target
+	ip    string
+	metro string
+}
+
+type Tunnel struct {
+	targets []resolvedTarget
+
+	auth string
+	// proxies maps metro name to the running tunnel proxy in that metro.
+	// Populated by Run, consumed by Close. Entries are pointers so that
+	// Close's "closed" bookkeeping mutates the map's own entries.
+	proxies map[string]*proxyInfo
+}
+
+// New creates a tunnel from the given targets. It resolves each target's
+// instance to a private IP and metro via the platform API.
+func New(ctx context.Context, targets []Target) (*Tunnel, error) {
+	authStr, err := volimport.GenRandAuth()
+	if err != nil {
+		return nil, fmt.Errorf("could not generate auth string: %w", err)
+	}
+
+	resolved, err := resolveTargets(ctx, targets)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Tunnel{targets: resolved, auth: authStr}, nil
+}
+
+// resolveTargets looks up each target's instance on the platform, returning a
+// resolvedTarget carrying its private IP and metro alongside the original
+// Target.
+//
+// TODO(craciunoiuc): extract a generic group.CollectRefsMap helper for this
+// key -> instance lookup, so the same logic can be shared with "instance
+// logs".
+func resolveTargets(ctx context.Context, targets []Target) ([]resolvedTarget, error) {
+	keys := make(multimetro.Keys, len(targets))
+	for i, tgt := range targets {
+		keys[i] = multimetro.ParseKey(tgt.host)
+	}
+
+	g, err := multimetro.NewClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	type instanceInfo struct {
+		ip    string
+		metro string
+	}
+	type resolvedInstance struct {
+		ref  group.Ref
+		info instanceInfo
+	}
+
+	resolved, err := group.CollectRefsSlices(ctx, g, keys.Refs(),
+		func(ctx context.Context, c multimetro.MetroClient, refs group.Refs) ([]resolvedInstance, group.Refs, error) {
+			log.G(ctx).Trace().Msg("getting instances for tunnel")
+			resp, err := c.GetInstances(ctx, refs.NameOrUUIDs(), platform.GetInstancesOpts{Details: new(true)})
+			if err != nil && !platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
+				return nil, nil, err
+			}
+			if resp == nil || resp.Data == nil {
+				return nil, nil, nil
+			}
+			var found group.Refs
+			var results []resolvedInstance
+			for i, inst := range resp.Data.Instances {
+				if inst.Status == nil || *inst.Status != platform.ResponseStatusSuccess {
+					continue
+				}
+				if len(inst.NetworkInterfaces) == 0 || inst.NetworkInterfaces[0].PrivateIp == "" {
+					return nil, nil, fmt.Errorf("instance %q has no private IP", refs[i].Display)
+				}
+				found = append(found, refs[i])
+				results = append(results, resolvedInstance{
+					ref: refs[i],
+					info: instanceInfo{
+						ip:    inst.NetworkInterfaces[0].PrivateIp,
+						metro: c.Metro.Name,
+					},
+				})
+			}
+			return results, found, nil
+		})
+	if err != nil {
+		return nil, fmt.Errorf("could not resolve instances: %w", err)
+	}
+
+	// NOTE(craciunoiuc): if the same instance name appears in multiple metros
+	// (no metro prefix given), the last-seen result wins. Users should include
+	// a metro prefix to disambiguate (e.g. fra/my-instance:8080).
+	infoByDisplay := make(map[string]instanceInfo, len(resolved))
+	for _, r := range resolved {
+		infoByDisplay[r.ref.Display] = r.info
+	}
+
+	resolvedTargets := make([]resolvedTarget, len(targets))
+	for i, tgt := range targets {
+		info, ok := infoByDisplay[tgt.host]
+		if !ok {
+			return nil, fmt.Errorf("could not determine metro for %q: include the metro prefix (e.g. fra/my-instance:8080)", tgt.host)
+		}
+		resolvedTargets[i] = resolvedTarget{Target: tgt, ip: info.ip, metro: info.metro}
+	}
+	return resolvedTargets, nil
+}
+
+// Run creates one tunnel service proxy instance per unique metro and stores
+// their metadata. For each metro, a control relay is
+// established to the proxy in that metro, then data relays are started for
+// every target in that metro.
+func (t *Tunnel) Run(ctx context.Context, g *group.Group[multimetro.MetroClient], proxyControlPort uint, tunnelImage string) error {
+	// Group targets by metro.
+	metroTargets := make(map[string][]resolvedTarget)
+	for _, tgt := range t.targets {
+		metroTargets[tgt.metro] = append(metroTargets[tgt.metro], tgt)
+	}
+	profile, err := config.G(ctx).CurrentProfile()
+	if err != nil {
+		return fmt.Errorf("getting current profile: %w", err)
+	}
+
+	metroInsecureMap := make(map[string]bool)
+	for _, m := range profile.Metros {
+		metroInsecureMap[m.Name] = ptr.ZeroIfNil(m.Insecure)
+	}
+
+	t.proxies = make(map[string]*proxyInfo, len(metroTargets))
+	for metro, targets := range metroTargets {
+		info, err := createProxy(ctx, g, metro, targets, t.auth, proxyControlPort, tunnelImage)
+		if info.uuid != "" {
+			// Track the proxy even when it fails after creation, so Close can
+			// still find and delete the already-provisioned, already-billed
+			// instance.
+			t.proxies[metro] = &info
+		}
+		if err != nil {
+			return fmt.Errorf("creating proxy in metro %q: %w", metro, err)
+		}
+	}
+
+	eg, ctx := errgroup.WithContext(ctx)
+
+	// Start a control relay per metro proxy. Errors (including panics) are
+	// propagated through the errgroup so a broken control relay cancels the
+	// whole tunnel instead of only being logged.
+	for metro, proxy := range t.proxies {
+		cr := tunnelRelay{
+			remoteAddr: net.JoinHostPort(proxy.fqdn, strconv.FormatUint(uint64(proxyControlPort), 10)),
+			auth:       t.auth,
+			insecure:   metroInsecureMap[metro],
+		}
+		ready := make(chan struct{})
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					log.G(ctx).Error().Interface("panic", r).Str("metro", metro).Msg("recovered from panic in control relay")
+					err = fmt.Errorf("panic in control relay for metro %q: %v", metro, r)
+				}
+			}()
+			defer close(ready)
+			if cErr := cr.controlUp(ctx, ready); cErr != nil {
+				return fmt.Errorf("control relay for metro %q: %w", metro, cErr)
+			}
+			return nil
+		})
+		// Wait for this metro's control relay before starting its data relays.
+		<-ready
+	}
+
+	for _, tgt := range t.targets {
+		proxy := t.proxies[tgt.metro]
+		r := tunnelRelay{
+			// TODO(antoineco): allow dual-stack by creating two separate listeners.
+			// Alternatively, we could default to "::" to create a tcp46 socket, but
+			// listening on all addresses is an insecure default.
+			localAddr:  net.JoinHostPort("127.0.0.1", strconv.FormatUint(uint64(tgt.source), 10)),
+			remoteAddr: net.JoinHostPort(proxy.fqdn, strconv.FormatUint(uint64(tgt.exposedProxyPort), 10)),
+			// NOTE(craciunoiuc): Only TCP is supported at the moment. This refers to the
+			// local listener; the remote side always uses TLS-over-TCP.
+			connectionType: tgt.network,
+			auth:           t.auth,
+			name:           proxy.uuid,
+			nameAddr:       fmt.Sprintf("%s:%d", tgt.host, tgt.dest),
+			insecure:       metroInsecureMap[tgt.metro],
+		}
+		metro := tgt.metro
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					log.G(ctx).Error().Interface("panic", r).Str("metro", metro).Msg("recovered from panic in data relay")
+					err = fmt.Errorf("panic in data relay for metro %q: %v", metro, r)
+				}
+			}()
+			return r.up(ctx)
+		})
+	}
+
+	return eg.Wait()
+}
+
+// Close removes all tunnel proxy instances across all metros.
+func (t *Tunnel) Close(ctx context.Context, g *group.Group[multimetro.MetroClient]) error {
+	var errs []error
+	for metro, proxy := range t.proxies {
+		if proxy.closed {
+			continue
+		}
+
+		err := group.DoMetro(ctx, g, metro, func(ctx context.Context, c multimetro.MetroClient) error {
+			log.G(ctx).Trace().Msg("deleting tunnel proxy instance")
+			_, err := c.DeleteInstances(ctx, []platform.DeleteInstanceRequestItem{{Uuid: &proxy.uuid}})
+			if err != nil && !platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
+				return fmt.Errorf("deleting proxy instance %q: %w", proxy.uuid, err)
+			}
+			proxy.closed = true
+			return nil
+		})
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package tunnel
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/binary"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newLocalTLSListener starts a TLS listener on 127.0.0.1 backed by an
+// ephemeral, self-signed certificate, standing in for the remote tunnel
+// service that tunnelConnection.handle dials via dialRemote.
+func newLocalTLSListener(t *testing.T) net.Listener {
+	t.Helper()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	require.NoError(t, err)
+
+	l, err := tls.Listen("tcp4", "127.0.0.1:0", &tls.Config{Certificates: []tls.Certificate{cert}})
+	require.NoError(t, err)
+	t.Cleanup(func() { l.Close() })
+	return l
+}
+
+// setupHandleTest starts a fake remote tunnel-service peer (running
+// remoteHandler against the accepted connection) and returns a
+// tunnelConnection wired up to dial it, plus the local ("client") end of the
+// net.Pipe that stands in for the accepted local connection normally handed
+// to handle by tunnelRelay.up.
+func setupHandleTest(t *testing.T, remoteHandler func(t *testing.T, rc net.Conn)) (*tunnelConnection, net.Conn) {
+	t.Helper()
+	l := newLocalTLSListener(t)
+
+	acceptDone := make(chan struct{})
+	go func() {
+		defer close(acceptDone)
+		rc, err := l.Accept()
+		if err != nil {
+			return
+		}
+		defer rc.Close()
+		remoteHandler(t, rc)
+	}()
+	t.Cleanup(func() { <-acceptDone })
+
+	clientSide, connSide := net.Pipe()
+	t.Cleanup(func() { clientSide.Close() })
+
+	c := &tunnelConnection{
+		relay: &tunnelRelay{remoteAddr: l.Addr().String(), insecure: true},
+		conn:  connSide,
+	}
+	return c, clientSide
+}
+
+// readAuth and writeStatus are invoked from goroutines that stand in for the
+// remote peer (directly, and indirectly via setupHandleTest's remoteHandler),
+// so they report failures via t.Errorf rather than testify's assert/require:
+// require's t.FailNow() is only safe to call from the goroutine running the
+// test function, and testifylint otherwise insists error checks use require.
+func readAuth(t *testing.T, rc net.Conn, auth []byte) {
+	t.Helper()
+	got := make([]byte, len(auth))
+	if _, err := io.ReadFull(rc, got); err != nil {
+		t.Errorf("reading auth: %v", err)
+		return
+	}
+	if !bytes.Equal(auth, got) {
+		t.Errorf("auth = %q, want %q", got, auth)
+	}
+}
+
+func writeStatus(t *testing.T, rc net.Conn, status int16) {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := binary.Write(&buf, binary.LittleEndian, status); err != nil {
+		t.Errorf("encoding status: %v", err)
+		return
+	}
+	if _, err := rc.Write(buf.Bytes()); err != nil {
+		t.Errorf("writing status: %v", err)
+	}
+}
+
+// TestTunnelConnectionHandle exercises tunnelConnection.handle's auth-status
+// branches and the bidirectional data relay. Run with -race: the "relays
+// data both ways" subtest races the connection's two copy directions against
+// each other on purpose, which is exactly the scenario that a regression of
+// the shared-err data race (a torn error value written concurrently by both
+// io.Copy directions) would be caught by.
+func TestTunnelConnectionHandle(t *testing.T) {
+	auth := []byte("test-auth-cookie")
+
+	t.Run("status zero: no available connections", func(t *testing.T) {
+		c, _ := setupHandleTest(t, func(t *testing.T, rc net.Conn) {
+			readAuth(t, rc, auth)
+			writeStatus(t, rc, 0)
+		})
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			c.handle(context.Background(), auth, "my-instance", "my-instance:8080")
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("handle did not return for a zero auth status")
+		}
+	})
+
+	t.Run("status negative: internal tunnel error", func(t *testing.T) {
+		c, _ := setupHandleTest(t, func(t *testing.T, rc net.Conn) {
+			readAuth(t, rc, auth)
+			writeStatus(t, rc, -1)
+		})
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			c.handle(context.Background(), auth, "my-instance", "my-instance:8080")
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("handle did not return for a negative auth status")
+		}
+	})
+
+	t.Run("remote closes before sending a full status", func(t *testing.T) {
+		c, _ := setupHandleTest(t, func(t *testing.T, rc net.Conn) {
+			readAuth(t, rc, auth)
+			_, _ = rc.Write([]byte{0x01}) // one byte, then hang up early
+		})
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			c.handle(context.Background(), auth, "my-instance", "my-instance:8080")
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("handle did not return after a short status read")
+		}
+	})
+
+	t.Run("status positive: relays data both ways and unblocks on remote close", func(t *testing.T) {
+		fromClient := []byte("hello-from-client")
+		fromRemote := []byte("hello-from-remote")
+
+		var gotFromClient []byte
+		c, clientSide := setupHandleTest(t, func(t *testing.T, rc net.Conn) {
+			readAuth(t, rc, auth)
+			writeStatus(t, rc, 1)
+
+			_, err := rc.Write(fromRemote)
+			require.NoError(t, err)
+
+			buf := make([]byte, len(fromClient))
+			_, err = io.ReadFull(rc, buf)
+			require.NoError(t, err)
+			gotFromClient = buf
+			// Returning here closes rc (deferred by the caller), which races
+			// handle's two io.Copy directions against each other.
+		})
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			c.handle(context.Background(), auth, "my-instance", "my-instance:8080")
+		}()
+
+		gotFromRemote := make([]byte, len(fromRemote))
+		_, err := io.ReadFull(clientSide, gotFromRemote)
+		require.NoError(t, err)
+		assert.Equal(t, fromRemote, gotFromRemote)
+
+		_, err = clientSide.Write(fromClient)
+		require.NoError(t, err)
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("handle did not return after the remote closed the connection")
+		}
+		assert.Equal(t, fromClient, gotFromClient)
+	})
+
+	t.Run("both ends close concurrently without racing (regression for shared err)", func(t *testing.T) {
+		// Reproduces a connection torn down from both ends at roughly the
+		// same time (e.g. a mid-transfer reset). Neither close is caused by
+		// the other, so if handle's two io.Copy directions still wrote to a
+		// shared `err` variable instead of independent ones, this is exactly
+		// the scenario -race would flag.
+		l := newLocalTLSListener(t)
+
+		rcCh := make(chan net.Conn, 1)
+		acceptDone := make(chan struct{})
+		go func() {
+			defer close(acceptDone)
+			rc, err := l.Accept()
+			if err != nil {
+				return
+			}
+			readAuth(t, rc, auth)
+			writeStatus(t, rc, 1)
+			rcCh <- rc
+		}()
+		t.Cleanup(func() { <-acceptDone })
+
+		clientSide, connSide := net.Pipe()
+		c := &tunnelConnection{
+			relay: &tunnelRelay{remoteAddr: l.Addr().String(), insecure: true},
+			conn:  connSide,
+		}
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			c.handle(context.Background(), auth, "my-instance", "my-instance:8080")
+		}()
+
+		rc := <-rcCh
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); rc.Close() }()
+		go func() { defer wg.Done(); clientSide.Close() }()
+		wg.Wait()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("handle did not return after both ends closed concurrently")
+		}
+	})
+
+	t.Run("no auth configured: skips the handshake and relays immediately", func(t *testing.T) {
+		fromRemote := []byte("hello-from-remote")
+		c, clientSide := setupHandleTest(t, func(t *testing.T, rc net.Conn) {
+			_, err := rc.Write(fromRemote)
+			require.NoError(t, err)
+		})
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			c.handle(context.Background(), nil, "my-instance", "my-instance:8080")
+		}()
+
+		got := make([]byte, len(fromRemote))
+		_, err := io.ReadFull(clientSide, got)
+		require.NoError(t, err)
+		assert.Equal(t, fromRemote, got)
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("handle did not return after the remote closed the connection")
+		}
+	})
+}


### PR DESCRIPTION
Nodes need this option `--net-internal-traffic=vm` in order to test it.

```
tunnel-3uhz1 │ [    0.141932] ERR:  [apptunlr] Target remote not in the same subnet.
tunnel-3uhz1 │ [    0.142826] ERR:  [apptunlr] Failed to hook TCP2TCP.
```

~The Tunlr also needs updating to remove the check for inter-vm comms.~
Done.

~TODO: Update tests when platform is stable.~

~Blocked on: https://github.com/unikraft-cloud/platform/pull/705~
Closes: TOOL-714