### PR TITLE
feat: Improved arg splitting

### DIFF
--- a/cmd/unikraft/testdata/TestGolden/auth/flow
+++ b/cmd/unikraft/testdata/TestGolden/auth/flow
@@ -7,7 +7,7 @@ $ unikraft profile list
 
 stdout:
 	NAME     ACTIVE  METROS
-	default  true    test
+	default  true    ["test"]
 
 $ unikraft metro list
 

--- a/cmd/unikraft/testdata/TestGolden/images/copy-inspect-delete
+++ b/cmd/unikraft/testdata/TestGolden/images/copy-inspect-delete
@@ -7,7 +7,7 @@ stdout:
 	digest:                           sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
 	config:
 	  platform:                       kraftcloud/x86_64
-	  cmd:                            /usr/bin/nginx,-c,/etc/nginx/nginx.conf
+	  cmd:                            ["/usr/bin/nginx", "-c", "/etc/nginx/nginx.conf"]
 	  env:
 	metadata:
 	  created:                        YYYY-MM-DD HH:MM:SS +0000 UTC

--- a/cmd/unikraft/testdata/TestGolden/images/inspect
+++ b/cmd/unikraft/testdata/TestGolden/images/inspect
@@ -5,7 +5,7 @@ stdout:
 	digest:                           sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890
 	config:
 	  platform:                       kraftcloud/x86_64
-	  cmd:                            /usr/bin/nginx,-c,/etc/nginx/nginx.conf
+	  cmd:                            ["/usr/bin/nginx", "-c", "/etc/nginx/nginx.conf"]
 	  env:
 	metadata:
 	  created:                        YYYY-MM-DD HH:MM:SS +0000 UTC

--- a/cmd/unikraft/testdata/TestGolden/instances/edit
+++ b/cmd/unikraft/testdata/TestGolden/instances/edit
@@ -17,7 +17,7 @@ stdout:
 	state:        stopped
 	image:        redis
 	runtime:
-	  args:       after,second
+	  args:       ["after,second"]
 	  env:
 	    A:        3
 	    B:        4

--- a/internal/cmd/instance_templates.go
+++ b/internal/cmd/instance_templates.go
@@ -85,7 +85,7 @@ type InstanceTemplate struct {
 	Image types.ImageRef[reference.Named] `mirror:"instance.image" field:",short"`
 
 	Runtime struct {
-		Args []string          `mirror:"instance.args" field:",short"`
+		Args InstanceArgs      `mirror:"instance.args" field:",short"`
 		Env  map[string]string `mirror:"instance.env" field:",long"`
 	}
 

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -19,6 +19,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/distribution/reference"
 	"github.com/google/uuid"
+	"mvdan.cc/sh/v3/shell"
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/cloud/sdk/platform/group"
 	"unikraft.com/cloud/sdk/platform/stop"
@@ -68,8 +69,8 @@ type InstanceCreateCmd struct {
 
 	Image string `group:"flag-create" shortcut:"image" help:"Image to deploy." placeholder:"<name>:<tag>" example:"nginx:latest,my-app:v1.2.3"`
 
-	Args []string `group:"flag-create" shortcut:"runtime.args" help:"Arguments to pass to the instance." placeholder:"arg"`
-	Env  []string `group:"flag-create" shortcut:"runtime.env" short:"e" help:"Environment variables." placeholder:"<key>=<value>" example:"DEBUG=true,PORT=8080"`
+	Args InstanceArgs `group:"flag-create" shortcut:"runtime.args" help:"Arguments to pass to the instance." placeholder:"arg"`
+	Env  []string     `group:"flag-create" shortcut:"runtime.env" short:"e" help:"Environment variables." placeholder:"<key>=<value>" example:"DEBUG=true,PORT=8080"`
 
 	Memory types.SizeMebibytes `group:"flag-create" shortcut:"resources.memory" short:"m" help:"Memory allocation." placeholder:"size" example:"128MiB,1GiB"`
 	Vcpus  int                 `group:"flag-create" shortcut:"resources.vcpus" help:"Number of vCPUs." placeholder:"n" example:"1,2,4"`
@@ -107,8 +108,8 @@ type InstanceEditCmd struct {
 	// Shortcut flags - only fields that support editing.
 	Image string `group:"flag-edit" shortcut:"image" help:"Image to deploy." placeholder:"<name>:<tag>" example:"nginx:latest,my-app:v1.2.3"`
 
-	Args []string `group:"flag-edit" shortcut:"runtime.args" help:"Arguments to pass to the instance." placeholder:"arg"`
-	Env  []string `group:"flag-edit" shortcut:"runtime.env" short:"e" help:"Environment variables." placeholder:"<key>=<value>" example:"DEBUG=true,PORT=8080"`
+	Args InstanceArgs `group:"flag-edit" shortcut:"runtime.args" help:"Arguments to pass to the instance." placeholder:"arg"`
+	Env  []string     `group:"flag-edit" shortcut:"runtime.env" short:"e" help:"Environment variables." placeholder:"<key>=<value>" example:"DEBUG=true,PORT=8080"`
 
 	Memory types.SizeMebibytes `group:"flag-edit" shortcut:"resources.memory" short:"m" help:"Memory allocation." placeholder:"size" example:"128MiB,1GiB"`
 	Vcpus  int                 `group:"flag-edit" shortcut:"resources.vcpus" help:"Number of vCPUs." placeholder:"n" example:"1,2,4"`
@@ -135,7 +136,7 @@ type Instance struct {
 	Image types.ImageRef[reference.Named] `mirror:"instance.image" field:",short" create:"set" edit:"set"`
 
 	Runtime struct {
-		Args []string          `mirror:"instance.args" field:",short" create:"set" edit:"set"`
+		Args InstanceArgs      `mirror:"instance.args" field:",short" create:"set" edit:"set"`
 		Env  map[string]string `mirror:"instance.env" field:",long" create:"set" edit:"set,add,del=keys"`
 	}
 
@@ -393,6 +394,47 @@ func (s InstanceScaleToZero) MarshalText() ([]byte, error) {
 func (s InstanceScaleToZero) MarshalJSON() ([]byte, error) {
 	type scaleToZeroJSON InstanceScaleToZero
 	return json.Marshal(scaleToZeroJSON(s))
+}
+
+// InstanceArgs is a []string type that uses shell-style word splitting when
+// unmarshaling from a string.
+type InstanceArgs []string
+
+func (a *InstanceArgs) UnmarshalText(data []byte) error {
+	s := string(data)
+	if s == "" {
+		*a = nil
+		return nil
+	}
+	if data[0] == '[' {
+		var s []string
+		if err := json.Unmarshal(data, &s); err != nil {
+			return err
+		}
+		*a = s
+		return nil
+	}
+	fields, err := shell.Fields(s, func(string) string { return "" })
+	if err != nil {
+		return fmt.Errorf("parsing args: %w", err)
+	}
+	*a = fields
+	return nil
+}
+
+func (a *InstanceArgs) UnmarshalJSON(data []byte) error {
+	// Try as JSON array first.
+	var arr []string
+	if err := json.Unmarshal(data, &arr); err == nil {
+		*a = arr
+		return nil
+	}
+	// Fall back to JSON string → shell split.
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	return a.UnmarshalText([]byte(s))
 }
 
 func (Instance) Type() resource.Type {
@@ -687,7 +729,7 @@ func instancePatchSpec(path string, op patchOp, value any) (platform.UpdateInsta
 	case "image":
 		return platform.UpdateInstancesRequestItemPropImage, value.(types.ImageRef[reference.Named]).Reference.String()
 	case "runtime.args":
-		return platform.UpdateInstancesRequestItemPropArgs, value.([]string)
+		return platform.UpdateInstancesRequestItemPropArgs, []string(value.(InstanceArgs))
 	case "runtime.env":
 		if op == patchOpDel {
 			return platform.UpdateInstancesRequestItemPropEnv, value.([]string)
@@ -736,7 +778,7 @@ func (Instance) Create(ctx context.Context, fields []resource.Field) ([]resource
 		case "image":
 			req.Image = new(field.Create.Set.(types.ImageRef[reference.Named]).Reference.String())
 		case "runtime.args":
-			req.Args = field.Create.Set.([]string)
+			req.Args = []string(field.Create.Set.(InstanceArgs))
 		case "runtime.env":
 			req.Env = field.Create.Set.(map[string]string)
 		case "resources.memory":

--- a/internal/resource/cmd/shortcuts.go
+++ b/internal/resource/cmd/shortcuts.go
@@ -7,6 +7,7 @@ package cmd
 
 import (
 	"cmp"
+	"encoding"
 	"fmt"
 	"reflect"
 
@@ -49,8 +50,14 @@ func ApplyShortcutFlags(args *SetArgs, flags []*kong.Flag) error {
 			fv = fv.Elem()
 		}
 
-		// Slice fields produce one --set entry per element.
-		if fv.Kind() == reflect.Slice {
+		// Slice fields produce one --set entry per element, unless the
+		// type implements TextUnmarshaler (meaning the slice is a single
+		// logical value, like InstanceArgs).
+		isTextUnmarshaler := false
+		if fv.CanAddr() {
+			_, isTextUnmarshaler = fv.Addr().Interface().(encoding.TextUnmarshaler)
+		}
+		if fv.Kind() == reflect.Slice && !isTextUnmarshaler {
 			for j := range fv.Len() {
 				elem := fv.Index(j)
 				// If the element is addressable, take its address to allow

--- a/internal/resource/value/format.go
+++ b/internal/resource/value/format.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/ettle/strcase"
@@ -56,9 +57,15 @@ func Format(value any) (string, error) {
 			if err != nil {
 				return "", err
 			}
+			if val.Kind() == reflect.String {
+				valStr = strconv.Quote(valStr)
+			}
 			result = append(result, valStr)
 		}
-		return strings.Join(result, ","), nil
+		if len(result) == 0 {
+			return "", nil
+		}
+		return "[" + strings.Join(result, ", ") + "]", nil
 	case reflect.Map:
 		var result []string
 		for _, key := range v.MapKeys() {
@@ -74,7 +81,7 @@ func Format(value any) (string, error) {
 			result = append(result, fmt.Sprintf("%s=%s", keyStr, valStr))
 		}
 		slices.Sort(result)
-		return strings.Join(result, ","), nil
+		return strings.Join(result, ", "), nil
 	case reflect.Struct:
 		var result []string
 		for i := range v.NumField() {
@@ -102,7 +109,7 @@ func Format(value any) (string, error) {
 			}
 			result = append(result, fmt.Sprintf("%s=%s", name, valStr))
 		}
-		return strings.Join(result, ","), nil
+		return strings.Join(result, ", "), nil
 	default:
 		return fmt.Sprintf("%v", value), nil
 	}

--- a/internal/resource/value/format_test.go
+++ b/internal/resource/value/format_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package value
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormat(t *testing.T) {
+	type s struct {
+		Name  string `name:"name"`
+		Value string `name:"value"`
+	}
+
+	tests := []struct {
+		name  string
+		input any
+		want  string
+	}{
+		{
+			name:  "string",
+			input: "hello",
+			want:  "hello",
+		},
+		{
+			name:  "int",
+			input: 42,
+			want:  "42",
+		},
+		{
+			name:  "bool",
+			input: true,
+			want:  "true",
+		},
+		{
+			name:  "nil",
+			input: nil,
+			want:  "",
+		},
+		{
+			name:  "slice",
+			input: []string{"foo", "bar", "baz"},
+			want:  `["foo", "bar", "baz"]`,
+		},
+		{
+			name:  "slice single element",
+			input: []string{"foo"},
+			want:  `["foo"]`,
+		},
+		{
+			name:  "slice with spaces in elements",
+			input: []string{"foo bar", "baz"},
+			want:  `["foo bar", "baz"]`,
+		},
+		{
+			name:  "empty slice",
+			input: []string{},
+			want:  "",
+		},
+		{
+			name:  "map",
+			input: map[string]string{"a": "1", "b": "2"},
+			want:  "a=1, b=2",
+		},
+		{
+			name:  "empty map",
+			input: map[string]string{},
+			want:  "",
+		},
+		{
+			name:  "struct",
+			input: s{Name: "hello", Value: "world"},
+			want:  "name=hello, value=world",
+		},
+		{
+			name:  "struct partial",
+			input: s{Name: "hello"},
+			want:  "name=hello",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Format(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/resource/value/parse.go
+++ b/internal/resource/value/parse.go
@@ -7,6 +7,7 @@ package value
 
 import (
 	"encoding"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -107,7 +108,21 @@ func parseReflect(input []string, value reflect.Value) error {
 	case reflect.Slice:
 		slice := reflect.MakeSlice(output.Type(), 0, 0)
 		for _, input := range input {
+			// Try JSON array syntax first.
+			trimmed := strings.TrimSpace(input)
+			if strings.HasPrefix(trimmed, "[") {
+				target := reflect.New(output.Type())
+				if err := json.Unmarshal([]byte(trimmed), target.Interface()); err == nil {
+					slice = reflect.AppendSlice(slice, target.Elem())
+					continue
+				}
+			}
+			// Fall back to comma-separated parsing.
 			for item := range strings.SplitSeq(input, ",") {
+				item = strings.TrimSpace(item)
+				if item == "" {
+					continue
+				}
 				val := reflect.New(output.Type().Elem()).Elem()
 				err := parseReflect([]string{item}, val)
 				if err != nil {
@@ -121,7 +136,21 @@ func parseReflect(input []string, value reflect.Value) error {
 	case reflect.Map:
 		mapp := reflect.MakeMap(output.Type())
 		for _, input := range input {
+			// Try JSON object syntax first.
+			trimmed := strings.TrimSpace(input)
+			if strings.HasPrefix(trimmed, "{") {
+				target := reflect.New(output.Type())
+				if err := json.Unmarshal([]byte(trimmed), target.Interface()); err == nil {
+					iter := target.Elem().MapRange()
+					for iter.Next() {
+						mapp.SetMapIndex(iter.Key(), iter.Value())
+					}
+					continue
+				}
+			}
+			// Fall back to comma-separated key=value parsing.
 			for item := range strings.SplitSeq(input, ",") {
+				item = strings.TrimSpace(item)
 				if item == "" {
 					continue
 				}
@@ -144,6 +173,19 @@ func parseReflect(input []string, value reflect.Value) error {
 	case reflect.Struct:
 		s := reflect.New(output.Type()).Elem()
 
+		// Try JSON object syntax if single input starting with {.
+		if len(input) == 1 {
+			trimmed := strings.TrimSpace(input[0])
+			if strings.HasPrefix(trimmed, "{") {
+				target := reflect.New(output.Type())
+				if err := json.Unmarshal([]byte(trimmed), target.Interface()); err == nil {
+					output.Set(target.Elem())
+					return nil
+				}
+			}
+		}
+
+		// Fall back to comma-separated key=value parsing.
 		notFound := make(map[string]struct{})
 		for _, input := range input {
 		process:

--- a/internal/resource/value/parse_test.go
+++ b/internal/resource/value/parse_test.go
@@ -115,6 +115,60 @@ func TestParseJSON(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, testStruct{Name: "hello", Value: 42}, got)
 	})
+
+	t.Run("slice with escaped quotes", func(t *testing.T) {
+		got, err := Parse[[]string]([]string{`["say \"hello\"", "world"]`})
+		require.NoError(t, err)
+		assert.Equal(t, []string{`say "hello"`, "world"}, got)
+	})
+
+	t.Run("slice with backslashes", func(t *testing.T) {
+		got, err := Parse[[]string]([]string{`["C:\\Users\\test", "foo\\bar"]`})
+		require.NoError(t, err)
+		assert.Equal(t, []string{`C:\Users\test`, `foo\bar`}, got)
+	})
+
+	t.Run("slice with newlines and tabs", func(t *testing.T) {
+		got, err := Parse[[]string]([]string{`["line1\nline2", "col1\tcol2"]`})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"line1\nline2", "col1\tcol2"}, got)
+	})
+
+	t.Run("slice with unicode escapes", func(t *testing.T) {
+		got, err := Parse[[]string]([]string{`["\u0048ello", "\u0057orld"]`})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"Hello", "World"}, got)
+	})
+
+	t.Run("slice with mixed escaped characters", func(t *testing.T) {
+		got, err := Parse[[]string]([]string{`["he said \"hi\\there\"\nok"]`})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"he said \"hi\\there\"\nok"}, got)
+	})
+
+	t.Run("map with escaped quotes in keys and values", func(t *testing.T) {
+		got, err := Parse[map[string]string]([]string{`{"k\"ey": "val\"ue"}`})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{`k"ey`: `val"ue`}, got)
+	})
+
+	t.Run("map with backslashes in values", func(t *testing.T) {
+		got, err := Parse[map[string]string]([]string{`{"path": "C:\\Users\\test"}`})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"path": `C:\Users\test`}, got)
+	})
+
+	t.Run("map with newlines in values", func(t *testing.T) {
+		got, err := Parse[map[string]string]([]string{`{"msg": "line1\nline2"}`})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"msg": "line1\nline2"}, got)
+	})
+
+	t.Run("struct with escaped quotes", func(t *testing.T) {
+		got, err := Parse[testStruct]([]string{`{"name": "say \"hi\"", "value": 1}`})
+		require.NoError(t, err)
+		assert.Equal(t, testStruct{Name: `say "hi"`, Value: 1}, got)
+	})
 }
 
 func TestParseCSV(t *testing.T) {
@@ -182,5 +236,65 @@ func TestParseCSV(t *testing.T) {
 		got, err := Parse[testStruct]([]string{"name=hello,value=42"})
 		require.NoError(t, err)
 		assert.Equal(t, testStruct{Name: "hello", Value: 42}, got)
+	})
+
+	t.Run("slice with quotes in values", func(t *testing.T) {
+		got, err := Parse[[]string]([]string{`say "hello"`, `it's fine`})
+		require.NoError(t, err)
+		assert.Equal(t, []string{`say "hello"`, `it's fine`}, got)
+	})
+
+	t.Run("slice with backslashes", func(t *testing.T) {
+		got, err := Parse[[]string]([]string{`C:\Users\test`})
+		require.NoError(t, err)
+		assert.Equal(t, []string{`C:\Users\test`}, got)
+	})
+
+	t.Run("slice with equals signs", func(t *testing.T) {
+		got, err := Parse[[]string]([]string{"a=b,c=d"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"a=b", "c=d"}, got)
+	})
+
+	t.Run("slice with only whitespace items", func(t *testing.T) {
+		got, err := Parse[[]string]([]string{" , , "})
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("map value with equals signs", func(t *testing.T) {
+		got, err := Parse[map[string]string]([]string{"key=a=b=c"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"key": "a=b=c"}, got)
+	})
+
+	t.Run("map value with quotes", func(t *testing.T) {
+		got, err := Parse[map[string]string]([]string{`key=say "hello"`})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"key": `say "hello"`}, got)
+	})
+
+	t.Run("map value with backslashes", func(t *testing.T) {
+		got, err := Parse[map[string]string]([]string{`path=C:\Users\test`})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"path": `C:\Users\test`}, got)
+	})
+
+	t.Run("map key with no value", func(t *testing.T) {
+		got, err := Parse[map[string]string]([]string{"key="})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"key": ""}, got)
+	})
+
+	t.Run("map key with no equals", func(t *testing.T) {
+		got, err := Parse[map[string]string]([]string{"key"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"key": ""}, got)
+	})
+
+	t.Run("struct with spaces in value", func(t *testing.T) {
+		got, err := Parse[testStruct]([]string{"name=hello world,value=42"})
+		require.NoError(t, err)
+		assert.Equal(t, testStruct{Name: "hello world", Value: 42}, got)
 	})
 }

--- a/internal/resource/value/parse_test.go
+++ b/internal/resource/value/parse_test.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package value
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testStruct struct {
+	Name  string `name:"name" json:"name"`
+	Value int    `name:"value" json:"value"`
+}
+
+func TestParseStandalone(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		got, err := Parse[string]([]string{"hello"})
+		require.NoError(t, err)
+		assert.Equal(t, "hello", got)
+	})
+
+	t.Run("int", func(t *testing.T) {
+		got, err := Parse[int]([]string{"42"})
+		require.NoError(t, err)
+		assert.Equal(t, 42, got)
+	})
+
+	t.Run("bool", func(t *testing.T) {
+		got, err := Parse[bool]([]string{"true"})
+		require.NoError(t, err)
+		assert.True(t, got)
+	})
+
+	t.Run("float", func(t *testing.T) {
+		got, err := Parse[float64]([]string{"3.14"})
+		require.NoError(t, err)
+		assert.InDelta(t, 3.14, got, 1e-10)
+	})
+
+	t.Run("empty slice input", func(t *testing.T) {
+		got, err := Parse[[]string]([]string{})
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("nil input", func(t *testing.T) {
+		got, err := Parse[string](nil)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+}
+
+func TestParseJSON(t *testing.T) {
+	t.Run("slice", func(t *testing.T) {
+		got, err := Parse[[]string]([]string{`["foo", "bar"]`})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo", "bar"}, got)
+	})
+
+	t.Run("slice with commas in values", func(t *testing.T) {
+		got, err := Parse[[]string]([]string{`["foo,bar", "baz"]`})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo,bar", "baz"}, got)
+	})
+
+	t.Run("slice combined with csv", func(t *testing.T) {
+		got, err := Parse[[]string]([]string{`["foo", "bar"]`, "baz,qux"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo", "bar", "baz", "qux"}, got)
+	})
+
+	t.Run("int slice", func(t *testing.T) {
+		got, err := Parse[[]int]([]string{`[1, 2, 3]`})
+		require.NoError(t, err)
+		assert.Equal(t, []int{1, 2, 3}, got)
+	})
+
+	t.Run("empty array", func(t *testing.T) {
+		got, err := Parse[[]string]([]string{"[]"})
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("map", func(t *testing.T) {
+		got, err := Parse[map[string]string]([]string{`{"a": "1", "b": "2"}`})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"a": "1", "b": "2"}, got)
+	})
+
+	t.Run("map with commas in values", func(t *testing.T) {
+		got, err := Parse[map[string]string]([]string{`{"key": "a,b,c"}`})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"key": "a,b,c"}, got)
+	})
+
+	t.Run("map combined with csv", func(t *testing.T) {
+		got, err := Parse[map[string]string]([]string{`{"a": "1"}`, "b=2"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"a": "1", "b": "2"}, got)
+	})
+
+	t.Run("empty object", func(t *testing.T) {
+		got, err := Parse[map[string]string]([]string{"{}"})
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("struct", func(t *testing.T) {
+		got, err := Parse[testStruct]([]string{`{"name": "hello", "value": 42}`})
+		require.NoError(t, err)
+		assert.Equal(t, testStruct{Name: "hello", Value: 42}, got)
+	})
+}
+
+func TestParseCSV(t *testing.T) {
+	t.Run("slice single", func(t *testing.T) {
+		got, err := Parse[[]string]([]string{"foo"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo"}, got)
+	})
+
+	t.Run("slice comma-separated", func(t *testing.T) {
+		got, err := Parse[[]string]([]string{"foo,bar"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo", "bar"}, got)
+	})
+
+	t.Run("slice multiple inputs", func(t *testing.T) {
+		got, err := Parse[[]string]([]string{"foo,bar", "baz,qux"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo", "bar", "baz", "qux"}, got)
+	})
+
+	t.Run("slice spaces trimmed", func(t *testing.T) {
+		got, err := Parse[[]string]([]string{"foo, bar, baz"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo", "bar", "baz"}, got)
+	})
+
+	t.Run("slice empty items skipped", func(t *testing.T) {
+		got, err := Parse[[]string]([]string{",foo,,bar,"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"foo", "bar"}, got)
+	})
+
+	t.Run("map single pair", func(t *testing.T) {
+		got, err := Parse[map[string]string]([]string{"key=value"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"key": "value"}, got)
+	})
+
+	t.Run("map multiple pairs", func(t *testing.T) {
+		got, err := Parse[map[string]string]([]string{"a=1,b=2"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"a": "1", "b": "2"}, got)
+	})
+
+	t.Run("map multiple inputs", func(t *testing.T) {
+		got, err := Parse[map[string]string]([]string{"a=1", "b=2"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"a": "1", "b": "2"}, got)
+	})
+
+	t.Run("map spaces trimmed", func(t *testing.T) {
+		got, err := Parse[map[string]string]([]string{"a=1, b=2"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"a": "1", "b": "2"}, got)
+	})
+
+	t.Run("map empty items skipped", func(t *testing.T) {
+		got, err := Parse[map[string]string]([]string{",a=1,,b=2,"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"a": "1", "b": "2"}, got)
+	})
+
+	t.Run("struct", func(t *testing.T) {
+		got, err := Parse[testStruct]([]string{"name=hello,value=42"})
+		require.NoError(t, err)
+		assert.Equal(t, testStruct{Name: "hello", Value: 42}, got)
+	})
+}


### PR DESCRIPTION
Fixes https://linear.app/unikraft/issue/TOOL-682/split-instance-args-in-cli.

When specified something like `--args "echo foo"`, this splits it into `["echo", "foo"]`. However, I noticed that this rendered weirdly, so updated the array-like rendering to use JSON-like formatting instead of CSV formatting, and updated the parser to support this as well, so we keep some level of consistency.