### PR TITLE
fix: Ensure links reserialize correctly

### DIFF
--- a/cmd/unikraft/instances_test.go
+++ b/cmd/unikraft/instances_test.go
@@ -253,6 +253,47 @@ func instancesTests(t *testing.T, r *testRunner) {
 			})
 	})
 
+	t.Run("shortcut-service-volume", func(t *testing.T) {
+		r.
+			online().
+			withCleaners(instanceCleaners).
+			run(t, []command{
+				// Create a service group first
+				{args: []string{
+					unikraftCmd, "service", "create",
+					"--output", "quiet",
+					"--set", "name=test-$UNIQ_SVC",
+					"--set", "metro=" + metroName,
+					"--set", "services=443:8080/tls+http",
+				}},
+				// Create a volume
+				{args: []string{
+					unikraftCmd, "volume", "create",
+					"--output", "quiet",
+					"--set", "name=test-$UNIQ_VOL",
+					"--set", "size=20",
+					"--set", "metro=" + metroName,
+				}},
+				// Create an instance using shortcut flags --service and -v
+				// to connect to the existing service and volume
+				{args: []string{
+					unikraftCmd, "instance", "create",
+					"--set", "name=test-$UNIQ_INST",
+					"--set", "metro=" + metroName,
+					"--set", "image=nginx:latest",
+					"--set", "autostart=true",
+					"--set", "resources.memory=128",
+					"--set", "resources.vcpus=1",
+					"--service", "test-$UNIQ_SVC",
+					"-v", "test-$UNIQ_VOL:/mnt",
+				}},
+				{args: []string{unikraftCmd, "instance", "inspect", "test-$UNIQ_INST"}},
+				{args: []string{unikraftCmd, "instance", "delete", "test-$UNIQ_INST"}},
+				{args: []string{unikraftCmd, "volume", "delete", "test-$UNIQ_VOL"}},
+				{args: []string{unikraftCmd, "service", "delete", "test-$UNIQ_SVC"}},
+			})
+	})
+
 	t.Run("autostart", func(t *testing.T) {
 		r.
 			online().

--- a/cmd/unikraft/testdata/TestGolden/instances/connect
+++ b/cmd/unikraft/testdata/TestGolden/instances/connect
@@ -14,11 +14,7 @@ stdout:
 	resources:
 	  memory:     128MiB
 	  vcpus:      1
-	service:
-	  name:       <SERVICE_NAME>
-	  uuid:       12345678-1234-1234-1234-123456789abc
-	  domains:
-	  - fqdn:     <DOMAIN>.unikraft.internal
+	service:      <SERVICE_NAME>
 	networks:
 	- uuid:       12345678-1234-1234-1234-123456789abc
 	  private-ip: 10.X.X.X
@@ -44,11 +40,7 @@ stdout:
 	resources:
 	  memory:     128MiB
 	  vcpus:      1
-	service:
-	  name:       <SERVICE_NAME>
-	  uuid:       12345678-1234-1234-1234-123456789abc
-	  domains:
-	  - fqdn:     <DOMAIN>.unikraft.internal
+	service:      <SERVICE_NAME>
 	networks:
 	- uuid:       12345678-1234-1234-1234-123456789abc
 	  private-ip: 10.X.X.X

--- a/cmd/unikraft/testdata/TestGolden/instances/create
+++ b/cmd/unikraft/testdata/TestGolden/instances/create
@@ -1,7 +1,7 @@
 $ unikraft instance list
 
 stdout:
-	METRO  NAME  STATE  IMAGE  ARGS  MEMORY  VCPUS  FQDN  CREATED
+	METRO  NAME  STATE  IMAGE  ARGS  MEMORY  VCPUS  SERVICE  CREATED
 
 $ unikraft instance create --set name=test-$UNIQ_INST --set metro=test --set image=nginx:latest --set runtime.env=A=1,B=2,C=3 --set autostart=true --set resources.memory=128 --set resources.vcpus=1
 
@@ -29,8 +29,8 @@ stdout:
 $ unikraft instance list
 
 stdout:
-	METRO  NAME               STATE    IMAGE  ARGS  MEMORY  VCPUS  FQDN  CREATED
-	test   test-<INST>  running  nginx        128MiB  1            RELATIVE_TIME
+	METRO  NAME               STATE    IMAGE  ARGS  MEMORY  VCPUS  SERVICE  CREATED
+	test   test-<INST>  running  nginx        128MiB  1               RELATIVE_TIME
 
 $ unikraft instance inspect test-$UNIQ_INST
 
@@ -63,4 +63,4 @@ stdout:
 $ unikraft instance list
 
 stdout:
-	METRO  NAME  STATE  IMAGE  ARGS  MEMORY  VCPUS  FQDN  CREATED
+	METRO  NAME  STATE  IMAGE  ARGS  MEMORY  VCPUS  SERVICE  CREATED

--- a/cmd/unikraft/testdata/TestGolden/instances/help
+++ b/cmd/unikraft/testdata/TestGolden/instances/help
@@ -43,10 +43,7 @@ stdout:
 	  image
 	  runtime, runtime.args, runtime.env
 	  resources, resources.memory, resources.vcpus
-	  service, service.name, service.uuid, service.services, service.domains,
-	  service.domains.*, service.domains.*.fqdn, service.domains.*.certificate,
-	  service.domains.*.certificate.name, service.domains.*.certificate.uuid,
-	  service.soft-limit, service.hard-limit
+	  service
 	  volumes, volumes.*
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped
@@ -103,10 +100,7 @@ stdout:
 	  image
 	  runtime, runtime.args, runtime.env
 	  resources, resources.memory, resources.vcpus
-	  service, service.name, service.uuid, service.services, service.domains,
-	  service.domains.*, service.domains.*.fqdn, service.domains.*.certificate,
-	  service.domains.*.certificate.name, service.domains.*.certificate.uuid,
-	  service.soft-limit, service.hard-limit
+	  service
 	  volumes, volumes.*
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped
@@ -171,10 +165,7 @@ stdout:
 	  image
 	  runtime, runtime.args, runtime.env
 	  resources, resources.memory, resources.vcpus
-	  service, service.name, service.uuid, service.services, service.domains,
-	  service.domains.*, service.domains.*.fqdn, service.domains.*.certificate,
-	  service.domains.*.certificate.name, service.domains.*.certificate.uuid,
-	  service.soft-limit, service.hard-limit
+	  service
 	  volumes, volumes.*
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped
@@ -241,10 +232,7 @@ stdout:
 	  image
 	  runtime, runtime.args, runtime.env
 	  resources, resources.memory, resources.vcpus
-	  service, service.name, service.uuid, service.services, service.domains,
-	  service.domains.*, service.domains.*.fqdn, service.domains.*.certificate,
-	  service.domains.*.certificate.name, service.domains.*.certificate.uuid,
-	  service.soft-limit, service.hard-limit
+	  service
 	  volumes, volumes.*
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped
@@ -324,10 +312,7 @@ stdout:
 	  image
 	  runtime, runtime.args, runtime.env
 	  resources, resources.memory, resources.vcpus
-	  service, service.name, service.uuid, service.services, service.domains,
-	  service.domains.*, service.domains.*.fqdn, service.domains.*.certificate,
-	  service.domains.*.certificate.name, service.domains.*.certificate.uuid,
-	  service.soft-limit, service.hard-limit
+	  service
 	  volumes, volumes.*
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped
@@ -451,10 +436,7 @@ stdout:
 	  image
 	  runtime, runtime.args, runtime.env
 	  resources, resources.memory, resources.vcpus
-	  service, service.name, service.uuid, service.services, service.domains,
-	  service.domains.*, service.domains.*.fqdn, service.domains.*.certificate,
-	  service.domains.*.certificate.name, service.domains.*.certificate.uuid,
-	  service.soft-limit, service.hard-limit
+	  service
 	  volumes, volumes.*
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped
@@ -554,10 +536,7 @@ stdout:
 	  image
 	  runtime, runtime.args, runtime.env
 	  resources, resources.memory, resources.vcpus
-	  service, service.name, service.uuid, service.services, service.domains,
-	  service.domains.*, service.domains.*.fqdn, service.domains.*.certificate,
-	  service.domains.*.certificate.name, service.domains.*.certificate.uuid,
-	  service.soft-limit, service.hard-limit
+	  service
 	  volumes, volumes.*
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped

--- a/cmd/unikraft/testdata/TestGolden/instances/shortcut-service-volume
+++ b/cmd/unikraft/testdata/TestGolden/instances/shortcut-service-volume
@@ -1,4 +1,14 @@
-$ unikraft instance create --set name=test-$UNIQ_INST --set metro=test --set image=nginx:latest --set autostart=true --set resources.memory=128 --set resources.vcpus=1 --set service.services=443:8080/tls+http
+$ unikraft service create --output quiet --set name=test-$UNIQ_SVC --set metro=test --set services=443:8080/tls+http
+
+stdout:
+	test/test-<SVC>
+
+$ unikraft volume create --output quiet --set name=test-$UNIQ_VOL --set size=20 --set metro=test
+
+stdout:
+	test/test-<VOL>
+
+$ unikraft instance create --set name=test-$UNIQ_INST --set metro=test --set image=nginx:latest --set autostart=true --set resources.memory=128 --set resources.vcpus=1 --service test-$UNIQ_SVC -v test-$UNIQ_VOL:/mnt
 
 stdout:
 	metro:        test
@@ -9,20 +19,15 @@ stdout:
 	resources:
 	  memory:     128MiB
 	  vcpus:      1
-	service:      <SERVICE_NAME>
+	service:      test-<SVC>
+	volumes:
+	- test-<VOL>:/mnt
 	networks:
 	- uuid:       12345678-1234-1234-1234-123456789abc
 	  private-ip: 10.X.X.X
 	  mac:        aa:bb:cc:dd:ee:ff
 	timestamps:
 	  created:    RELATIVE_TIME
-
-$ SERVICE_NAME=$(unikraft instance inspect test-$UNIQ_INST --output 'template={{ .service.name }}')
-
-$ unikraft service edit $SERVICE_NAME --output quiet --add domains=name=$UNIQ_DOMAIN
-
-stdout:
-	<SERVICE_NAME>
 
 $ unikraft instance inspect test-$UNIQ_INST
 
@@ -35,7 +40,9 @@ stdout:
 	resources:
 	  memory:     128MiB
 	  vcpus:      1
-	service:      <SERVICE_NAME>
+	service:      test-<SVC>
+	volumes:
+	- test-<VOL>:/mnt
 	networks:
 	- uuid:       12345678-1234-1234-1234-123456789abc
 	  private-ip: 10.X.X.X
@@ -47,3 +54,13 @@ $ unikraft instance delete test-$UNIQ_INST
 
 stdout:
 	test-<INST>
+
+$ unikraft volume delete test-$UNIQ_VOL
+
+stdout:
+	test-<VOL>
+
+$ unikraft service delete test-$UNIQ_SVC
+
+stdout:
+	test-<SVC>

--- a/cmd/unikraft/testdata/TestGolden/services/create
+++ b/cmd/unikraft/testdata/TestGolden/services/create
@@ -17,9 +17,7 @@ stdout:
 	  created:     RELATIVE_TIME
 	domains:
 	- fqdn:        <DOMAIN_A>.unikraft.example
-	  certificate:
-	    name:      <DOMAIN_A>.unikraft.example-xxxxx
-	    uuid:      12345678-1234-1234-1234-123456789abc
+	  certificate: <DOMAIN_A>.unikraft.example-xxxxx
 	services:
 	- 443:8080/tls+http
 	- 80:443/http+redirect
@@ -38,9 +36,7 @@ stdout:
 	  created:     RELATIVE_TIME
 	domains:
 	- fqdn:        <DOMAIN_B>.unikraft.example
-	  certificate:
-	    name:      <DOMAIN_B>.unikraft.example-xxxxx
-	    uuid:      12345678-1234-1234-1234-123456789abc
+	  certificate: <DOMAIN_B>.unikraft.example-xxxxx
 	services:
 	- 443:8080/tls+http
 	- 80:443/http+redirect
@@ -66,9 +62,7 @@ stdout:
 	  created:     RELATIVE_TIME
 	domains:
 	- fqdn:        <DOMAIN_A>.unikraft.example
-	  certificate:
-	    name:      <DOMAIN_A>.unikraft.example-xxxxx
-	    uuid:      12345678-1234-1234-1234-123456789abc
+	  certificate: <DOMAIN_A>.unikraft.example-xxxxx
 	services:
 	- 443:8080/tls+http
 	- 80:443/http+redirect
@@ -84,9 +78,7 @@ stdout:
 	  created:     RELATIVE_TIME
 	domains:
 	- fqdn:        <DOMAIN_B>.unikraft.example
-	  certificate:
-	    name:      <DOMAIN_B>.unikraft.example-xxxxx
-	    uuid:      12345678-1234-1234-1234-123456789abc
+	  certificate: <DOMAIN_B>.unikraft.example-xxxxx
 	services:
 	- 443:8080/tls+http
 	- 80:443/http+redirect

--- a/cmd/unikraft/testdata/TestGolden/services/edit
+++ b/cmd/unikraft/testdata/TestGolden/services/edit
@@ -22,9 +22,7 @@ stdout:
 	  created:     RELATIVE_TIME
 	domains:
 	- fqdn:        <DOMAIN_EDIT>.unikraft.example
-	  certificate:
-	    name:      <DOMAIN_EDIT>.unikraft.example-xxxxx
-	    uuid:      12345678-1234-1234-1234-123456789abc
+	  certificate: <DOMAIN_EDIT>.unikraft.example-xxxxx
 	services:
 	- 1000:2000/tls
 

--- a/cmd/unikraft/testdata/TestGolden/services/help
+++ b/cmd/unikraft/testdata/TestGolden/services/help
@@ -28,9 +28,8 @@ stdout:
 	  autoscale
 	  limits, limits.soft, limits.hard
 	  timestamps, timestamps.created
-	  domains, domains.*, domains.*.fqdn, domains.*.certificate,
-	  domains.*.certificate.name, domains.*.certificate.uuid
-	  instances, instances.*, instances.*.name, instances.*.uuid
+	  domains, domains.*, domains.*.fqdn, domains.*.certificate
+	  instances, instances.*
 	  services, services.*
 
 	Global flags:
@@ -74,9 +73,8 @@ stdout:
 	  autoscale
 	  limits, limits.soft, limits.hard
 	  timestamps, timestamps.created
-	  domains, domains.*, domains.*.fqdn, domains.*.certificate,
-	  domains.*.certificate.name, domains.*.certificate.uuid
-	  instances, instances.*, instances.*.name, instances.*.uuid
+	  domains, domains.*, domains.*.fqdn, domains.*.certificate
+	  instances, instances.*
 	  services, services.*
 
 	Flags:
@@ -128,9 +126,8 @@ stdout:
 	  autoscale
 	  limits, limits.soft, limits.hard
 	  timestamps, timestamps.created
-	  domains, domains.*, domains.*.fqdn, domains.*.certificate,
-	  domains.*.certificate.name, domains.*.certificate.uuid
-	  instances, instances.*, instances.*.name, instances.*.uuid
+	  domains, domains.*, domains.*.fqdn, domains.*.certificate
+	  instances, instances.*
 	  services, services.*
 
 	Flags:
@@ -184,9 +181,8 @@ stdout:
 	  autoscale
 	  limits, limits.soft, limits.hard
 	  timestamps, timestamps.created
-	  domains, domains.*, domains.*.fqdn, domains.*.certificate,
-	  domains.*.certificate.name, domains.*.certificate.uuid
-	  instances, instances.*, instances.*.name, instances.*.uuid
+	  domains, domains.*, domains.*.fqdn, domains.*.certificate
+	  instances, instances.*
 	  services, services.*
 
 	Flags:
@@ -245,9 +241,8 @@ stdout:
 	  autoscale
 	  limits, limits.soft, limits.hard
 	  timestamps, timestamps.created
-	  domains, domains.*, domains.*.fqdn, domains.*.certificate,
-	  domains.*.certificate.name, domains.*.certificate.uuid
-	  instances, instances.*, instances.*.name, instances.*.uuid
+	  domains, domains.*, domains.*.fqdn, domains.*.certificate
+	  instances, instances.*
 	  services, services.*
 
 	Flags:
@@ -326,9 +321,8 @@ stdout:
 	  autoscale
 	  limits, limits.soft, limits.hard
 	  timestamps, timestamps.created
-	  domains, domains.*, domains.*.fqdn, domains.*.certificate,
-	  domains.*.certificate.name, domains.*.certificate.uuid
-	  instances, instances.*, instances.*.name, instances.*.uuid
+	  domains, domains.*, domains.*.fqdn, domains.*.certificate
+	  instances, instances.*
 	  services, services.*
 
 	Flags:
@@ -406,9 +400,8 @@ stdout:
 	  autoscale
 	  limits, limits.soft, limits.hard
 	  timestamps, timestamps.created
-	  domains, domains.*, domains.*.fqdn, domains.*.certificate,
-	  domains.*.certificate.name, domains.*.certificate.uuid
-	  instances, instances.*, instances.*.name, instances.*.uuid
+	  domains, domains.*, domains.*.fqdn, domains.*.certificate
+	  instances, instances.*
 	  services, services.*
 
 	Flags:

--- a/cmd/unikraft/testdata/TestGolden/volumes/help
+++ b/cmd/unikraft/testdata/TestGolden/volumes/help
@@ -39,9 +39,8 @@ stdout:
 	  quota-policy
 	  persistent
 	  timestamps, timestamps.created
-	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
-	  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
-	  by.*.read-only
+	  attached-to, attached-to.*
+	  mounted-by, mounted-by.*
 
 	Global flags:
 	  -h, --help
@@ -87,9 +86,8 @@ stdout:
 	  quota-policy
 	  persistent
 	  timestamps, timestamps.created
-	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
-	  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
-	  by.*.read-only
+	  attached-to, attached-to.*
+	  mounted-by, mounted-by.*
 
 	Flags:
 	  -w, --watch=<duration>
@@ -143,9 +141,8 @@ stdout:
 	  quota-policy
 	  persistent
 	  timestamps, timestamps.created
-	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
-	  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
-	  by.*.read-only
+	  attached-to, attached-to.*
+	  mounted-by, mounted-by.*
 
 	Flags:
 	      --filter
@@ -201,9 +198,8 @@ stdout:
 	  quota-policy
 	  persistent
 	  timestamps, timestamps.created
-	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
-	  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
-	  by.*.read-only
+	  attached-to, attached-to.*
+	  mounted-by, mounted-by.*
 
 	Flags:
 	      --until, --filter
@@ -263,9 +259,8 @@ stdout:
 	  quota-policy
 	  persistent
 	  timestamps, timestamps.created
-	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
-	  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
-	  by.*.read-only
+	  attached-to, attached-to.*
+	  mounted-by, mounted-by.*
 
 	Flags:
 	      --set=<name>=<value>, --set-file=<name>=<filename>
@@ -439,9 +434,8 @@ stdout:
 	  quota-policy
 	  persistent
 	  timestamps, timestamps.created
-	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
-	  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
-	  by.*.read-only
+	  attached-to, attached-to.*
+	  mounted-by, mounted-by.*
 
 	Flags:
 	      --set=<name>=<value>, --set-file=<name>=<filename>
@@ -515,9 +509,8 @@ stdout:
 	  quota-policy
 	  persistent
 	  timestamps, timestamps.created
-	  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
-	  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
-	  by.*.read-only
+	  attached-to, attached-to.*
+	  mounted-by, mounted-by.*
 
 	Flags:
 	      --all

--- a/cmd/unikraft/testdata/TestGolden/volumes/import/serve
+++ b/cmd/unikraft/testdata/TestGolden/volumes/import/serve
@@ -20,11 +20,7 @@ stdout:
 	resources:
 	  memory:     256MiB
 	  vcpus:      1
-	service:
-	  name:       <SERVICE_NAME>
-	  uuid:       12345678-1234-1234-1234-123456789abc
-	  domains:
-	  - fqdn:     <DOMAIN>.unikraft.internal
+	service:      <SERVICE_NAME>
 	volumes:
 	- test-<VOL>:/wwwroot
 	networks:
@@ -47,11 +43,7 @@ stdout:
 	resources:
 	  memory:     256MiB
 	  vcpus:      1
-	service:
-	  name:       <SERVICE_NAME>
-	  uuid:       12345678-1234-1234-1234-123456789abc
-	  domains:
-	  - fqdn:     <DOMAIN>.unikraft.internal
+	service:      <SERVICE_NAME>
 	volumes:
 	- test-<VOL>:/wwwroot
 	networks:

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/alecthomas/kong"
 	"github.com/distribution/reference"
-	"github.com/google/uuid"
 	"mvdan.cc/sh/v3/shell"
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/cloud/sdk/platform/group"
@@ -218,11 +217,7 @@ func (i *InstanceService) UnmarshalText(data []byte) error {
 		*i = InstanceService(parsed)
 		return nil
 	}
-	key := multimetro.ParseKey(str)
-	i.Metro = key.Metro
-	i.UUID = key.UUID
-	i.Name = key.Name
-	return nil
+	return i.Link.UnmarshalText([]byte(str))
 }
 
 func (i *InstanceService) UnmarshalJSON(data []byte) error {
@@ -318,10 +313,8 @@ func (v *InstanceVolume) UnmarshalText(data []byte) error {
 		}
 	}
 
-	if uuid.Validate(name) == nil {
-		v.UUID = name
-	} else if name != "" {
-		v.Name = name
+	if err := v.Link.UnmarshalText([]byte(name)); err != nil {
+		return err
 	}
 	v.At = at
 	v.Readonly = readonly

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -761,6 +761,9 @@ func (Instance) Create(ctx context.Context, fields []resource.Field) ([]resource
 			}
 		case "volumes":
 			for _, vol := range field.Create.Set.([]*InstanceVolume) {
+				if vol.Metro != "" && vol.Metro != metro {
+					return nil, fmt.Errorf("cannot create instance: metro mismatch between volume (%q) and instance (%q)", vol.Metro, metro)
+				}
 				reqVol := platform.CreateInstanceRequestVolume{
 					At: vol.At,
 				}

--- a/internal/cmd/link.go
+++ b/internal/cmd/link.go
@@ -39,6 +39,12 @@ func (l Link[T]) Link() (string, resource.Key) {
 	}
 }
 
+// MarshalText implements encoding.TextMarshaler.
+// It returns the name, matching the round-trip with UnmarshalText.
+func (l Link[T]) MarshalText() ([]byte, error) {
+	return []byte(l.Name), nil
+}
+
 // UnmarshalText implements encoding.TextUnmarshaler.
 // When parsing from text, the value is stored as the name.
 func (l *Link[T]) UnmarshalText(text []byte) error {

--- a/internal/cmd/link.go
+++ b/internal/cmd/link.go
@@ -40,15 +40,24 @@ func (l Link[T]) Link() (string, resource.Key) {
 }
 
 // MarshalText implements encoding.TextMarshaler.
-// It returns the name, matching the round-trip with UnmarshalText.
+// It formats the link as a multimetro key string, matching the round-trip
+// with UnmarshalText which parses via multimetro.ParseKey.
 func (l Link[T]) MarshalText() ([]byte, error) {
-	return []byte(l.Name), nil
+	k := multimetro.Key{
+		Metro: l.Metro,
+		Name:  l.Name,
+		UUID:  l.UUID,
+	}
+	return []byte(k.Canonical()), nil
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler.
-// When parsing from text, the value is stored as the name.
+// When parsing from text, the value is parsed as a multimetro key.
 func (l *Link[T]) UnmarshalText(text []byte) error {
-	l.Name = string(text)
+	key := multimetro.ParseKey(string(text))
+	l.Metro = key.Metro
+	l.Name = key.Name
+	l.UUID = key.UUID
 	return nil
 }
 


### PR DESCRIPTION
This was causing shortcut serialization+reserialization to accidentally
include the link details in the output, instead of the correct output.