### PR TITLE
fix(build): Always use cpio as default

### DIFF
--- a/internal/builder/rootfs.go
+++ b/internal/builder/rootfs.go
@@ -174,14 +174,9 @@ func buildRootfsPackaged(_ context.Context, opts BuildOpts) (_ []*imagespec.Imag
 func buildRootfsDirectory(ctx context.Context, opts BuildOpts) (_ []*imagespec.Image, rerr error) {
 	cfg := buildImageConfig(opts)
 
-	format := opts.Rootfs.Format
-	if format == "" {
-		format = kraftfile.FsTypeErofs
-	}
-
 	var imgs []*imagespec.Image
 	for _, p := range opts.Platform {
-		f, err := os.CreateTemp("", "unikraft-rootfs-*."+string(format))
+		f, err := os.CreateTemp("", "unikraft-rootfs-*."+string(opts.Rootfs.Format))
 		if err != nil {
 			return nil, fmt.Errorf("could not create temporary file: %w", err)
 		}
@@ -192,7 +187,7 @@ func buildRootfsDirectory(ctx context.Context, opts BuildOpts) (_ []*imagespec.I
 			}
 		}()
 
-		if err := packageRootfs(ctx, format, f, os.DirFS(opts.Rootfs.Path), opts); err != nil {
+		if err := packageRootfs(ctx, opts.Rootfs.Format, f, os.DirFS(opts.Rootfs.Path), opts); err != nil {
 			return nil, err
 		}
 
@@ -210,11 +205,6 @@ func buildRootfsDirectory(ctx context.Context, opts BuildOpts) (_ []*imagespec.I
 func buildRootfsTarball(ctx context.Context, opts BuildOpts) (_ []*imagespec.Image, rerr error) {
 	cfg := buildImageConfig(opts)
 
-	format := opts.Rootfs.Format
-	if format == "" {
-		format = kraftfile.FsTypeErofs
-	}
-
 	tarFile, err := os.Open(opts.Rootfs.Path)
 	if err != nil {
 		return nil, fmt.Errorf("could not open tarball: %w", err)
@@ -228,7 +218,7 @@ func buildRootfsTarball(ctx context.Context, opts BuildOpts) (_ []*imagespec.Ima
 
 	var imgs []*imagespec.Image
 	for _, p := range opts.Platform {
-		f, err := os.CreateTemp("", "unikraft-rootfs-*."+string(format))
+		f, err := os.CreateTemp("", "unikraft-rootfs-*."+string(opts.Rootfs.Format))
 		if err != nil {
 			return nil, fmt.Errorf("could not create temporary file: %w", err)
 		}
@@ -239,7 +229,7 @@ func buildRootfsTarball(ctx context.Context, opts BuildOpts) (_ []*imagespec.Ima
 			}
 		}()
 
-		if err := packageRootfs(ctx, format, f, srcFS, opts); err != nil {
+		if err := packageRootfs(ctx, opts.Rootfs.Format, f, srcFS, opts); err != nil {
 			return nil, err
 		}
 

--- a/internal/builder/rootfs_test.go
+++ b/internal/builder/rootfs_test.go
@@ -159,25 +159,6 @@ func TestRootfsDirectory(t *testing.T) {
 	require.Equal(t, "nested\n", files["subdir/nested.txt"])
 }
 
-func TestRootfsDirectoryDefaultFormat(t *testing.T) {
-	dir := writeTestDirectory(t)
-
-	// Format intentionally left empty to test default (erofs).
-	imgs := runBuildRootfs(t, BuildOpts{
-		Rootfs: RootfsOpts{
-			Path: dir,
-			Type: kraftfile.SourceTypeDirectory,
-		},
-		Platform: []ocispec.Platform{{OS: "fc", Architecture: "x86_64"}},
-	})
-	require.Len(t, imgs, 1)
-
-	// Default format is EROFS; verify contents are readable as EROFS.
-	files := readErofsInitrd(t, imgs[0])
-	require.Contains(t, files, "hello.txt")
-	require.Equal(t, "hello\n", files["hello.txt"])
-}
-
 func TestRootfsDirectoryCpioFormat(t *testing.T) {
 	dir := writeTestDirectory(t)
 


### PR DESCRIPTION
Don't use erofs as the default in any circumstances. It should be applied globally, for all the build types, not just for directory sources.

Technically, this was already happening, since the parsed kraftfile always has a format set, but the code should be clearer here.