### PR TITLE
feat: Use new /v1/auth API to fetch organization details

### DIFF
--- a/internal/cmd/login/login.go
+++ b/internal/cmd/login/login.go
@@ -91,9 +91,20 @@ func (cmd *LoginCmd) Run(ctx context.Context, cfg *config.Config) error {
 		token = *resp.Data.Token
 		organization = cmp.Or(ptr.ZeroIfNil(resp.Data.OrganizationName), cmd.Organization)
 	}
+	tempProfile.Token = token
 
 	if organization == "" {
-		return jujuerrors.New("no organization provided or received from control plane")
+		var err error
+		organization, err = cmd.getOrg(ctx, tempProfile)
+		if err != nil {
+			log.G(ctx).Error().
+				Msg("could not determine organization from control plane, specify organization with --organization flag")
+			return err
+		} else {
+			log.G(ctx).Info().
+				Str("organization", organization).
+				Msg("found organization from control plane")
+		}
 	}
 
 	// Log the organization we're logging into
@@ -208,10 +219,12 @@ func (cmd *LoginCmd) generateUniqueProfileName(cfg *config.Config, organization 
 	}
 }
 
-func (cmd *LoginCmd) getMetros(ctx context.Context, profile *config.Profile) ([]config.Metro, error) {
+func (cmd *LoginCmd) client(profile *config.Profile) controlplane.Client {
 	copts := []controlplane.ClientOption{
 		controlplane.WithDefaultEndpoint(profile.ControlPlane),
-		controlplane.WithToken(profile.Token),
+	}
+	if profile.Token != "" {
+		copts = append(copts, controlplane.WithToken(profile.Token))
 	}
 	if cmd.AllowInsecure {
 		copts = append(copts, controlplane.WithHTTPClient(httpclient.InsecureHTTPClient))
@@ -219,6 +232,11 @@ func (cmd *LoginCmd) getMetros(ctx context.Context, profile *config.Profile) ([]
 		copts = append(copts, controlplane.WithHTTPClient(httpclient.DefaultHTTPClient))
 	}
 	client := controlplane.NewClient(copts...)
+	return client
+}
+
+func (cmd *LoginCmd) getMetros(ctx context.Context, profile *config.Profile) ([]config.Metro, error) {
+	client := cmd.client(profile)
 
 	metroResp, err := client.ListMetros(ctx)
 	if err != nil {
@@ -240,15 +258,7 @@ func (cmd *LoginCmd) getMetros(ctx context.Context, profile *config.Profile) ([]
 }
 
 func (cmd *LoginCmd) getAuth(ctx context.Context, profile *config.Profile) (*controlplane.Response[controlplane.CheckAuthorizationResponseData], error) {
-	copts := []controlplane.ClientOption{
-		controlplane.WithDefaultEndpoint(profile.ControlPlane),
-	}
-	if cmd.AllowInsecure {
-		copts = append(copts, controlplane.WithHTTPClient(httpclient.InsecureHTTPClient))
-	} else {
-		copts = append(copts, controlplane.WithHTTPClient(httpclient.DefaultHTTPClient))
-	}
-	client := controlplane.NewClient(copts...)
+	client := cmd.client(profile)
 
 	req, err := getFingerprint()
 	if err != nil {
@@ -329,4 +339,17 @@ func (cmd *LoginCmd) getAuth(ctx context.Context, profile *config.Profile) (*con
 	}
 
 	return event, nil
+}
+
+func (cmd *LoginCmd) getOrg(ctx context.Context, profile *config.Profile) (string, error) {
+	client := cmd.client(profile)
+
+	resp, err := client.GetAuthorization(ctx)
+	if err != nil {
+		return "", jujuerrors.Annotate(err, "getting authorization")
+	}
+	if resp.Data == nil || resp.Data.OrganizationName == nil {
+		return "", jujuerrors.New("no organization name received from control plane")
+	}
+	return *resp.Data.OrganizationName, nil
 }

--- a/internal/cmd/login/login.go
+++ b/internal/cmd/login/login.go
@@ -166,6 +166,17 @@ func (cmd *LoginCmd) Run(ctx context.Context, cfg *config.Config) error {
 // if a profile with the same name already exists but for a different
 // organization.
 func (cmd *LoginCmd) findOrCreateProfile(cfg *config.Config, organization, loginControlPlane string) (*config.Profile, error) {
+	// If we've explicitly specified a profile name, use that
+	if name, ok := cfg.OverriddenCurrentProfile(); ok {
+		if profile, ok := cfg.Profiles[name]; ok {
+			return &profile, nil
+		}
+		return &config.Profile{
+			Type: config.ProfileTypeCloud,
+			Name: name,
+		}, nil
+	}
+
 	// Search existing profiles for one with matching organization and controlplane
 	for name, profile := range cfg.Profiles {
 		if profile.Organization == organization && profile.ControlPlane == loginControlPlane {

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -208,3 +208,13 @@ func (config *Config) CurrentProfileName() string {
 func (config *Config) OverrideCurrentProfile(name string) {
 	config.selectedProfile = name
 }
+
+func (config *Config) OverriddenCurrentProfile() (string, bool) {
+	if config == nil {
+		return "", false
+	}
+	if config.selectedProfile == "" {
+		return "", false
+	}
+	return config.selectedProfile, true
+}


### PR DESCRIPTION
Fixes https://linear.app/unikraft/issue/TOOL-716/populate-cli-organization-from-controlplane-if-not-specified-with.

If the user doesn't specify an `--organization` with their `--token`, we
would previously fail out. We do need to know the user for various
operations.

This patch communicates with the controlplane to determine the organization
from the token if it's not specified using the new `GET /v1/auth` API.