### PR TITLE
fix: Disable detecting containerd snapshotting

### DIFF
--- a/internal/builder/rootfs.go
+++ b/internal/builder/rootfs.go
@@ -209,11 +209,6 @@ func buildRootfsDockerfile(ctx context.Context, opts BuildOpts) (_ []*imagespec.
 	}
 
 	attrs := map[string]string{}
-	// HACK: disabled multi-platform mode due to buildkit symlink bug.
-	// https://github.com/moby/buildkit/issues/6684
-	// if len(opts.Platform) > 0 {
-	// 	attrs["multi-platform"] = "true"
-	// }
 	localDirs := map[string]string{}
 	if err := applyBuildOpts(attrs, localDirs, &session, opts); err != nil {
 		return nil, err

--- a/internal/buildkit/connect.go
+++ b/internal/buildkit/connect.go
@@ -116,21 +116,20 @@ func dockerBuildkit(ctx context.Context) (*client.Client, *client.Info, error) {
 		return nil, nil, fmt.Errorf("creating docker buildkit client: %w", err)
 	}
 
-	// we need features that are *only* supported when the containerd
-	// snapshotter is enabled :(
-	var hasCtrdSnapshotter bool
-	workers, err := c.ListWorkers(ctx)
-	if err != nil {
-		return nil, nil, c.Close()
-	}
-	for _, w := range workers {
-		if _, ok := w.Labels["org.mobyproject.buildkit.worker.snapshotter"]; ok {
-			hasCtrdSnapshotter = true
-		}
-	}
-	if !hasCtrdSnapshotter {
-		return nil, nil, c.Close()
-	}
+	// NOTE: logic for detecting if the containerd snapshotter is enabled
+	// var hasCtrdSnapshotter bool
+	// workers, err := c.ListWorkers(ctx)
+	// if err != nil {
+	// 	return nil, nil, c.Close()
+	// }
+	// for _, w := range workers {
+	// 	if _, ok := w.Labels["org.mobyproject.buildkit.worker.snapshotter"]; ok {
+	// 		hasCtrdSnapshotter = true
+	// 	}
+	// }
+	// if !hasCtrdSnapshotter {
+	// 	return nil, nil, c.Close()
+	// }
 
 	info, err := c.Info(ctx)
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/unikraft/cli/issues/288.

We don't actually use these features for buildkit anymore. I think we originally needed them for multi-platform... but we're not using that anyways due to a buildkit bug.

