### PR TITLE
fix: Ensure that logs don't rewind back to the very beginning

### DIFF
--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -79,13 +79,17 @@ func (r *logsReader) rewind(tail int) (n int64, err error) {
 
 	total := 0
 
-	var chunkOffset int64 = 0
 	chunk := make([]byte, logPageSize)
+	chunkOffset := ptr.ZeroIfNil(r.end)
 	for {
-		chunkOffset -= int64(len(chunk))
+		requestOffset := chunkOffset - logPageSize
+		if r.start != nil && requestOffset <= *r.start {
+			requestOffset = *r.start
+		}
+		chunk := chunk[:chunkOffset-requestOffset]
 
 		var chunkSize int
-		chunkOffset, chunkSize, err = r.readChunk(chunk, chunkOffset)
+		chunkOffset, chunkSize, err = r.readChunk(chunk, requestOffset)
 		if err != nil {
 			return 0, err
 		}
@@ -191,6 +195,10 @@ func (r *logsReader) readChunk(p []byte, off int64) (actualOffset int64, n int, 
 	n, err = base64.StdEncoding.Decode(p, []byte(ptr.ZeroIfNil(data.Output)))
 	if err != nil {
 		return 0, 0, err
+	}
+	dataRangeSize := ptr.ZeroIfNil(dataRange.End) - ptr.ZeroIfNil(dataRange.Start)
+	if int64(n) != dataRangeSize {
+		return 0, 0, fmt.Errorf("expected to read %d bytes but got %d", dataRangeSize, n)
 	}
 	return ptr.ZeroIfNil(dataRange.Start), n, nil
 }


### PR DESCRIPTION
Using `--tail` with logs could sometimes rewind and produce bizarre results.

Imagine a page size of 1000, and a log size of 2500. We would previously produce the follow sequence of requests:
- offset=-1000, limit=1000 (returns back start=1500)
- offset=500, limit=1000
- offset=-500, limit=1000 (returns back start=1500)
- weird errors, and strangeness occurs

The issue is that we need to recognize when we accidentally rewind behind the start, and distinguish that from when we don't *know* the start, and so need to use a negative offset.

Additionally, add a sanity check for the platform, that ensures that it definitely does return the expected amount of data!