### PR TITLE
fix: Make install.sh compatible with sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -95,13 +95,26 @@ need_cmd() { command -v "$1" >/dev/null 2>&1 || err "Required command not found:
 # HTTP download abstraction - uses curl if available, falls back to wget
 # Usage: http_download <url> <output_file>
 # Returns: HTTP status code (or approximation for wget)
-# Sets: HTTP_CODE variable
+# Sets: HTTP_CODE variable, SSL_ERROR variable ("1" if SSL error, "" otherwise)
 http_download() {
   url="$1"
   output="$2"
+  SSL_ERROR=""
 
   if command -v curl >/dev/null 2>&1; then
-    HTTP_CODE=$(curl -sSL -w '%{http_code}' -o "$output" "$url" 2>/dev/null) || HTTP_CODE="000"
+    curl_exit=0
+    HTTP_CODE=$(curl -sSL -w '%{http_code}' -o "$output" "$url" 2>/dev/null) || curl_exit=$?
+    if [ "$curl_exit" -ne 0 ]; then
+      # curl SSL-related exit codes:
+      # 35: SSL connect error
+      # 51: Peer's SSL certificate was not OK
+      # 60: Peer certificate cannot be authenticated with known CA certificates
+      # 77: Problem reading SSL CA cert
+      case "$curl_exit" in
+        35|51|60|77) SSL_ERROR="1" ;;
+      esac
+      HTTP_CODE="000"
+    fi
   elif command -v wget >/dev/null 2>&1; then
     # wget doesn't easily return HTTP codes, so we parse server response
     stderr_file=$(mktemp)
@@ -109,6 +122,11 @@ http_download() {
       wget_exit=0
     else
       wget_exit=$?
+    fi
+
+    # wget exit code 5 indicates SSL verification failure
+    if [ "$wget_exit" -eq 5 ]; then
+      SSL_ERROR="1"
     fi
 
     # Try to extract HTTP code from server response
@@ -198,7 +216,11 @@ resolve_prefix() {
   if [ -z "$v" ]; then
     step_fail "Fetching latest version"
     if [ "$HTTP_CODE" = "000" ]; then
-      err "Network error: could not connect to $BASE_URL"
+      if [ -n "$SSL_ERROR" ]; then
+        err "SSL certificate verification failed connecting to $BASE_URL. Ensure CA certificates are installed (e.g., ca-certificates package)."
+      else
+        err "Network error: could not connect to $BASE_URL"
+      fi
     elif [ "$HTTP_CODE" = "404" ]; then
       err "Version file not found at ${ch_file_url} (HTTP 404)"
     else
@@ -354,7 +376,11 @@ main() {
   if [ "$HTTP_CODE" != "200" ]; then
     step_fail "Downloading Unikraft CLI"
     if [ "$HTTP_CODE" = "000" ]; then
-      err "Network error: could not connect to download server"
+      if [ -n "$SSL_ERROR" ]; then
+        err "SSL certificate verification failed. Ensure CA certificates are installed (e.g., ca-certificates package)."
+      else
+        err "Network error: could not connect to download server"
+      fi
     elif [ "$HTTP_CODE" = "404" ]; then
       err "Binary not found (HTTP 404). Version $VERSION may not exist for ${PLATFORM}/${ARCH}."
     else

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env sh
+set -eu
 
 CHANNEL="${UNIKRAFT_CLI_INSTALL_CHANNEL:-stable}"
 VERSION="${UNIKRAFT_CLI_INSTALL_VERSION:-}"
@@ -9,16 +9,16 @@ BIN_DIR="${UNIKRAFT_CLI_INSTALL_BIN_DIR:-}"
 BASE_URL="${UNIKRAFT_CLI_INSTALL_URL:-https://pkg.unikraft.com}"
 
 # Spinner characters
-SPINNER_CHARS='|/-\'
+SPINNER_CHARS="|/-\\"
 SPINNER_PID=""
 SPINNER_MSG=""
 
 # Colors
-CYAN='\033[36m'
-GREEN='\033[32m'
-RED='\033[31m'
-YELLOW='\033[33m'
-RESET='\033[0m'
+CYAN=$(printf '\033[36m')
+GREEN=$(printf '\033[32m')
+RED=$(printf '\033[31m')
+YELLOW=$(printf '\033[33m')
+RESET=$(printf '\033[0m')
 
 # Clean up spinner on exit
 cleanup() {
@@ -29,13 +29,17 @@ trap cleanup EXIT
 start_spinner() {
   SPINNER_MSG="$1"
   # Only show spinner if stdout is a terminal
-  if [[ ! -t 1 ]]; then
+  if [ ! -t 1 ]; then
     return
   fi
   (
     i=0
-    while true; do
-      printf "\r${CYAN}%s${RESET} %s " "${SPINNER_CHARS:i++%${#SPINNER_CHARS}:1}" "$SPINNER_MSG"
+    len=${#SPINNER_CHARS}
+    while :; do
+      idx=$((i % len + 1))
+      ch=$(printf "%s" "$SPINNER_CHARS" | cut -c "$idx")
+      printf "\r%s%s%s %s " "$CYAN" "$ch" "$RESET" "$SPINNER_MSG"
+      i=$((i + 1))
       sleep 0.1
     done
   ) &
@@ -43,27 +47,27 @@ start_spinner() {
 }
 
 stop_spinner() {
-  if [[ -n "${SPINNER_PID:-}" ]]; then
+  if [ -n "${SPINNER_PID:-}" ]; then
     kill "$SPINNER_PID" 2>/dev/null || true
     wait "$SPINNER_PID" 2>/dev/null || true
     SPINNER_PID=""
     # Clear the spinner line
-    if [[ -t 1 ]]; then
+    if [ -t 1 ]; then
       printf "\r\033[K"
     fi
   fi
 }
 
 step_done() {
-  local msg="$1"
+  msg="$1"
   stop_spinner
-  printf "${GREEN}✓${RESET} %s\n" "$msg"
+  printf "%s✓%s %s\n" "$GREEN" "$RESET" "$msg"
 }
 
 step_fail() {
-  local msg="$1"
+  msg="$1"
   stop_spinner
-  printf "${RED}✗${RESET} %s\n" "$msg" >&2
+  printf "%s✗%s %s\n" "$RED" "$RESET" "$msg" >&2
 }
 
 usage() {
@@ -93,21 +97,27 @@ need_cmd() { command -v "$1" >/dev/null 2>&1 || err "Required command not found:
 # Returns: HTTP status code (or approximation for wget)
 # Sets: HTTP_CODE variable
 http_download() {
-  local url="$1" output="$2"
+  url="$1"
+  output="$2"
 
   if command -v curl >/dev/null 2>&1; then
     HTTP_CODE=$(curl -sSL -w '%{http_code}' -o "$output" "$url" 2>/dev/null) || HTTP_CODE="000"
   elif command -v wget >/dev/null 2>&1; then
-    # wget doesn't easily return HTTP codes, so we parse --server-response
-    local stderr_file
+    # wget doesn't easily return HTTP codes, so we parse server response
     stderr_file=$(mktemp)
-    if wget -q --server-response -O "$output" "$url" 2>"$stderr_file"; then
-      HTTP_CODE="200"
+    if wget -q -S -O "$output" "$url" 2>"$stderr_file"; then
+      wget_exit=0
     else
-      # Try to extract HTTP code from server response
-      HTTP_CODE=$(grep -o 'HTTP/[0-9.]* [0-9]*' "$stderr_file" | tail -1 | awk '{print $2}')
-      # If we couldn't parse it, use exit-code-based approximation
-      if [[ -z "$HTTP_CODE" ]]; then
+      wget_exit=$?
+    fi
+
+    # Try to extract HTTP code from server response
+    HTTP_CODE=$(awk '{for (i=1; i<=NF; i++) if ($i ~ /^[0-9][0-9][0-9]$/) code=$i} END{print code}' "$stderr_file")
+    # If we couldn't parse it, use exit-code-based approximation
+    if [ -z "$HTTP_CODE" ]; then
+      if [ "$wget_exit" -eq 0 ]; then
+        HTTP_CODE="200"
+      else
         HTTP_CODE="000"
       fi
     fi
@@ -124,16 +134,16 @@ need_http_cmd() {
 }
 
 parse_args() {
-  while [[ $# -gt 0 ]]; do
+  while [ $# -gt 0 ]; do
     case "$1" in
       --channel)
-        [[ -z "${2:-}" ]] && err "Option --channel requires a value"
+        [ -z "${2:-}" ] && err "Option --channel requires a value"
         CHANNEL="$2"; shift 2 ;;
       --version)
-        [[ -z "${2:-}" ]] && err "Option --version requires a value"
+        [ -z "${2:-}" ] && err "Option --version requires a value"
         VERSION="$2"; shift 2 ;;
       --bin-dir)
-        [[ -z "${2:-}" ]] && err "Option --bin-dir requires a value"
+        [ -z "${2:-}" ] && err "Option --bin-dir requires a value"
         BIN_DIR="$2"; shift 2 ;;
       -h|--help)
         usage; exit 0 ;;
@@ -144,7 +154,6 @@ parse_args() {
 }
 
 detect_platform() {
-  local os arch
   os=$(uname -s)
   arch=$(uname -m)
 
@@ -165,7 +174,7 @@ detect_platform() {
 
 resolve_prefix() {
   # Determine S3 prefix where artifacts are stored
-  if [[ -n "$VERSION" ]]; then
+  if [ -n "$VERSION" ]; then
     PREFIX="endpoints/cli/content/${VERSION}/"
     return
   fi
@@ -174,24 +183,23 @@ resolve_prefix() {
 
   start_spinner "Fetching latest version"
 
-  local v="" ch_file_url
+  v=""
   ch_file_url="${BASE_URL}/endpoints/cli/content/${CHANNEL}.txt"
 
   # Try to fetch the channel file, capturing both output and HTTP code
-  local tmpfile
   tmpfile=$(mktemp)
   http_download "$ch_file_url" "$tmpfile"
 
-  if [[ "$HTTP_CODE" == "200" ]]; then
+  if [ "$HTTP_CODE" = "200" ]; then
     v=$(tr -d '\r\n' < "$tmpfile")
   fi
   rm -f "$tmpfile"
 
-  if [[ -z "$v" ]]; then
+  if [ -z "$v" ]; then
     step_fail "Fetching latest version"
-    if [[ "$HTTP_CODE" == "000" ]]; then
+    if [ "$HTTP_CODE" = "000" ]; then
       err "Network error: could not connect to $BASE_URL"
-    elif [[ "$HTTP_CODE" == "404" ]]; then
+    elif [ "$HTTP_CODE" = "404" ]; then
       err "Version file not found at ${ch_file_url} (HTTP 404)"
     else
       err "Failed to fetch version info (HTTP $HTTP_CODE)"
@@ -204,92 +212,87 @@ resolve_prefix() {
 }
 
 dir_in_path() {
-  local check_dir="$1"
+  check_dir="$1"
   # Normalize the directory path
-  if [[ -d "$check_dir" ]]; then
+  if [ -d "$check_dir" ]; then
     check_dir=$(cd "$check_dir" 2>/dev/null && pwd) || return 1
   fi
-  echo ":$PATH:" | grep -q ":$check_dir:"
+  case ":$PATH:" in
+    *":$check_dir:") return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 choose_bindir() {
-  local default_bin_dir="${UNIKRAFT_CLI_INSTALL_DEFAULT_BIN_DIR:-$HOME/.local/bin}"
+  default_bin_dir="${UNIKRAFT_CLI_INSTALL_DEFAULT_BIN_DIR:-$HOME/.local/bin}"
 
-  if [[ -n "$BIN_DIR" ]]; then
+  if [ -n "$BIN_DIR" ]; then
     # User explicitly specified a directory - use it as-is
     DEST_DIR="$BIN_DIR"
   else
     # Check common home bin directories in preference order
-    local -a preferred_dirs
-    if [[ -n "${UNIKRAFT_CLI_INSTALL_PREFERRED_DIRS:-}" ]]; then
-      IFS=':' read -ra preferred_dirs <<< "$UNIKRAFT_CLI_INSTALL_PREFERRED_DIRS"
+    if [ -n "${UNIKRAFT_CLI_INSTALL_PREFERRED_DIRS:-}" ]; then
+      preferred_dirs="$UNIKRAFT_CLI_INSTALL_PREFERRED_DIRS"
     else
-      preferred_dirs=(
-        "$HOME/.local/bin"
-        "$HOME/bin"
-        "$HOME/.bin"
-      )
+      preferred_dirs="$HOME/.local/bin:$HOME/bin:$HOME/.bin"
     fi
 
     DEST_DIR=""
-    for dir in "${preferred_dirs[@]}"; do
+    old_ifs=$IFS
+    IFS=:
+    for dir in $preferred_dirs; do
       if dir_in_path "$dir"; then
         DEST_DIR="$dir"
         break
       fi
     done
+    IFS=$old_ifs
 
     # If none of the preferred dirs are in PATH, warn and use default
-    if [[ -z "$DEST_DIR" ]]; then
-      printf "${YELLOW}Warning:${RESET} None of the standard bin directories (~/.local/bin, ~/bin, ~/.bin) are in your PATH.\n"
-      printf "         Using ${CYAN}%s${RESET} - you may need to add it to your PATH.\n" "$default_bin_dir"
+    if [ -z "$DEST_DIR" ]; then
+      printf "%sWarning:%s None of the standard bin directories (~/.local/bin, ~/bin, ~/.bin) are in your PATH.\n" "$YELLOW" "$RESET"
+      printf "         Using %s%s%s - you may need to add it to your PATH.\n" "$CYAN" "$default_bin_dir" "$RESET"
       DEST_DIR="$default_bin_dir"
     fi
   fi
 
-  local mkdir_err
-  if ! mkdir_err=$(mkdir -p "$DEST_DIR" 2>&1); then
-    err "Could not create bin directory $DEST_DIR: $mkdir_err"
-  fi
-  if [[ ! -d "$DEST_DIR" ]]; then
+  mkdir_err=$(mkdir -p "$DEST_DIR" 2>&1) || err "Could not create bin directory $DEST_DIR: $mkdir_err"
+  if [ ! -d "$DEST_DIR" ]; then
     err "Could not create bin directory: $DEST_DIR"
   fi
 }
 
 verify_checksum() {
-  local archive_path="$1" sha_url="$2"
+  archive_path="$1"
+  sha_url="$2"
 
   start_spinner "Verifying checksum"
 
-  local sha_tmp
   sha_tmp=$(mktemp)
   http_download "$sha_url" "$sha_tmp"
 
-  if [[ "$HTTP_CODE" != "200" ]]; then
+  if [ "$HTTP_CODE" != "200" ]; then
     rm -f "$sha_tmp" || true
     # Checksum file missing is a warning, not a fatal error
     stop_spinner
-    printf "${YELLOW}⚠${RESET} Checksum file not available, skipping verification\n"
+    printf "%s⚠%s Checksum file not available, skipping verification\n" "$YELLOW" "$RESET"
     return
   fi
 
-  local expected raw first
-  raw=$(cat "$sha_tmp")
-  # If file includes filename, take first field; else treat as raw hash
-  first=$(echo "$raw" | awk '{print $1}')
-  expected="$first"
+  expected=$(awk '{print $1; exit}' "$sha_tmp")
 
-  local actual
   if command -v sha256sum >/dev/null 2>&1; then
-    actual=$(sha256sum "$archive_path" | awk '{print $1}')
+    actual=$(sha256sum "$archive_path") || err "Failed to calculate sha256"
+    actual=${actual%% *}
   else
     need_cmd shasum
-    actual=$(shasum -a 256 "$archive_path" | awk '{print $1}')
+    actual=$(shasum -a 256 "$archive_path") || err "Failed to calculate sha256"
+    actual=${actual%% *}
   fi
 
   rm -f "$sha_tmp" || true
 
-  if [[ "$actual" != "$expected" ]]; then
+  if [ "$actual" != "$expected" ]; then
     step_fail "Verifying checksum"
     err "Checksum mismatch: expected $expected, got $actual. The download may be corrupted."
   fi
@@ -298,33 +301,34 @@ verify_checksum() {
 }
 
 extract_and_install() {
-  local archive_path="$1"
+  archive_path="$1"
 
   start_spinner "Installing to $DEST_DIR"
 
-  local extract_err
-  if ! extract_err=$(tar -xzf "$archive_path" "$BIN_NAME" 2>&1); then
+  extract_err=$(tar -xzf "$archive_path" "$BIN_NAME" 2>&1) || {
     step_fail "Installing to $DEST_DIR"
     err "Failed to extract archive: $extract_err"
-  fi
+  }
 
-  local install_err
-  if ! install_err=$(install -m 0755 "$BIN_NAME" "$DEST_DIR/$BIN_NAME" 2>&1); then
+  install_err=$(install -m 0755 "$BIN_NAME" "$DEST_DIR/$BIN_NAME" 2>&1) || {
     step_fail "Installing to $DEST_DIR"
     err "Failed to install binary to $DEST_DIR: $install_err"
-  fi
+  }
 
   step_done "Installed to $DEST_DIR"
 }
 
 post_install_note() {
-  if ! echo ":$PATH:" | grep -q ":$DEST_DIR:"; then
+  case ":$PATH:" in
+    *":$DEST_DIR:") return 0 ;;
+  esac
+  if [ -n "$DEST_DIR" ]; then
     echo "  Add to PATH: export PATH=\"$DEST_DIR:\$PATH\""
   fi
 }
 
 configure_auth() {
-  printf "\nRun ${CYAN}unikraft login${RESET} to get started.\n"
+  printf "\nRun %sunikraft login%s to get started.\n" "$CYAN" "$RESET"
 }
 
 main() {
@@ -333,14 +337,13 @@ main() {
   resolve_prefix
   choose_bindir
 
-  local asset="unikraft-${PLATFORM}-${ARCH}.${EXT}"
-  local url="${BASE_URL}/${PREFIX}${asset}"
-  local sha_url="${url}.sha256"
+  asset="unikraft-${PLATFORM}-${ARCH}.${EXT}"
+  url="${BASE_URL}/${PREFIX}${asset}"
+  sha_url="${url}.sha256"
 
   need_http_cmd
   need_cmd tar
 
-  local tmpdir archive_path
   tmpdir=$(mktemp -d)
   archive_path="$tmpdir/$asset"
 
@@ -348,11 +351,11 @@ main() {
 
   http_download "$url" "$archive_path"
 
-  if [[ "$HTTP_CODE" != "200" ]]; then
+  if [ "$HTTP_CODE" != "200" ]; then
     step_fail "Downloading Unikraft CLI"
-    if [[ "$HTTP_CODE" == "000" ]]; then
+    if [ "$HTTP_CODE" = "000" ]; then
       err "Network error: could not connect to download server"
-    elif [[ "$HTTP_CODE" == "404" ]]; then
+    elif [ "$HTTP_CODE" = "404" ]; then
       err "Binary not found (HTTP 404). Version $VERSION may not exist for ${PLATFORM}/${ARCH}."
     else
       err "Download failed (HTTP $HTTP_CODE)"


### PR DESCRIPTION
So that we don't need bash installed, which isn't available everywhere. Also it's just nice practice.

Additionally, run shellcheck and fix any resulting issues.