### PR TITLE
test: Better cleaning of metros output

### DIFF
--- a/cmd/unikraft/instances_test.go
+++ b/cmd/unikraft/instances_test.go
@@ -312,11 +312,6 @@ var instanceCleaners = []cleaner{
 		repl:    "<SERVICE_NAME>",
 	},
 	{
-		// auto-generated domain names like "foo.ukp-stable.apw.unikraft.internal"
-		pattern: regexp.MustCompile(`\b\.[a-z0-9.\-]+\.unikraft\.(app|internal)\b`),
-		repl:    ".unikraft.internal",
-	},
-	{
 		// auto-generated volume names like "vol-0g8gc"
 		pattern: regexp.MustCompile(`\bvol-[a-z0-9]+\b`),
 		repl:    "<INLINE_VOL>",

--- a/cmd/unikraft/main_test.go
+++ b/cmd/unikraft/main_test.go
@@ -275,16 +275,16 @@ func (b *testBuilder) run(t *testing.T, commands []command) {
 				report.cleaners = append(
 					report.cleaners,
 					cleaner{
-						pattern: regexp.MustCompile(regexp.QuoteMeta(metro.Name)),
-						repl:    "test",
-					},
-					cleaner{
 						pattern: regexp.MustCompile(regexp.QuoteMeta(metro.Endpoint)),
-						repl:    "https://api.test.unikraft.internal",
+						repl:    "https://api.unikraft.test",
 					},
 					cleaner{
 						pattern: regexp.MustCompile(regexp.QuoteMeta(metro.Index().Host)),
-						repl:    "index.test.unikraft.internal",
+						repl:    "index.unikraft.test",
+					},
+					cleaner{
+						pattern: regexp.MustCompile(regexp.QuoteMeta(metro.Name)),
+						repl:    "test",
 					},
 				)
 			}
@@ -458,6 +458,11 @@ var cleaners = []cleaner{
 		// temp config paths like "/tmp/TestGolden.../001/config.yaml" change between runs
 		pattern: regexp.MustCompile(`/tmp/TestGolden[^/]+/`),
 		repl:    "/tmp/TestGolden/",
+	},
+	{
+		// auto-generated domain names like "foo.ukp-stable.apw.unikraft.internal"
+		pattern: regexp.MustCompile(`\.[a-z0-9.\-]+\.unikraft\.(app|internal)\b`),
+		repl:    ".unikraft.internal",
 	},
 }
 

--- a/cmd/unikraft/testdata/TestGolden/auth/flow
+++ b/cmd/unikraft/testdata/TestGolden/auth/flow
@@ -13,7 +13,7 @@ $ unikraft metro list
 
 stdout:
 	NAME  COUNTRY  ENDPOINT
-	test  xx       https://api.test.unikraft.internal
+	test  xx       https://api.unikraft.test
 
 $ unikraft logout
 

--- a/cmd/unikraft/testdata/TestGolden/config/get
+++ b/cmd/unikraft/testdata/TestGolden/config/get
@@ -10,7 +10,7 @@ stdout:
 	  organization: test
 	  metros:
 	  - name:       test
-	    endpoint:   https://api.test.unikraft.internal
+	    endpoint:   https://api.unikraft.test
 	    country:    xx
 	    insecure:   false
 
@@ -28,7 +28,7 @@ stdout:
 	        "metros": [
 	          {
 	            "country": "xx",
-	            "endpoint": "https://api.test.unikraft.internal",
+	            "endpoint": "https://api.unikraft.test",
 	            "insecure": false,
 	            "name": "test"
 	          }
@@ -53,7 +53,7 @@ stdout:
 	      insecure: false
 	      metros:
 	      - country: xx
-	        endpoint: https://api.test.unikraft.internal
+	        endpoint: https://api.unikraft.test
 	        insecure: false
 	        name: test
 	      name: default

--- a/cmd/unikraft/testdata/TestGolden/instances/instances/add-domain
+++ b/cmd/unikraft/testdata/TestGolden/instances/instances/add-domain
@@ -13,7 +13,7 @@ stdout:
 	  uuid:       12345678-1234-1234-1234-123456789abc
 	  name:       <SERVICE_NAME>
 	  domains:
-	  - fqdn:     <SERVICE_NAME>.ukp-staging.unikraft.internal
+	  - fqdn:     <SERVICE_NAME>.unikraft.internal
 	networks:
 	- uuid:       12345678-1234-1234-1234-123456789abc
 	  private-ip: 10.X.X.X
@@ -43,7 +43,7 @@ stdout:
 	  uuid:       12345678-1234-1234-1234-123456789abc
 	  name:       <SERVICE_NAME>
 	  domains:
-	  - fqdn:     <SERVICE_NAME>.ukp-staging.unikraft.internal
+	  - fqdn:     <SERVICE_NAME>.unikraft.internal
 	  - fqdn:     <DOMAIN>.unikraft.internal
 	networks:
 	- uuid:       12345678-1234-1234-1234-123456789abc


### PR DESCRIPTION
Removes references to staging/stable in the output.

Split from https://github.com/unikraft/cli/pull/266, it makes it a bit neater.