### PR TITLE
docs: Update flag docs

### DIFF
--- a/cmd/unikraft/testdata/TestGolden/auth/help
+++ b/cmd/unikraft/testdata/TestGolden/auth/help
@@ -173,11 +173,13 @@ stdout:
 
 	Flags:
 	      --filter
-	          Filter output based on a field value (e.g. --filter state==running).
+	          Filter output based on a field value.
+	          [examples: name==my-instance, metro==fra]
 	  -w, --watch=<duration>
 	          Watch for changes and refresh output. Defaults to 2s.
 	      --sort
-	          Sort output by field values (e.g. --sort name,-timestamps.created-at). Use - prefix for descending, + for ascending.
+	          Sort output by field values. Use - prefix for descending, + for ascending.
+	          [examples: name, -timestamps.created-at]
 	  -f, --field
 	          Specify which fields to include in the output.
 	  -o, --output
@@ -397,11 +399,13 @@ stdout:
 
 	Flags:
 	      --filter
-	          Filter output based on a field value (e.g. --filter state==running).
+	          Filter output based on a field value.
+	          [examples: name==my-instance, metro==fra]
 	  -w, --watch=<duration>
 	          Watch for changes and refresh output. Defaults to 2s.
 	      --sort
-	          Sort output by field values (e.g. --sort name,-timestamps.created-at). Use - prefix for descending, + for ascending.
+	          Sort output by field values. Use - prefix for descending, + for ascending.
+	          [examples: name, -timestamps.created-at]
 	  -f, --field
 	          Specify which fields to include in the output.
 	  -o, --output

--- a/cmd/unikraft/testdata/TestGolden/certificates/help
+++ b/cmd/unikraft/testdata/TestGolden/certificates/help
@@ -136,11 +136,13 @@ stdout:
 
 	Flags:
 	      --filter
-	          Filter output based on a field value (e.g. --filter state==running).
+	          Filter output based on a field value.
+	          [examples: name==my-instance, metro==fra]
 	  -w, --watch=<duration>
 	          Watch for changes and refresh output. Defaults to 2s.
 	      --sort
-	          Sort output by field values (e.g. --sort name,-timestamps.created-at). Use - prefix for descending, + for ascending.
+	          Sort output by field values. Use - prefix for descending, + for ascending.
+	          [examples: name, -timestamps.created-at]
 	  -f, --field
 	          Specify which fields to include in the output.
 	  -o, --output
@@ -191,7 +193,8 @@ stdout:
 
 	Flags:
 	      --until, --filter
-	          Filter expression to wait for (e.g. --until state==running).
+	          Filter expression to wait for.
+	          [examples: state==running, state!=stopped]
 	      --interval
 	          Polling interval.
 	          [default: 2s]
@@ -336,7 +339,8 @@ stdout:
 	      --all
 	          Remove all certificates. Prompts for confirmation.
 	      --filter
-	          Filter certificates to remove (e.g. --filter state==running). Prompts for confirmation.
+	          Filter certificates to remove. Prompts for confirmation.
+	          [examples: name==my-instance, metro==fra]
 	      --force
 	          Do not prompt for confirmation when using --all or --filter.
 	  -f, --field

--- a/cmd/unikraft/testdata/TestGolden/images/help
+++ b/cmd/unikraft/testdata/TestGolden/images/help
@@ -117,11 +117,13 @@ stdout:
 
 	Flags:
 	      --filter
-	          Filter output based on a field value (e.g. --filter state==running).
+	          Filter output based on a field value.
+	          [examples: name==my-instance, metro==fra]
 	  -w, --watch=<duration>
 	          Watch for changes and refresh output. Defaults to 2s.
 	      --sort
-	          Sort output by field values (e.g. --sort name,-timestamps.created-at). Use - prefix for descending, + for ascending.
+	          Sort output by field values. Use - prefix for descending, + for ascending.
+	          [examples: name, -timestamps.created-at]
 	  -f, --field
 	          Specify which fields to include in the output.
 	  -o, --output

--- a/cmd/unikraft/testdata/TestGolden/instances/help
+++ b/cmd/unikraft/testdata/TestGolden/instances/help
@@ -191,11 +191,13 @@ stdout:
 
 	Flags:
 	      --filter
-	          Filter output based on a field value (e.g. --filter state==running).
+	          Filter output based on a field value.
+	          [examples: name==my-instance, metro==fra]
 	  -w, --watch=<duration>
 	          Watch for changes and refresh output. Defaults to 2s.
 	      --sort
-	          Sort output by field values (e.g. --sort name,-timestamps.created-at). Use - prefix for descending, + for ascending.
+	          Sort output by field values. Use - prefix for descending, + for ascending.
+	          [examples: name, -timestamps.created-at]
 	  -f, --field
 	          Specify which fields to include in the output.
 	  -o, --output
@@ -259,7 +261,8 @@ stdout:
 
 	Flags:
 	      --until, --filter
-	          Filter expression to wait for (e.g. --until state==running).
+	          Filter expression to wait for.
+	          [examples: state==running, state!=stopped]
 	      --interval
 	          Polling interval.
 	          [default: 2s]
@@ -392,9 +395,9 @@ stdout:
 	      --vcpus=<n>
 	          Number of vCPUs.
 	          [examples: 1, 2, 4]
-	  -v, --volume=<name>:<path>[:<ro>]
+	  -v, --volume=<name>:<path>[:<options>]
 	          Attach volume.
-	          [examples: my-vol:/data, cache:/tmp:ro]
+	          [examples: my-vol:/data, cache:/tmp:ro, data:/mnt:size=10GiB]
 	      --service=<name>
 	          Service group name or key.
 	  -p, --publish=<src>:<dest>[/<handlers>]
@@ -405,7 +408,11 @@ stdout:
 	          [examples: example.com, api.example.com]
 	      --scale-to-zero=<key>=<value>
 	          Scale-to-zero options.
-	          [example: policy=on,cooldown-time=300]
+	            policy: on | off
+	            cooldown-time: cooldown in ms before scaling to zero
+	            notify-time: notification time in ms before scaling to zero
+	            stateful: true | false.
+	          [examples: on, policy=on,cooldown-time=300, policy=on,stateful=true,cooldown-time=500,notify-time=100]
 	      --restart=<policy>
 	          Restart policy.
 	          [examples: always, on-failure, never]
@@ -516,7 +523,11 @@ stdout:
 	          [examples: 1, 2, 4]
 	      --scale-to-zero=<key>=<value>
 	          Scale-to-zero options.
-	          [example: policy=on,cooldown-time=300]
+	            policy: on | off
+	            cooldown-time: cooldown in ms before scaling to zero
+	            notify-time: notification time in ms before scaling to zero
+	            stateful: true | false.
+	          [examples: on, policy=on,cooldown-time=300, policy=on,stateful=true,cooldown-time=500,notify-time=100]
 
 $ unikraft instance delete --help
 
@@ -565,7 +576,8 @@ stdout:
 	      --all
 	          Remove all instances. Prompts for confirmation.
 	      --filter
-	          Filter instances to remove (e.g. --filter state==running). Prompts for confirmation.
+	          Filter instances to remove. Prompts for confirmation.
+	          [examples: name==my-instance, metro==fra]
 	      --force
 	          Do not prompt for confirmation when using --all or --filter.
 	  -f, --field
@@ -734,11 +746,13 @@ stdout:
 
 	Flags:
 	      --filter
-	          Filter output based on a field value (e.g. --filter state==running).
+	          Filter output based on a field value.
+	          [examples: name==my-instance, metro==fra]
 	  -w, --watch=<duration>
 	          Watch for changes and refresh output. Defaults to 2s.
 	      --sort
-	          Sort output by field values (e.g. --sort name,-timestamps.created-at). Use - prefix for descending, + for ascending.
+	          Sort output by field values. Use - prefix for descending, + for ascending.
+	          [examples: name, -timestamps.created-at]
 	  -f, --field
 	          Specify which fields to include in the output.
 	  -o, --output
@@ -938,7 +952,8 @@ stdout:
 	      --all
 	          Remove all instance-templates. Prompts for confirmation.
 	      --filter
-	          Filter instance-templates to remove (e.g. --filter state==running). Prompts for confirmation.
+	          Filter instance-templates to remove. Prompts for confirmation.
+	          [examples: name==my-instance, metro==fra]
 	      --force
 	          Do not prompt for confirmation when using --all or --filter.
 	  -f, --field

--- a/cmd/unikraft/testdata/TestGolden/resources/help
+++ b/cmd/unikraft/testdata/TestGolden/resources/help
@@ -59,7 +59,8 @@ stdout:
 	      --all
 	          Remove all resources. Prompts for confirmation.
 	      --filter
-	          Filter resources to remove (e.g. --filter state==running). Prompts for confirmation.
+	          Filter resources to remove. Prompts for confirmation.
+	          [examples: name==my-instance, metro==fra]
 	      --force
 	          Do not prompt for confirmation when using --all or --filter.
 	  -f, --field

--- a/cmd/unikraft/testdata/TestGolden/services/help
+++ b/cmd/unikraft/testdata/TestGolden/services/help
@@ -135,11 +135,13 @@ stdout:
 
 	Flags:
 	      --filter
-	          Filter output based on a field value (e.g. --filter state==running).
+	          Filter output based on a field value.
+	          [examples: name==my-instance, metro==fra]
 	  -w, --watch=<duration>
 	          Watch for changes and refresh output. Defaults to 2s.
 	      --sort
-	          Sort output by field values (e.g. --sort name,-timestamps.created-at). Use - prefix for descending, + for ascending.
+	          Sort output by field values. Use - prefix for descending, + for ascending.
+	          [examples: name, -timestamps.created-at]
 	  -f, --field
 	          Specify which fields to include in the output.
 	  -o, --output
@@ -189,7 +191,8 @@ stdout:
 
 	Flags:
 	      --until, --filter
-	          Filter expression to wait for (e.g. --until state==running).
+	          Filter expression to wait for.
+	          [examples: state==running, state!=stopped]
 	      --interval
 	          Polling interval.
 	          [default: 2s]
@@ -412,7 +415,8 @@ stdout:
 	      --all
 	          Remove all services. Prompts for confirmation.
 	      --filter
-	          Filter services to remove (e.g. --filter state==running). Prompts for confirmation.
+	          Filter services to remove. Prompts for confirmation.
+	          [examples: name==my-instance, metro==fra]
 	      --force
 	          Do not prompt for confirmation when using --all or --filter.
 	  -f, --field

--- a/cmd/unikraft/testdata/TestGolden/volumes/help
+++ b/cmd/unikraft/testdata/TestGolden/volumes/help
@@ -149,11 +149,13 @@ stdout:
 
 	Flags:
 	      --filter
-	          Filter output based on a field value (e.g. --filter state==running).
+	          Filter output based on a field value.
+	          [examples: name==my-instance, metro==fra]
 	  -w, --watch=<duration>
 	          Watch for changes and refresh output. Defaults to 2s.
 	      --sort
-	          Sort output by field values (e.g. --sort name,-timestamps.created-at). Use - prefix for descending, + for ascending.
+	          Sort output by field values. Use - prefix for descending, + for ascending.
+	          [examples: name, -timestamps.created-at]
 	  -f, --field
 	          Specify which fields to include in the output.
 	  -o, --output
@@ -205,7 +207,8 @@ stdout:
 
 	Flags:
 	      --until, --filter
-	          Filter expression to wait for (e.g. --until state==running).
+	          Filter expression to wait for.
+	          [examples: state==running, state!=stopped]
 	      --interval
 	          Polling interval.
 	          [default: 2s]
@@ -520,7 +523,8 @@ stdout:
 	      --all
 	          Remove all volumes. Prompts for confirmation.
 	      --filter
-	          Filter volumes to remove (e.g. --filter state==running). Prompts for confirmation.
+	          Filter volumes to remove. Prompts for confirmation.
+	          [examples: name==my-instance, metro==fra]
 	      --force
 	          Do not prompt for confirmation when using --all or --filter.
 	  -f, --field

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -75,13 +75,13 @@ type InstanceCreateCmd struct {
 	Memory types.SizeMebibytes `group:"flag-create" shortcut:"resources.memory" short:"m" help:"Memory allocation." placeholder:"size" example:"128MiB,1GiB"`
 	Vcpus  int                 `group:"flag-create" shortcut:"resources.vcpus" help:"Number of vCPUs." placeholder:"n" example:"1,2,4"`
 
-	Volume []InstanceVolume `group:"flag-create" shortcut:"volumes" short:"v" help:"Attach volume." placeholder:"<name>:<path>[:<ro>]" example:"my-vol:/data,cache:/tmp:ro"`
+	Volume []InstanceVolume `group:"flag-create" shortcut:"volumes" short:"v" help:"Attach volume." placeholder:"<name>:<path>[:<options>]" example:"my-vol:/data,cache:/tmp:ro,data:/mnt:size=10GiB"`
 
 	Service InstanceService `group:"flag-create" shortcut:"service" help:"Service group name or key." placeholder:"name"`
 	Publish []Service       `group:"flag-create" shortcut:"service.services" short:"p" help:"Publish port." placeholder:"<src>:<dest>[/<handlers>]" example:"443:8080/http+tls,80:8080/http"`
 	Domain  []Domain        `group:"flag-create" shortcut:"service.domains" help:"Service domain." placeholder:"fqdn" example:"example.com,api.example.com"`
 
-	ScaleToZero InstanceScaleToZero `group:"flag-create" shortcut:"scale-to-zero" help:"Scale-to-zero options." placeholder:"<key>=<value>" example:"policy=on\\,cooldown-time=300"`
+	ScaleToZero InstanceScaleToZero `group:"flag-create" shortcut:"scale-to-zero" help:"Scale-to-zero options.\n  policy: on | off\n  cooldown-time: cooldown in ms before scaling to zero\n  notify-time: notification time in ms before scaling to zero\n  stateful: true | false" placeholder:"<key>=<value>" example:"on,policy=on\\,cooldown-time=300,policy=on\\,stateful=true\\,cooldown-time=500\\,notify-time=100"`
 
 	Restart string `group:"flag-create" shortcut:"restart.policy" help:"Restart policy." placeholder:"policy" example:"always,on-failure,never"`
 
@@ -114,7 +114,7 @@ type InstanceEditCmd struct {
 	Memory types.SizeMebibytes `group:"flag-edit" shortcut:"resources.memory" short:"m" help:"Memory allocation." placeholder:"size" example:"128MiB,1GiB"`
 	Vcpus  int                 `group:"flag-edit" shortcut:"resources.vcpus" help:"Number of vCPUs." placeholder:"n" example:"1,2,4"`
 
-	ScaleToZero InstanceScaleToZero `group:"flag-edit" shortcut:"scale-to-zero" help:"Scale-to-zero options." placeholder:"<key>=<value>" example:"policy=on\\,cooldown-time=300"`
+	ScaleToZero InstanceScaleToZero `group:"flag-edit" shortcut:"scale-to-zero" help:"Scale-to-zero options.\n  policy: on | off\n  cooldown-time: cooldown in ms before scaling to zero\n  notify-time: notification time in ms before scaling to zero\n  stateful: true | false" placeholder:"<key>=<value>" example:"on,policy=on\\,cooldown-time=300,policy=on\\,stateful=true\\,cooldown-time=500\\,notify-time=100"`
 }
 
 func (c *InstanceEditCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox, kctx *kong.Context) error {

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -137,9 +137,9 @@ type FormatOpts struct {
 
 type ResourceListCmd[R resource.GettableListableResource] struct {
 	Targets []string            `arg:"" name:"target" optional:"" completion-predictor:"resource-key-${name}" help:"Target ${names} to list."`
-	Filter  []string            `help:"Filter output based on a field value (e.g. --filter state==running)." sep:"none"`
+	Filter  []string            `help:"Filter output based on a field value." example:"name==my-instance,metro==fra" sep:"none"`
 	Watch   *time.Duration      `short:"w" help:"Watch for changes and refresh output. Defaults to 2s." type:"optional" placeholder:"duration"`
-	Sort    xkong.GreedyStrings `help:"Sort output by field values (e.g. --sort name,-timestamps.created-at). Use - prefix for descending, + for ascending."`
+	Sort    xkong.GreedyStrings `help:"Sort output by field values. Use - prefix for descending, + for ascending." example:"name,-timestamps.created-at"`
 
 	FormatOpts
 
@@ -279,7 +279,7 @@ func (cmd *ResourceGetCmd[R]) Run(ctx context.Context, stdio config.Stdio, sandb
 
 type ResourceWaitCmd[R resource.GettableResource] struct {
 	Targets []string `arg:"" name:"target" completion-predictor:"resource-key-${name}" help:"Target ${names} to wait for."`
-	Until   []string `help:"Filter expression to wait for (e.g. --until state==running)." sep:"none" required:"" aliases:"filter"`
+	Until   []string `help:"Filter expression to wait for." example:"state==running,state!=stopped" sep:"none" required:"" aliases:"filter"`
 
 	Interval time.Duration `long:"interval" default:"2s" help:"Polling interval."`
 	Timeout  time.Duration `long:"timeout" default:"0" help:"Timeout before giving up."`
@@ -564,7 +564,7 @@ type ResourceBulkRemoveCmd[R interface {
 	Targets []string `arg:"" name:"target" optional:"" completion-predictor:"resource-key-${name}" help:"Target ${names} to remove."`
 
 	All    bool     `xor:"select" help:"Remove all ${names}. Prompts for confirmation."`
-	Filter []string `xor:"select" help:"Filter ${names} to remove (e.g. --filter state==running). Prompts for confirmation." sep:"none"`
+	Filter []string `xor:"select" help:"Filter ${names} to remove. Prompts for confirmation." example:"name==my-instance,metro==fra" sep:"none"`
 	Force  bool     `help:"Do not prompt for confirmation when using --all or --filter."`
 
 	FormatOpts


### PR DESCRIPTION
Using "native" kingkong examples, as well as clarifying how filter and scale-to-zero work.

Fixes https://linear.app/unikraft/issue/TOOL-569/filter-until-docs.
Fixes https://linear.app/unikraft/issue/TOOL-501/help-for-scale-to-zero-should-show-the-exact-format-allowed.