### PR TITLE
fix: Defer opening buildkit client until use

### DIFF
--- a/internal/builder/build.go
+++ b/internal/builder/build.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/containerd/platforms"
-	"github.com/moby/buildkit/client"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	imagespec "unikraft.com/x/image-spec"
 
@@ -55,7 +54,7 @@ const (
 )
 
 // Build a unikraft image based on the provided build options.
-func Build(ctx context.Context, opts BuildOpts, c *client.Client) ([]*imagespec.Image, error) {
+func Build(ctx context.Context, opts BuildOpts) ([]*imagespec.Image, error) {
 	kernels, err := BuildKernel(ctx, opts)
 	if err != nil {
 		return nil, err
@@ -100,7 +99,7 @@ func Build(ctx context.Context, opts BuildOpts, c *client.Client) ([]*imagespec.
 		return images, nil
 	}
 
-	roots, err := BuildRootfs(ctx, c, opts)
+	roots, err := BuildRootfs(ctx, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/builder/build_test.go
+++ b/internal/builder/build_test.go
@@ -281,8 +281,9 @@ func runBuild(t *testing.T, ctx context.Context, opts BuildOpts) []*imagespec.Im
 	if cleanup != nil {
 		t.Cleanup(cleanup)
 	}
+	ctx = buildkit.WithBuildkitContext(ctx, bkc)
 
-	imgs, err := Build(ctx, opts, bkc)
+	imgs, err := Build(ctx, opts)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		for _, img := range imgs {

--- a/internal/builder/rootfs.go
+++ b/internal/builder/rootfs.go
@@ -30,6 +30,7 @@ import (
 
 	"unikraft.com/cli/internal/builder/cpio"
 	"unikraft.com/cli/internal/builder/erofs"
+	"unikraft.com/cli/internal/buildkit"
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/images"
 	"unikraft.com/x/kraftfile"
@@ -39,7 +40,7 @@ type Rootfs struct {
 	File *os.File
 }
 
-func BuildRootfs(ctx context.Context, c *client.Client, opts BuildOpts) (_ []*imagespec.Image, rerr error) {
+func BuildRootfs(ctx context.Context, opts BuildOpts) (_ []*imagespec.Image, rerr error) {
 	if len(opts.Platform) == 0 {
 		return nil, fmt.Errorf("at least one platform must be specified")
 	}
@@ -86,6 +87,14 @@ func BuildRootfs(ctx context.Context, c *client.Client, opts BuildOpts) (_ []*im
 		LocalDirs:     localDirs,
 		Frontend:      "dockerfile.v0",
 		FrontendAttrs: attrs,
+	}
+
+	c, cleanup, err := buildkit.ConnectToBuildkit(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if cleanup != nil {
+		defer cleanup()
 	}
 
 	pw, err := progresswriter.NewPrinter(context.WithoutCancel(ctx), os.Stderr, "auto")

--- a/internal/buildkit/connect.go
+++ b/internal/buildkit/connect.go
@@ -25,6 +25,10 @@ import (
 )
 
 func ConnectToBuildkit(ctx context.Context) (c *client.Client, cleanup func(), rerr error) {
+	if c = BuildkitFromContext(ctx); c != nil {
+		return c, func() {}, nil
+	}
+
 	var buildkitInfo *client.Info
 	var buildkitAddr string
 

--- a/internal/buildkit/context.go
+++ b/internal/buildkit/context.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The KraftKit Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package buildkit
+
+import (
+	"context"
+
+	"github.com/moby/buildkit/client"
+)
+
+type buildkitContextKey struct{}
+
+func WithBuildkitContext(ctx context.Context, c *client.Client) context.Context {
+	return context.WithValue(ctx, buildkitContextKey{}, c)
+}
+
+func BuildkitFromContext(ctx context.Context) *client.Client {
+	if c, ok := ctx.Value(buildkitContextKey{}).(*client.Client); ok {
+		return c
+	}
+	return nil
+}

--- a/internal/cmd/build.go
+++ b/internal/cmd/build.go
@@ -10,7 +10,6 @@ import (
 
 	"golang.org/x/mod/semver"
 	"unikraft.com/cli/internal/builder"
-	"unikraft.com/cli/internal/buildkit"
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/images"
 	imagespec "unikraft.com/x/image-spec"
@@ -108,15 +107,7 @@ func (c *BuildCmd) Run(ctx context.Context, cfg *config.Config) error {
 		buildOpts.Rootfs.SSH = ssh
 	}
 
-	bkc, cleanup, err := buildkit.ConnectToBuildkit(ctx)
-	if err != nil {
-		return err
-	}
-	if cleanup != nil {
-		defer cleanup()
-	}
-
-	imgs, err := builder.Build(ctx, buildOpts, bkc)
+	imgs, err := builder.Build(ctx, buildOpts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We should defer opening buildkit until right before we need to use it.

However, we add the context helpers so that we can still inject it for the purposes of testing.

e.g. with this code path https://github.com/unikraft/cli/pull/253, we don't need a buildkit, so we should avoid opening the client.