### PR TITLE
feat(cmd): Add rollout mechanics when creating

### DIFF
--- a/cmd/unikraft/integration/instance_test.go
+++ b/cmd/unikraft/integration/instance_test.go
@@ -10,6 +10,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1430,6 +1431,152 @@ cmd: ["cat", "/marker.txt"]
 		assert.Regexp(t, `image:\s+nginx`, out)
 
 		r.Run(t, append([]string{"unikraft", "instance", "delete"}, instances...))
+	})
+
+	t.Run("service-rollout", func(t *testing.T) {
+		r := runner(t, true, []string{staging, stable})
+		svcName := "test-" + uniq()
+
+		r.Run(t, []string{
+			"unikraft", "service", "create",
+			"--output", "quiet",
+			"--name", svcName,
+			"--metro", r.Config.MetroName,
+			"--service", "443:8080/http+tls",
+		})
+
+		out := r.Run(t, []string{
+			"unikraft", "instance", "create",
+			"--output", "template={{ .name }}",
+			"--name", "test-" + uniq(),
+			"--metro", r.Config.MetroName,
+			"--image", "nginx:latest",
+			"--service", svcName,
+			"--autostart",
+			"--memory", "128",
+			"--vcpus", "1",
+			"--replicas", "1",
+		})
+		before := strings.Fields(out)
+		require.Len(t, before, 2)
+
+		controlName := "test-" + uniq()
+		r.Run(t, []string{
+			"unikraft", "instance", "create",
+			"--output", "quiet",
+			"--name", controlName,
+			"--metro", r.Config.MetroName,
+			"--image", "nginx:1.25",
+			"--memory", "128",
+			"--vcpus", "1",
+		})
+		controlImage := strings.TrimSpace(r.Run(t, []string{
+			"unikraft", "--log-level=error", "instance", "inspect",
+			"--output", "template={{ .image }}", controlName,
+		}))
+
+		out = r.Run(t, []string{
+			"unikraft", "--log-level=error", "instance", "create",
+			"--output", "template={{ .name }}",
+			"--name", "test-" + uniq(),
+			"--metro", r.Config.MetroName,
+			"--image", "nginx:1.25",
+			"--service", svcName,
+			"--autostart",
+			"--memory", "128",
+			"--vcpus", "1",
+			"--service-rollout",
+		})
+		after := strings.Fields(out)
+		require.Len(t, after, 2)
+		assert.NotEqual(t, before, after)
+
+		out = r.Run(t, []string{"unikraft", "instance", "list", "--output", "quiet"})
+		for _, name := range before {
+			assert.NotContains(t, out, name)
+		}
+		for _, name := range after {
+			assert.Contains(t, out, name)
+		}
+
+		out = r.Run(t, append([]string{"unikraft", "instance", "inspect"}, after...))
+		assert.Regexp(t, `image:\s+nginx`, out)
+		assert.Regexp(t, `state:\s+running`, out)
+
+		afterImage := r.Run(t, append([]string{
+			"unikraft", "--log-level=error", "instance", "inspect", "--output", "template={{ .image }}",
+		}, after...))
+		assert.Equal(t, []string{controlImage, controlImage}, strings.Fields(afterImage))
+
+		svcSolo := "test-" + uniq()
+		r.Run(t, []string{
+			"unikraft", "service", "create",
+			"--output", "quiet",
+			"--name", svcSolo,
+			"--metro", r.Config.MetroName,
+			"--service", "443:8080/http+tls",
+		})
+		soloBefore := strings.TrimSpace(r.Run(t, []string{
+			"unikraft", "instance", "create",
+			"--output", "template={{ .name }}",
+			"--name", "test-" + uniq(),
+			"--metro", r.Config.MetroName,
+			"--image", "nginx:latest",
+			"--service", svcSolo,
+			"--autostart",
+			"--memory", "128",
+			"--vcpus", "1",
+		}))
+		soloAfter := strings.Fields(r.Run(t, []string{
+			"unikraft", "--log-level=error", "instance", "run",
+			"--output", "template={{ .name }}",
+			"--name", "test-" + uniq(),
+			"--metro", r.Config.MetroName,
+			"--image", "nginx:1.25",
+			"--service", svcSolo,
+			"--memory", "128",
+			"--vcpus", "1",
+			"--service-rollout",
+		}))
+		require.Len(t, soloAfter, 1)
+		assert.NotEqual(t, soloBefore, soloAfter[0])
+
+		out = r.Run(t, []string{"unikraft", "instance", "list", "--output", "quiet"})
+		assert.NotContains(t, out, soloBefore)
+		assert.Contains(t, out, soloAfter[0])
+
+		r.Run(t, append(append([]string{"unikraft", "instance", "delete", controlName}, after...), soloAfter...))
+		r.Run(t, []string{"unikraft", "service", "delete", svcName, svcSolo})
+	})
+
+	t.Run("service-rollout-rejects", func(t *testing.T) {
+		r := runner(t, true, []string{staging, stable})
+		base := []string{
+			"unikraft", "instance", "create",
+			"--metro", r.Config.MetroName,
+			"--image", "nginx:latest",
+		}
+
+		out := r.Run(t, append(slices.Clone(base),
+			"--service", "some-service",
+			"--autostart",
+			"--service-rollout",
+			"--replicas", "2",
+		), integ.ExpectFail())
+		assert.Contains(t, out, "--replicas cannot be used with --service-rollout")
+
+		out = r.Run(t, append(slices.Clone(base),
+			"--autostart",
+			"--service-rollout",
+		), integ.ExpectFail())
+		assert.Contains(t, out, "requires an existing service group")
+
+		out = r.Run(t, append(slices.Clone(base),
+			"--service", "some-service",
+			"--set", "autostart=false",
+			"--service-rollout",
+		), integ.ExpectFail())
+		assert.Contains(t, out, "requires --autostart")
 	})
 
 	t.Run("watch-timeout", func(t *testing.T) {

--- a/cmd/unikraft/integration/instance_test.go
+++ b/cmd/unikraft/integration/instance_test.go
@@ -1499,9 +1499,11 @@ cmd: ["cat", "/marker.txt"]
 			assert.Contains(t, out, name)
 		}
 
-		out = r.Run(t, append([]string{"unikraft", "instance", "inspect"}, after...))
-		assert.Regexp(t, `image:\s+nginx`, out)
-		assert.Regexp(t, `state:\s+running`, out)
+		for _, name := range after {
+			inspected := r.Run(t, []string{"unikraft", "instance", "inspect", name})
+			assert.Regexp(t, `image:\s+nginx`, inspected)
+			assert.Regexp(t, `state:\s+running`, inspected)
+		}
 
 		afterImage := r.Run(t, append([]string{
 			"unikraft", "--log-level=error", "instance", "inspect", "--output", "template={{ .image }}",
@@ -1549,6 +1551,68 @@ cmd: ["cat", "/marker.txt"]
 		r.Run(t, []string{"unikraft", "service", "delete", svcName, svcSolo})
 	})
 
+	t.Run("service-rollout-replace", func(t *testing.T) {
+		r := runner(t, true, []string{staging, stable})
+		svcName := "test-" + uniq()
+
+		r.Run(t, []string{
+			"unikraft", "service", "create",
+			"--output", "quiet",
+			"--name", svcName,
+			"--metro", r.Config.MetroName,
+			"--service", "443:8080/http+tls",
+		})
+
+		out := r.Run(t, []string{
+			"unikraft", "instance", "create",
+			"--output", "template={{ .name }}",
+			"--name", "test-" + uniq(),
+			"--metro", r.Config.MetroName,
+			"--image", "nginx:latest",
+			"--service", svcName,
+			"--autostart",
+			"--memory", "128",
+			"--vcpus", "1",
+			"--replicas", "1",
+		})
+		before := strings.Fields(out)
+		require.Len(t, before, 2)
+
+		// Replace stops the old instances before it starts the new ones, and
+		// --rollout-healthy-after holds the new ones up before the old ones go.
+		out = r.Run(t, []string{
+			"unikraft", "--log-level=error", "instance", "create",
+			"--output", "template={{ .name }}",
+			"--name", "test-" + uniq(),
+			"--metro", r.Config.MetroName,
+			"--image", "nginx:1.25",
+			"--service", svcName,
+			"--autostart",
+			"--memory", "128",
+			"--vcpus", "1",
+			"--service-rollout=replace",
+			"--rollout-healthy-after=2s",
+		})
+		after := strings.Fields(out)
+		require.Len(t, after, 2)
+
+		out = r.Run(t, []string{"unikraft", "instance", "list", "--output", "quiet"})
+		for _, name := range before {
+			assert.NotContains(t, out, name)
+		}
+		for _, name := range after {
+			assert.Contains(t, out, name)
+		}
+
+		for _, name := range after {
+			inspected := r.Run(t, []string{"unikraft", "instance", "inspect", name})
+			assert.Regexp(t, `state:\s+running`, inspected)
+		}
+
+		r.Run(t, append([]string{"unikraft", "instance", "delete"}, after...))
+		r.Run(t, []string{"unikraft", "service", "delete", svcName})
+	})
+
 	t.Run("service-rollout-rejects", func(t *testing.T) {
 		r := runner(t, true, []string{staging, stable})
 		base := []string{
@@ -1577,6 +1641,145 @@ cmd: ["cat", "/marker.txt"]
 			"--service-rollout",
 		), integ.ExpectFail())
 		assert.Contains(t, out, "requires --autostart")
+
+		out = r.Run(t, append(slices.Clone(base),
+			"--service", "some-service",
+			"--autostart",
+			"--service-rollout=sideways",
+		), integ.ExpectFail())
+		assert.Contains(t, out, `unknown rollout mode "sideways"`)
+
+		out = r.Run(t, append(slices.Clone(base),
+			"--rollout-healthy-after=30s",
+		), integ.ExpectFail())
+		assert.Contains(t, out, "--rollout-healthy-after requires --service-rollout")
+
+		out = r.Run(t, append(slices.Clone(base),
+			"--service", "some-service",
+			"--autostart",
+			"--service-rollout",
+			"--rollout-healthy-after=-30s",
+		), integ.ExpectFail())
+		assert.Contains(t, out, "--rollout-healthy-after cannot be negative")
+
+		out = r.Run(t, append(slices.Clone(base),
+			"--service", "test-"+uniq(),
+			"--autostart",
+			"--service-rollout",
+		), integ.ExpectFail())
+		assert.Contains(t, out, "not found")
+
+		out = r.Run(t, append(slices.Clone(base),
+			"--service", "some-service",
+			"--autostart",
+			"--service-rollout=sideways",
+			"--save", "-",
+		), integ.ExpectFail())
+		assert.Contains(t, out, `unknown rollout mode "sideways"`)
+	})
+
+	t.Run("service-rollout-dry-run", func(t *testing.T) {
+		r := runner(t, true, []string{staging, stable})
+		svcName := "test-" + uniq()
+
+		r.Run(t, []string{
+			"unikraft", "service", "create",
+			"--output", "quiet",
+			"--name", svcName,
+			"--metro", r.Config.MetroName,
+			"--service", "443:8080/http+tls",
+		})
+		before := strings.Fields(r.Run(t, []string{
+			"unikraft", "instance", "create",
+			"--output", "template={{ .name }}",
+			"--name", "test-" + uniq(),
+			"--metro", r.Config.MetroName,
+			"--image", "nginx:latest",
+			"--service", svcName,
+			"--autostart",
+			"--memory", "128",
+			"--vcpus", "1",
+			"--replicas", "1",
+		}))
+		require.Len(t, before, 2)
+
+		out := r.Run(t, []string{
+			"unikraft", "--log-level=error", "instance", "create",
+			"--metro", r.Config.MetroName,
+			"--image", "nginx:1.25",
+			"--service", svcName,
+			"--autostart",
+			"--memory", "128",
+			"--vcpus", "1",
+			"--service-rollout",
+			"--dry-run",
+		})
+		assert.Regexp(t, `replicas\s+:= 1`, out)
+		for _, name := range before {
+			assert.Contains(t, out, name)
+		}
+
+		list := r.Run(t, []string{"unikraft", "instance", "list", "--output", "quiet"})
+		for _, name := range before {
+			assert.Contains(t, list, name)
+		}
+
+		r.Run(t, append([]string{"unikraft", "instance", "delete"}, before...))
+		r.Run(t, []string{"unikraft", "service", "delete", svcName})
+	})
+
+	t.Run("service-rollout-rollback", func(t *testing.T) {
+		r := runner(t, true, []string{staging, stable})
+
+		for _, mode := range []string{"rolling", "replace"} {
+			t.Run(mode, func(t *testing.T) {
+				svcName := "test-" + uniq()
+				r.Run(t, []string{
+					"unikraft", "service", "create",
+					"--output", "quiet",
+					"--name", svcName,
+					"--metro", r.Config.MetroName,
+					"--service", "443:8080/http+tls",
+				})
+				before := strings.TrimSpace(r.Run(t, []string{
+					"unikraft", "instance", "create",
+					"--output", "template={{ .name }}",
+					"--name", "test-" + uniq(),
+					"--metro", r.Config.MetroName,
+					"--image", "nginx:latest",
+					"--service", svcName,
+					"--autostart",
+					"--memory", "128",
+					"--vcpus", "1",
+				}))
+
+				rolled := "test-" + uniq()
+				out := r.Run(t, []string{
+					"unikraft", "--timeout=90s", "instance", "create",
+					"--output", "quiet",
+					"--name", rolled,
+					"--metro", r.Config.MetroName,
+					"--image", "nginx:1.25",
+					"--service", svcName,
+					"--autostart",
+					"--memory", "128",
+					"--vcpus", "1",
+					"--service-rollout=" + mode,
+					"--rollout-healthy-after=300s",
+				}, integ.ExpectFail())
+				assert.Regexp(t, `rollout interrupted|timed out`, out)
+
+				list := r.Run(t, []string{"unikraft", "instance", "list", "--output", "quiet"})
+				assert.NotContains(t, list, rolled)
+				assert.Contains(t, list, before)
+
+				inspected := r.Run(t, []string{"unikraft", "instance", "inspect", before})
+				assert.Regexp(t, `state:\s+running`, inspected)
+
+				r.Run(t, []string{"unikraft", "instance", "delete", before})
+				r.Run(t, []string{"unikraft", "service", "delete", svcName})
+			})
+		}
 	})
 
 	t.Run("watch-timeout", func(t *testing.T) {

--- a/cmd/unikraft/testdata/TestHelp/instances
+++ b/cmd/unikraft/testdata/TestHelp/instances
@@ -396,6 +396,14 @@ Examples:
   	  --plugin
   'name=sandbox,image=plugins/sandbox:latest,config={"persist_path":"/data"}'
 
+  # Replace every instance in a service group with a new image
+  unikraft instance create \
+  	  --metro fra \
+  	  --image my-app:v2 \
+  	  --service my-service \
+  	  --autostart \
+  	  --service-rollout
+
 Fields:
   metro
   name
@@ -555,6 +563,8 @@ Create flags:
           Create from a checkpoint.
       --rm
           Automatically delete the instance when it stops.
+      --service-rollout
+          Replace every instance in the service group with a new one.
 
 $ unikraft instance new --help
 
@@ -594,6 +604,14 @@ Examples:
   	  --plugin
   'name=sandbox,image=plugins/sandbox:latest,config={"persist_path":"/data"}'
 
+  # Replace every instance in a service group with a new image
+  unikraft instance create \
+  	  --metro fra \
+  	  --image my-app:v2 \
+  	  --service my-service \
+  	  --autostart \
+  	  --service-rollout
+
 Fields:
   metro
   name
@@ -753,6 +771,8 @@ Create flags:
           Create from a checkpoint.
       --rm
           Automatically delete the instance when it stops.
+      --service-rollout
+          Replace every instance in the service group with a new one.
 
 $ unikraft instance run --help
 
@@ -799,6 +819,9 @@ Examples:
   # Deploy a new instance with a configured plugin
   unikraft instance run --metro=fra --image=my-app:latest --plugin
   'name=sandbox,image=plugins/sandbox:latest,config={"persist_path":"/data"}'
+
+  # Roll every instance in a service group over to a new image
+  unikraft instance run --image=my-app:v2 --service=api --service-rollout
 
 Fields:
   metro
@@ -961,6 +984,8 @@ Create flags:
           Create from a checkpoint.
       --rm
           Automatically delete the instance when it stops.
+      --service-rollout
+          Replace every instance in the service group with a new one.
 
 $ unikraft instance edit --help
 

--- a/cmd/unikraft/testdata/TestHelp/instances
+++ b/cmd/unikraft/testdata/TestHelp/instances
@@ -404,6 +404,16 @@ Examples:
   	  --autostart \
   	  --service-rollout
 
+  # Roll a service group whose instances need sole access to their volume, and
+  # hold the new ones up for a minute first
+  unikraft instance create \
+  	  --metro fra \
+  	  --image my-db:v2 \
+  	  --service my-db \
+  	  --autostart \
+  	  --service-rollout=replace \
+  	  --rollout-healthy-after=1m
+
 Fields:
   metro
   name
@@ -563,8 +573,10 @@ Create flags:
           Create from a checkpoint.
       --rm
           Automatically delete the instance when it stops.
-      --service-rollout
-          Replace every instance in the service group with a new one.
+      --service-rollout=<mode>
+          Replace every instance in the service group with a new one and delete the old ones. Requires --autostart. One of: rolling (default), replace.
+      --rollout-healthy-after=<duration>
+          Time the new instances must keep running before the rollout deletes the ones they replace.
 
 $ unikraft instance new --help
 
@@ -612,6 +624,16 @@ Examples:
   	  --autostart \
   	  --service-rollout
 
+  # Roll a service group whose instances need sole access to their volume, and
+  # hold the new ones up for a minute first
+  unikraft instance create \
+  	  --metro fra \
+  	  --image my-db:v2 \
+  	  --service my-db \
+  	  --autostart \
+  	  --service-rollout=replace \
+  	  --rollout-healthy-after=1m
+
 Fields:
   metro
   name
@@ -771,8 +793,10 @@ Create flags:
           Create from a checkpoint.
       --rm
           Automatically delete the instance when it stops.
-      --service-rollout
-          Replace every instance in the service group with a new one.
+      --service-rollout=<mode>
+          Replace every instance in the service group with a new one and delete the old ones. Requires --autostart. One of: rolling (default), replace.
+      --rollout-healthy-after=<duration>
+          Time the new instances must keep running before the rollout deletes the ones they replace.
 
 $ unikraft instance run --help
 
@@ -984,8 +1008,10 @@ Create flags:
           Create from a checkpoint.
       --rm
           Automatically delete the instance when it stops.
-      --service-rollout
-          Replace every instance in the service group with a new one.
+      --service-rollout=<mode>
+          Replace every instance in the service group with a new one and delete the old ones. Requires --autostart. One of: rolling (default), replace.
+      --rollout-healthy-after=<duration>
+          Time the new instances must keep running before the rollout deletes the ones they replace.
 
 $ unikraft instance edit --help
 

--- a/cmd/unikraft/testdata/TestHelp/run
+++ b/cmd/unikraft/testdata/TestHelp/run
@@ -43,6 +43,9 @@ Examples:
   unikraft run --metro=fra --image=my-app:latest --plugin
   'name=sandbox,image=plugins/sandbox:latest,config={"persist_path":"/data"}'
 
+  # Roll every instance in a service group over to a new image
+  unikraft run --image=my-app:v2 --service=api --service-rollout
+
 Fields:
   metro
   name
@@ -204,3 +207,5 @@ Create flags:
           Create from a checkpoint.
       --rm
           Automatically delete the instance when it stops.
+      --service-rollout
+          Replace every instance in the service group with a new one.

--- a/cmd/unikraft/testdata/TestHelp/run
+++ b/cmd/unikraft/testdata/TestHelp/run
@@ -207,5 +207,7 @@ Create flags:
           Create from a checkpoint.
       --rm
           Automatically delete the instance when it stops.
-      --service-rollout
-          Replace every instance in the service group with a new one.
+      --service-rollout=<mode>
+          Replace every instance in the service group with a new one and delete the old ones. Requires --autostart. One of: rolling (default), replace.
+      --rollout-healthy-after=<duration>
+          Time the new instances must keep running before the rollout deletes the ones they replace.

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -41,6 +41,7 @@ import (
 	"unikraft.com/cli/internal/resource"
 	"unikraft.com/cli/internal/resource/cmd"
 	"unikraft.com/cli/internal/resource/value"
+	"unikraft.com/cli/internal/rollout"
 	"unikraft.com/cli/internal/timeouts"
 	"unikraft.com/cli/internal/tunnel"
 	"unikraft.com/cli/internal/types"
@@ -78,7 +79,8 @@ type InstancesCmd struct {
 type InstanceCreateCmd struct {
 	cmd.ResourceCreateCmd[Instance]
 
-	DeleteOnStop bool `group:"flag-create" name:"rm" help:"Automatically delete the instance when it stops."`
+	DeleteOnStop   bool `group:"flag-create" name:"rm" help:"Automatically delete the instance when it stops."`
+	ServiceRollout bool `group:"flag-create" name:"service-rollout" help:"Replace every instance in the service group with a new one."`
 }
 
 func (c *InstanceCreateCmd) Run(ctx context.Context, stdio config.Stdio, partition *resource.Partition) error {
@@ -94,7 +96,120 @@ func (c *InstanceCreateCmd) Run(ctx context.Context, stdio config.Stdio, partiti
 			return fmt.Errorf("--domain cannot be used with --service")
 		}
 	}
-	return c.ResourceCreateCmd.Run(ctx, stdio, partition)
+	_, err := c.RunResources(ctx, stdio, partition)
+	return err
+}
+
+// RunResources creates the instances and, when asked for a rollout, replaces
+// the instances already in the service group with them.
+func (c *InstanceCreateCmd) RunResources(ctx context.Context, stdio config.Stdio, partition *resource.Partition) ([]resource.Resource, error) {
+	if !c.ServiceRollout {
+		return c.ResourceCreateCmd.RunResources(ctx, stdio, partition)
+	}
+	if c.Save != "" {
+		// --save writes the spec the flags hold and creates nothing, so it
+		// keeps the values the user gave and the rollout stays out of it.
+		return c.ResourceCreateCmd.RunResources(ctx, stdio, partition)
+	}
+	return c.runServiceRollout(ctx, stdio, partition)
+}
+
+// runServiceRollout replaces every instance in the target service group. It
+// creates as many instances as the group already holds and waits for all of
+// them to run before it deletes any of the old ones.
+func (c *InstanceCreateCmd) runServiceRollout(ctx context.Context, stdio config.Stdio, partition *resource.Partition) ([]resource.Resource, error) {
+	fields, err := c.CreateFields(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := rollout.FieldValue[int64](fields, "replicas"); ok {
+		return nil, fmt.Errorf("--replicas cannot be used with --service-rollout: the rollout creates one instance for every instance already in the service group")
+	}
+	if autostart, _ := rollout.FieldValue[bool](fields, "autostart"); !autostart {
+		return nil, fmt.Errorf("--service-rollout requires --autostart: the old instances are only deleted once the new ones run")
+	}
+	svc, ok := rollout.FieldValue[*InstanceService](fields, "service")
+	if !ok || svc == nil || (svc.Name == "" && svc.UUID == "") {
+		return nil, fmt.Errorf("--service-rollout requires an existing service group")
+	}
+
+	metro, _ := rollout.FieldValue[LinkName[Metro]](fields, "metro")
+	key := multimetro.Key{Metro: cmp.Or(svc.Metro, string(metro)), UUID: svc.UUID}
+	if svc.UUID == "" {
+		key.Name = svc.Name
+	}
+	svcResults, err := (ServiceGroup{}).Get(ctx, []string{key.Canonical()})
+	if err != nil {
+		return nil, fmt.Errorf("looking up service group %q: %w", key.Canonical(), err)
+	}
+	if len(svcResults) == 0 {
+		return nil, fmt.Errorf("service group %q not found", key.Canonical())
+	}
+	svcGroup := svcResults[0].(ServiceGroup)
+
+	oldKeys := make([]string, 0, len(svcGroup.Instances))
+	for _, inst := range svcGroup.Instances {
+		key := multimetro.Key{Metro: cmp.Or(inst.Metro, string(svcGroup.Metro)), UUID: inst.UUID}
+		if inst.UUID == "" {
+			key.Name = inst.Name
+		}
+		if key.Name == "" && key.UUID == "" {
+			continue
+		}
+		oldKeys = append(oldKeys, key.Canonical())
+	}
+	if len(oldKeys) == 0 {
+		log.G(ctx).Info().
+			Str("service", svcGroup.Name).
+			Msg("service group is empty, creating without a rollout")
+		return c.ResourceCreateCmd.RunResources(ctx, stdio, partition)
+	}
+
+	count := int64(len(oldKeys))
+	if err := rollout.ValidateCapacity(ctx, string(svcGroup.Metro), svcGroup.Autoscale, count, fields); err != nil {
+		return nil, err
+	}
+
+	if count > 1 {
+		if err := c.SetCreateFields(ctx, append(slices.Clone(fields), resource.Field{
+			Name:   "replicas",
+			Create: &resource.Patch{Set: count - 1},
+		})); err != nil {
+			return nil, err
+		}
+	}
+	log.G(ctx).Info().
+		Str("service", svcGroup.Name).
+		Int64("instances", count).
+		Msg("rolling out")
+
+	created, err := c.ResourceCreateCmd.RunResources(ctx, stdio, partition)
+	if err == nil && int64(len(created)) < count {
+		err = fmt.Errorf("rollout created %d of %d instances", len(created), count)
+	}
+	// A create reports success for an instance that exists but never reached
+	// the running state, so the states are checked as well as the error.
+	for _, r := range created {
+		inst := r.(Instance)
+		if state := platform.InstanceState(inst.State); state != platform.InstanceStateRunning &&
+			state != platform.InstanceStateStandby {
+			err = errors.Join(err, fmt.Errorf("instance %s is %s, not running", cmp.Or(inst.Name, inst.UUID), state))
+		}
+	}
+	if err != nil {
+		return created, errors.Join(err, rollout.Undo(ctx, partition, Instance{}, created))
+	}
+
+	if err := partition.WrapDeletable(Instance{}).Delete(ctx, oldKeys); err != nil {
+		// The new instances are the wanted state by now, so they stay and the
+		// group holds both sets until the old ones are dealt with.
+		return created, fmt.Errorf("the new instances are up, but deleting the replaced ones failed, so %s are still in the service group: %w",
+			strings.Join(oldKeys, " "), err)
+	}
+	log.G(ctx).Info().
+		Strs("instances", oldKeys).
+		Msg("replaced instances deleted")
+	return created, nil
 }
 
 type Instance struct {
@@ -1621,6 +1736,17 @@ func (Instance) Examples() map[cmd.CmdType][]kingkong.Example {
 	  --metro fra \
 	  --image nginx:latest \
 	  --plugin 'name=sandbox,image=plugins/sandbox:latest,config={"persist_path":"/data"}'`,
+				},
+			},
+			{
+				Description: "Replace every instance in a service group with a new image",
+				Commands: []string{
+					`unikraft instance create \
+	  --metro fra \
+	  --image my-app:v2 \
+	  --service my-service \
+	  --autostart \
+	  --service-rollout`,
 				},
 			},
 		},

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -40,6 +40,7 @@ import (
 	"unikraft.com/cli/internal/muxreader"
 	"unikraft.com/cli/internal/resource"
 	"unikraft.com/cli/internal/resource/cmd"
+	"unikraft.com/cli/internal/resource/patch"
 	"unikraft.com/cli/internal/resource/value"
 	"unikraft.com/cli/internal/rollout"
 	"unikraft.com/cli/internal/timeouts"
@@ -79,9 +80,38 @@ type InstancesCmd struct {
 type InstanceCreateCmd struct {
 	cmd.ResourceCreateCmd[Instance]
 
-	DeleteOnStop   bool `group:"flag-create" name:"rm" help:"Automatically delete the instance when it stops."`
-	ServiceRollout bool `group:"flag-create" name:"service-rollout" help:"Replace every instance in the service group with a new one."`
+	DeleteOnStop        bool                 `group:"flag-create" name:"rm" help:"Automatically delete the instance when it stops."`
+	ServiceRollout      *InstanceRolloutMode `group:"flag-create" name:"service-rollout" type:"optional" help:"Replace every instance in the service group with a new one and delete the old ones. Requires --autostart. One of: rolling (default), replace." placeholder:"mode"`
+	RolloutHealthyAfter time.Duration        `group:"flag-create" name:"rollout-healthy-after" help:"Time the new instances must keep running before the rollout deletes the ones they replace." placeholder:"duration"`
 }
+
+// InstanceRolloutMode is how a rollout swaps the old instances for the new.
+type InstanceRolloutMode string
+
+const (
+	// RolloutRolling means every new instance comes up before any old one goes.
+	RolloutRolling InstanceRolloutMode = "rolling"
+	// RolloutReplace means the old instances stop before the new ones start.
+	RolloutReplace InstanceRolloutMode = "replace"
+)
+
+const (
+	// rolloutWaitTimeout is how long one step of a rollout asks again for its
+	// instances. Equivalent to 90 timeouts.
+	rolloutWaitTimeout = 900 * time.Second
+	// rolloutPollInterval is how long a rollout leaves between two reads.
+	rolloutPollInterval = 5 * time.Second
+)
+
+// Platform defaults for an instance that sets neither.
+const (
+	defaultInstanceVcpus    = 1
+	defaultInstanceMemoryMb = 128
+)
+
+// errInstancePending marks an instance that has not settled yet, which a
+// rollout waits for instead of failing.
+var errInstancePending = errors.New("instance is not up yet")
 
 func (c *InstanceCreateCmd) Run(ctx context.Context, stdio config.Stdio, partition *resource.Partition) error {
 	if c.DeleteOnStop {
@@ -103,113 +133,322 @@ func (c *InstanceCreateCmd) Run(ctx context.Context, stdio config.Stdio, partiti
 // RunResources creates the instances and, when asked for a rollout, replaces
 // the instances already in the service group with them.
 func (c *InstanceCreateCmd) RunResources(ctx context.Context, stdio config.Stdio, partition *resource.Partition) ([]resource.Resource, error) {
-	if !c.ServiceRollout {
+	if c.RolloutHealthyAfter < 0 {
+		return nil, fmt.Errorf("--rollout-healthy-after cannot be negative")
+	}
+	if c.ServiceRollout == nil {
+		if c.RolloutHealthyAfter != 0 {
+			return nil, fmt.Errorf("--rollout-healthy-after requires --service-rollout")
+		}
 		return c.ResourceCreateCmd.RunResources(ctx, stdio, partition)
 	}
-	if c.Save != "" {
-		// --save writes the spec the flags hold and creates nothing, so it
-		// keeps the values the user gave and the rollout stays out of it.
-		return c.ResourceCreateCmd.RunResources(ctx, stdio, partition)
+	mode := cmp.Or(ptr.ZeroIfNil(c.ServiceRollout), RolloutRolling)
+	if mode != RolloutRolling && mode != RolloutReplace {
+		return nil, fmt.Errorf("unknown rollout mode %q, want %q or %q", mode, RolloutRolling, RolloutReplace)
 	}
-	return c.runServiceRollout(ctx, stdio, partition)
-}
 
-// runServiceRollout replaces every instance in the target service group. It
-// creates as many instances as the group already holds and waits for all of
-// them to run before it deletes any of the old ones.
-func (c *InstanceCreateCmd) runServiceRollout(ctx context.Context, stdio config.Stdio, partition *resource.Partition) ([]resource.Resource, error) {
 	fields, err := c.CreateFields(ctx)
 	if err != nil {
 		return nil, err
 	}
-	if _, ok := rollout.FieldValue[int64](fields, "replicas"); ok {
-		return nil, fmt.Errorf("--replicas cannot be used with --service-rollout: the rollout creates one instance for every instance already in the service group")
+	if _, ok := patch.CreateValue[int64](fields, "replicas"); ok {
+		return nil, fmt.Errorf("--replicas cannot be used with --service-rollout")
 	}
-	if autostart, _ := rollout.FieldValue[bool](fields, "autostart"); !autostart {
-		return nil, fmt.Errorf("--service-rollout requires --autostart: the old instances are only deleted once the new ones run")
+	if autostart, _ := patch.CreateValue[bool](fields, "autostart"); !autostart {
+		return nil, fmt.Errorf("--service-rollout requires --autostart")
 	}
-	svc, ok := rollout.FieldValue[*InstanceService](fields, "service")
+	svc, ok := patch.CreateValue[*InstanceService](fields, "service")
 	if !ok || svc == nil || (svc.Name == "" && svc.UUID == "") {
 		return nil, fmt.Errorf("--service-rollout requires an existing service group")
 	}
 
-	metro, _ := rollout.FieldValue[LinkName[Metro]](fields, "metro")
-	key := multimetro.Key{Metro: cmp.Or(svc.Metro, string(metro)), UUID: svc.UUID}
-	if svc.UUID == "" {
-		key.Name = svc.Name
+	if c.Save != "" {
+		return c.ResourceCreateCmd.RunResources(ctx, stdio, partition)
 	}
-	svcResults, err := (ServiceGroup{}).Get(ctx, []string{key.Canonical()})
-	if err != nil {
-		return nil, fmt.Errorf("looking up service group %q: %w", key.Canonical(), err)
-	}
-	if len(svcResults) == 0 {
-		return nil, fmt.Errorf("service group %q not found", key.Canonical())
-	}
-	svcGroup := svcResults[0].(ServiceGroup)
+	return c.runServiceRollout(ctx, stdio, partition, mode, fields, svc)
+}
 
-	oldKeys := make([]string, 0, len(svcGroup.Instances))
-	for _, inst := range svcGroup.Instances {
-		key := multimetro.Key{Metro: cmp.Or(inst.Metro, string(svcGroup.Metro)), UUID: inst.UUID}
-		if inst.UUID == "" {
-			key.Name = inst.Name
+// runServiceRollout replaces every instance in the target service group with
+// a new one, and deletes the old set once the new one runs.
+func (c *InstanceCreateCmd) runServiceRollout(ctx context.Context, stdio config.Stdio, partition *resource.Partition, mode InstanceRolloutMode, fields []resource.Field, svc *InstanceService) ([]resource.Resource, error) {
+	svcGroup, oldKeys, err := rolloutTarget(ctx, fields, svc)
+	if err != nil {
+		if !c.DryRun {
+			return nil, err
 		}
-		if key.Name == "" && key.UUID == "" {
-			continue
-		}
-		oldKeys = append(oldKeys, key.Canonical())
+		log.G(ctx).Warn().Err(err).
+			Msg("cannot read the service group, replaced instances not shown")
+	} else if svcGroup.Autoscale {
+		return nil, fmt.Errorf("autoscaling enabled, can't rollout service group %q", cmp.Or(svcGroup.Name, svcGroup.UUID))
 	}
-	if len(oldKeys) == 0 {
+	if len(oldKeys) == 0 && !c.DryRun {
 		log.G(ctx).Info().
 			Str("service", svcGroup.Name).
 			Msg("service group is empty, creating without a rollout")
 		return c.ResourceCreateCmd.RunResources(ctx, stdio, partition)
 	}
-
 	count := int64(len(oldKeys))
-	if err := rollout.ValidateCapacity(ctx, string(svcGroup.Metro), svcGroup.Autoscale, count, fields); err != nil {
-		return nil, err
-	}
 
-	if count > 1 {
-		if err := c.SetCreateFields(ctx, append(slices.Clone(fields), resource.Field{
-			Name:   "replicas",
-			Create: &resource.Patch{Set: count - 1},
-		})); err != nil {
+	var running multimetro.Keys
+	if !c.DryRun {
+		results, err := (Instance{}).Get(ctx, oldKeys.Strings())
+		if err != nil {
+			return nil, fmt.Errorf("reading the instances of service group %q: %w", svcGroup.Name, err)
+		}
+		var freed rollout.Footprint
+		for _, r := range results {
+			inst := r.(Instance)
+			if !inst.State.IsRunning() {
+				continue
+			}
+			running = append(running, inst.key)
+			freed.Instances++
+			freed.Vcpus += int64(inst.Resources.VCPUs)
+			freed.MemoryMb += int64(inst.Resources.Memory)
+		}
+
+		var size rollout.Footprint
+		vcpus, hasVcpus := patch.CreateValue[int](fields, "resources.vcpus")
+		memory, hasMemory := patch.CreateValue[types.SizeMebibytes](fields, "resources.memory")
+		inherited := false
+		if v, ok := patch.CreateValue[string](fields, "template"); ok && v != "" {
+			inherited = true
+		}
+		for _, path := range []string{"branch", "checkpoint"} {
+			if v, ok := patch.CreateValue[multimetro.Key](fields, path); ok && (v.Name != "" || v.UUID != "") {
+				inherited = true
+			}
+		}
+		if (hasVcpus && hasMemory) || !inherited {
+			size.Vcpus = cmp.Or(int64(vcpus), defaultInstanceVcpus)
+			size.MemoryMb = cmp.Or(int64(memory), defaultInstanceMemoryMb)
+		}
+
+		if err := rollout.ValidateCapacity(ctx, rollout.CapacityOpts{
+			Metro:      string(svcGroup.Metro),
+			Count:      count,
+			Concurrent: mode == RolloutRolling,
+			Size:       size,
+			Freed:      freed,
+		}); err != nil {
 			return nil, err
 		}
 	}
+
+	patched := slices.Clone(fields)
+	if count > 1 {
+		patched = patch.SetCreateValue(patched, "replicas", count-1)
+	}
+	if mode == RolloutReplace {
+		patched = patch.SetCreateValue(patched, "autostart", false)
+	}
+	if err := c.SetCreateFields(ctx, patched); err != nil {
+		return nil, err
+	}
+
+	if c.DryRun {
+		if _, err := c.ResourceCreateCmd.RunResources(ctx, stdio, partition); err != nil {
+			return nil, err
+		}
+		if len(oldKeys) > 0 {
+			fmt.Fprintf(stdio.Stdout, "replaces := %s\n", strings.Join(oldKeys.Strings(), " "))
+		}
+		return nil, nil
+	}
+
+	g, err := multimetro.NewClient(ctx)
+	if err != nil {
+		return nil, err
+	}
 	log.G(ctx).Info().
 		Str("service", svcGroup.Name).
+		Str("mode", string(mode)).
 		Int64("instances", count).
 		Msg("rolling out")
 
-	created, err := c.ResourceCreateCmd.RunResources(ctx, stdio, partition)
+	var created []resource.Resource
+	var stopped multimetro.Keys
+	undo := func(cause error) ([]resource.Resource, error) {
+		errs := []error{cause}
+		if len(stopped) > 0 {
+			errs = append(errs, restoreInstances(ctx, g, stopped))
+		}
+		undoCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), rolloutWaitTimeout)
+		defer cancel()
+		errs = append(errs, rollout.Undo(undoCtx, partition, Instance{}, created))
+		return created, errors.Join(errs...)
+	}
+
+	quiet := stdio
+	quiet.Stdout = io.Discard
+	created, err = c.ResourceCreateCmd.RunResources(ctx, quiet, partition)
 	if err == nil && int64(len(created)) < count {
 		err = fmt.Errorf("rollout created %d of %d instances", len(created), count)
 	}
-	// A create reports success for an instance that exists but never reached
-	// the running state, so the states are checked as well as the error.
-	for _, r := range created {
-		inst := r.(Instance)
-		if state := platform.InstanceState(inst.State); state != platform.InstanceStateRunning &&
-			state != platform.InstanceStateStandby {
-			err = errors.Join(err, fmt.Errorf("instance %s is %s, not running", cmp.Or(inst.Name, inst.UUID), state))
-		}
-	}
 	if err != nil {
-		return created, errors.Join(err, rollout.Undo(ctx, partition, Instance{}, created))
+		return undo(err)
+	}
+	newKeys := make(multimetro.Keys, len(created))
+	for i, r := range created {
+		newKeys[i] = r.(Instance).key
 	}
 
-	if err := partition.WrapDeletable(Instance{}).Delete(ctx, oldKeys); err != nil {
-		// The new instances are the wanted state by now, so they stay and the
-		// group holds both sets until the old ones are dealt with.
-		return created, fmt.Errorf("the new instances are up, but deleting the replaced ones failed, so %s are still in the service group: %w",
-			strings.Join(oldKeys, " "), err)
+	if mode == RolloutReplace {
+		log.G(ctx).Info().
+			Strs("instances", oldKeys.Strings()).
+			Msg("stopping the replaced instances")
+		stopped = running
+		if _, err := stopInstances(ctx, g, oldKeys, StopOpts{DrainTimeout: -1}); err != nil {
+			return undo(fmt.Errorf("stopping the replaced instances: %w", err))
+		}
+		if err := waitInstances(ctx, g, oldKeys, platform.InstanceStateStopped); err != nil {
+			return undo(fmt.Errorf("waiting for the replaced instances to stop: %w", err))
+		}
+		if _, err := startInstances(ctx, g, newKeys); err != nil {
+			return undo(fmt.Errorf("starting the new instances: %w", err))
+		}
+	}
+
+	if err := instancesUp(ctx, newKeys); err != nil {
+		return undo(fmt.Errorf("the new instances did not come up: %w", err))
+	}
+
+	if c.RolloutHealthyAfter > 0 {
+		log.G(ctx).Info().
+			Str("healthy-after", c.RolloutHealthyAfter.String()).
+			Msg("keeping the new instances up before the replaced ones are removed")
+		select {
+		case <-ctx.Done():
+			return undo(fmt.Errorf("rollout interrupted while the new instances were up: %s", ctx.Err()))
+		case <-time.After(c.RolloutHealthyAfter):
+		}
+		if err := instancesUp(ctx, newKeys); err != nil {
+			return undo(fmt.Errorf("the new instances did not stay up: %w", err))
+		}
+	}
+
+	if err := partition.WrapDeletable(Instance{}).Delete(ctx, oldKeys.Strings()); err != nil {
+		left := oldKeys.Strings()
+		results, getErr := (Instance{}).Get(ctx, left)
+		if _, ok := errors.AsType[group.ErrRefNotFound](getErr); getErr == nil || ok {
+			left = left[:0]
+			for _, r := range results {
+				inst := r.(Instance)
+				left = append(left, cmp.Or(inst.Name, inst.UUID))
+			}
+		}
+		if len(left) > 0 {
+			return created, fmt.Errorf("the new instances are up, but deleting the replaced ones failed, so %s are still in the service group: %w",
+				strings.Join(left, " "), err)
+		}
+		log.G(ctx).Warn().Err(err).
+			Msg("the replaced instances are gone, but their delete reported an error")
 	}
 	log.G(ctx).Info().
-		Strs("instances", oldKeys).
+		Strs("instances", oldKeys.Strings()).
 		Msg("replaced instances deleted")
+	if err := c.Output.WithDefault(cmd.PrinterTypeKeyValue).Print(ctx, stdio.Stdout, c.Field, Instance{}, created...); err != nil {
+		return created, err
+	}
 	return created, nil
+}
+
+// restoreInstances starts the instances a rollout stopped and reports whether
+// they came back.
+func restoreInstances(ctx context.Context, g *group.Group[multimetro.MetroClient], keys multimetro.Keys) error {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), rolloutWaitTimeout)
+	defer cancel()
+
+	log.G(ctx).Warn().
+		Strs("instances", keys.Strings()).
+		Msg("unwinding the rollout, starting the replaced instances again")
+	if _, err := startInstances(ctx, g, keys); err != nil {
+		return fmt.Errorf("starting the replaced instances again: %w", err)
+	}
+	if err := instancesUp(ctx, keys); err != nil {
+		return fmt.Errorf("the replaced instances did not come back: %w", err)
+	}
+	return nil
+}
+
+// rolloutTarget reads back the service group whose instances a rollout
+// replaces, with a key for each of them.
+func rolloutTarget(ctx context.Context, fields []resource.Field, svc *InstanceService) (ServiceGroup, multimetro.Keys, error) {
+	var none ServiceGroup
+	metro, _ := patch.CreateValue[LinkName[Metro]](fields, "metro")
+	key := multimetro.Key{Metro: cmp.Or(svc.Metro, string(metro)), UUID: svc.UUID}
+	if svc.UUID == "" {
+		key.Name = svc.Name
+	}
+	results, err := (ServiceGroup{}).Get(ctx, []string{key.Canonical()})
+	if err != nil {
+		return none, nil, fmt.Errorf("looking up service group %q: %w", key.Canonical(), err)
+	}
+	if len(results) == 0 {
+		return none, nil, fmt.Errorf("service group %q not found", key.Canonical())
+	}
+	svcGroup := results[0].(ServiceGroup)
+
+	old := make(multimetro.Keys, 0, len(svcGroup.Instances))
+	for _, inst := range svcGroup.Instances {
+		key := multimetro.Key{
+			Metro: cmp.Or(inst.Metro, string(svcGroup.Metro)),
+			Name:  inst.Name,
+			UUID:  inst.UUID,
+		}
+		if key.Name == "" && key.UUID == "" {
+			continue
+		}
+		old = append(old, key)
+	}
+	return svcGroup, old, nil
+}
+
+// instancesUp waits for every instance to run and reports the ones that do
+// not. An instance a metro does not list yet is read again.
+func instancesUp(ctx context.Context, keys multimetro.Keys) error {
+	ctx, cancel := context.WithTimeout(ctx, rolloutWaitTimeout)
+	defer cancel()
+
+	for {
+		err := checkInstancesUp(ctx, keys)
+		if !errors.Is(err, errInstancePending) {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(rolloutPollInterval):
+		}
+	}
+}
+
+// checkInstancesUp reads the instances back once and reports why any of them
+// is not up.
+func checkInstancesUp(ctx context.Context, keys multimetro.Keys) error {
+	results, err := (Instance{}).Get(ctx, keys.Strings())
+	if err != nil {
+		if _, ok := errors.AsType[group.ErrRefNotFound](err); ok {
+			return fmt.Errorf("%w: %w", errInstancePending, err)
+		}
+		return err
+	}
+	var pending, failed []error
+	for _, r := range results {
+		inst := r.(Instance)
+		name := cmp.Or(inst.Name, inst.UUID)
+		switch platform.InstanceState(inst.State) {
+		case platform.InstanceStateRunning, platform.InstanceStateStandby:
+		case platform.InstanceStateStarting:
+			pending = append(pending, fmt.Errorf("%w: instance %s is %s", errInstancePending, name, inst.State))
+		default:
+			failed = append(failed, fmt.Errorf("instance %s is %s, not running", name, inst.State))
+		}
+	}
+	if len(failed) > 0 {
+		return errors.Join(append(failed, pending...)...)
+	}
+	return errors.Join(pending...)
 }
 
 type Instance struct {
@@ -1749,6 +1988,18 @@ func (Instance) Examples() map[cmd.CmdType][]kingkong.Example {
 	  --service-rollout`,
 				},
 			},
+			{
+				Description: "Roll a service group whose instances need sole access to their volume, and hold the new ones up for a minute first",
+				Commands: []string{
+					`unikraft instance create \
+	  --metro fra \
+	  --image my-db:v2 \
+	  --service my-db \
+	  --autostart \
+	  --service-rollout=replace \
+	  --rollout-healthy-after=1m`,
+				},
+			},
 		},
 		cmd.CmdTypeEdit: {
 			{
@@ -2191,6 +2442,70 @@ func (args *StopOpts) toReq(nameOrUUID platform.NameOrUUID) platform.StopInstanc
 		req.DrainTimeoutMs = &timeout
 	}
 	return req
+}
+
+// waitInstances blocks until every instance reaches a state.
+func waitInstances(ctx context.Context, g *group.Group[multimetro.MetroClient], keys multimetro.Keys, state platform.InstanceState) error {
+	ctx, cancel := context.WithTimeout(ctx, rolloutWaitTimeout)
+	defer cancel()
+
+	ask := func(ctx context.Context, keys multimetro.Keys) error {
+		return group.DoRefs(ctx, g, keys.Refs(), func(ctx context.Context, c multimetro.MetroClient, refs group.Refs) (group.Refs, error) {
+			log.G(ctx).Trace().Str("state", string(state)).Msg("waiting for instances")
+			reqs := make([]platform.WaitInstancesRequestItem, 0, len(refs))
+			for _, ref := range refs.NameOrUUIDs() {
+				reqs = append(reqs, platform.WaitInstancesRequestItem{
+					Name:     ref.Name,
+					Uuid:     ref.Uuid,
+					State:    &state,
+					TimeoutS: new(int64(-1)),
+				})
+			}
+			resp, err := timeouts.TryWithFallback(ctx, reqs, func(ctx context.Context, reqs []platform.WaitInstancesRequestItem) (*platform.Response[platform.WaitInstancesResponseData], error) {
+				return c.WaitInstances(ctx, reqs, platform.WaitInstancesOpts{})
+			})
+			if _, err := timeouts.Tolerate(ctx, resp, err, "instances did not reach the state in time"); err != nil {
+				return nil, err
+			}
+			if resp == nil || resp.Data == nil {
+				return nil, nil
+			}
+			var waited group.Refs
+			for _, instance := range resp.Data.Instances {
+				if instance.State != state {
+					log.G(ctx).Trace().
+						Str("instance", cmp.Or(instance.Name, instance.Uuid)).
+						Str("state", string(instance.State)).
+						Msgf("instance is not %s yet", state)
+					continue
+				}
+				waited = append(waited, group.Ref{
+					Metro: c.Metro.Name,
+					Name:  instance.Name,
+					UUID:  instance.Uuid,
+				})
+			}
+			return waited, nil
+		})
+	}
+
+	pending := keys
+	for {
+		err := ask(ctx, pending)
+		notFound, ok := errors.AsType[group.ErrRefNotFound](err)
+		if err == nil || !ok {
+			return err
+		}
+		pending = make(multimetro.Keys, 0, len(notFound.Refs))
+		for _, ref := range notFound.Refs {
+			pending = append(pending, multimetro.Key(ref))
+		}
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(rolloutPollInterval):
+		}
+	}
 }
 
 func startInstances(ctx context.Context, g *group.Group[multimetro.MetroClient], keys multimetro.Keys) (multimetro.Keys, error) {

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -100,6 +100,12 @@ func (InstanceRunCmd) Examples() []kingkong.Example {
 				`unikraft instance run --metro=fra --image=my-app:latest --plugin 'name=sandbox,image=plugins/sandbox:latest,config={"persist_path":"/data"}'`,
 			},
 		},
+		{
+			Description: "Roll every instance in a service group over to a new image",
+			Commands: []string{
+				"unikraft instance run --image=my-app:v2 --service=api --service-rollout",
+			},
+		},
 	}
 }
 

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -773,7 +773,8 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, stdio config.Stdio, part
 type ResourceCreateCmd[R resource.CreatableResource] struct {
 	SetArgs
 
-	generated *FlagSet
+	generated  *FlagSet
+	resolution *createResolution
 
 	Visual bool   `xor:"edit-mode" help:"Open an editor to modify fields visually."`
 	Cmd    string `xor:"edit-mode" help:"Run a command to edit fields (receives YAML on stdin, outputs edited YAML on stdout)."`
@@ -828,14 +829,25 @@ func (cmd *ResourceCreateCmd[R]) Run(ctx context.Context, stdio config.Stdio, pa
 	return err
 }
 
-func (cmd *ResourceCreateCmd[R]) RunResources(ctx context.Context, stdio config.Stdio, partition *resource.Partition) ([]resource.Resource, error) {
+// createResolution is the field state a create works from.
+type createResolution struct {
+	fields  []resource.Field
+	patched []resource.Field
+	create  []resource.Field
+}
+
+// resolve works out the field state from the flags.
+func (cmd *ResourceCreateCmd[R]) resolve(ctx context.Context) (*createResolution, error) {
+	if cmd.resolution != nil {
+		return cmd.resolution, nil
+	}
 	spec, err := cmd.toPatchSpec()
 	if err != nil {
 		return nil, err
 	}
 
 	var empty R
-	r := partition.WrapCreatable(empty)
+	var res createResolution
 	fieldsResource := resource.Resource(empty)
 	if typed, ok := any(empty).(interface {
 		WithType(string) resource.Resource
@@ -846,18 +858,13 @@ func (cmd *ResourceCreateCmd[R]) RunResources(ctx context.Context, stdio config.
 			fieldsResource = typed.WithType(values[0])
 		}
 	}
-	fields, err := fieldsResource.Fields(ctx)
+	res.fields, err = fieldsResource.Fields(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get fields: %w", err)
 	}
-	patched, err := patch.PatchedFields(ctx, fields, spec)
+	res.patched, err = patch.PatchedFields(ctx, res.fields, spec)
 	if err != nil {
 		return nil, err
-	}
-
-	// Handle --save: write YAML to file and exit
-	if cmd.Save != "" {
-		return nil, saveYAML(cmd.Save, stdio, empty, fields, patched, true)
 	}
 
 	// Handle different editing modes (mutually exclusive via xor:"edit-mode" tag)
@@ -874,24 +881,60 @@ func (cmd *ResourceCreateCmd[R]) RunResources(ctx context.Context, stdio config.
 		editor = patch.ContentEditorFunc(cmd.Load)
 	}
 	if editor != nil {
-		patched, err = patch.Create(ctx, empty, fields, patched, editor)
+		res.patched, err = patch.Create(ctx, empty, res.fields, res.patched, editor)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	patchedFields := patch.FilterCreateFields(patched)
+	res.create = patch.FilterCreateFields(res.patched)
+	cmd.resolution = &res
+	return cmd.resolution, nil
+}
 
-	// Validate required fields before printing/applying
-	if err := patch.ValidateRequired(fields, patched, true); err != nil {
+// CreateFields returns the create patches this command applies.
+func (cmd *ResourceCreateCmd[R]) CreateFields(ctx context.Context) ([]resource.Field, error) {
+	res, err := cmd.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return res.create, nil
+}
+
+// SetCreateFields replaces the create patches CreateFields returned, so a
+// wrapping command can decide a value the flags do not carry.
+func (cmd *ResourceCreateCmd[R]) SetCreateFields(ctx context.Context, fields []resource.Field) error {
+	res, err := cmd.resolve(ctx)
+	if err != nil {
+		return err
+	}
+	res.create = fields
+	return nil
+}
+
+func (cmd *ResourceCreateCmd[R]) RunResources(ctx context.Context, stdio config.Stdio, partition *resource.Partition) ([]resource.Resource, error) {
+	res, err := cmd.resolve(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var empty R
+
+	if cmd.Save != "" {
+		return nil, saveYAML(cmd.Save, stdio, empty, res.fields, res.patched, true)
+	}
+
+	// Validate required fields before printing/applying, against the patches
+	// the create applies.
+	if err := patch.ValidateRequired(res.fields, res.create, true); err != nil {
 		return nil, err
 	}
 
 	if cmd.DryRun {
-		return nil, PrintPatches(stdio.Stdout, patchedFields, true)
+		return nil, PrintPatches(stdio.Stdout, res.create, true)
 	}
 
-	resources, opErr := r.Create(ctx, patchedFields)
+	resources, opErr := partition.WrapCreatable(empty).Create(ctx, res.create)
 	if opErr != nil && len(resources) == 0 {
 		return nil, opErr
 	}

--- a/internal/resource/cmd/cmd_test.go
+++ b/internal/resource/cmd/cmd_test.go
@@ -2211,3 +2211,44 @@ func TestFilterComparisonOperators(t *testing.T) {
 		assert.Contains(t, out.String(), "test3")
 	})
 }
+
+func TestCreateFieldsSetByWrapper(t *testing.T) {
+	env := resourcet.NewTestEnv()
+	ctx := resourcet.WithTestEnv(context.Background(), env)
+	partition := &resource.Partition{}
+
+	var out bytes.Buffer
+	cmd := &ResourceCreateCmd[resourcet.TestResource]{
+		Set: []map[string]string{
+			{"name": "test-wrapped"},
+			{"settings.foo": "100"},
+		},
+		Output: Printer{Type: PrinterTypeQuiet},
+	}
+
+	fields, err := cmd.CreateFields(ctx)
+	require.NoError(t, err)
+
+	// The create patches hold no edit-only field.
+	assert.Empty(t, resource.GetFieldByPathString(fields, "edit_only"))
+
+	// A wrapping command decides a value over the one the flags gave. The
+	// create works from the same resolution, so the new value reaches it.
+	replaced := false
+	for _, field := range resource.GetFieldByPathString(fields, "settings.foo") {
+		if field.Create != nil {
+			field.Create.Set = 250
+			replaced = true
+		}
+	}
+	require.True(t, replaced)
+	require.NoError(t, cmd.SetCreateFields(ctx, fields))
+
+	resources, err := cmd.RunResources(ctx, testStdio(&out), partition)
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+
+	created := resources[0].(resourcet.TestResource)
+	assert.Equal(t, "test-wrapped", created.Name)
+	assert.Equal(t, 250, created.Settings.Foo)
+}

--- a/internal/resource/patch/value.go
+++ b/internal/resource/patch/value.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package patch
+
+import (
+	"unikraft.com/cli/internal/resource"
+)
+
+// CreateValue reads the value a create sets at path.
+func CreateValue[T any](fields []resource.Field, path string) (T, bool) {
+	for _, field := range resource.GetFieldByPathString(fields, path) {
+		if field.Create == nil || field.Create.Set == nil {
+			continue
+		}
+		if v, ok := field.Create.Set.(T); ok {
+			return v, true
+		}
+	}
+	var zero T
+	return zero, false
+}
+
+// SetCreateValue sets what a create applies at path, replacing any patch the
+// flags produced.
+func SetCreateValue(fields []resource.Field, path string, set any) []resource.Field {
+	found := false
+	for _, field := range resource.GetFieldByPathString(fields, path) {
+		if field.Create == nil {
+			continue
+		}
+		field.Create.Set = set
+		found = true
+	}
+	if found {
+		return fields
+	}
+	return append(fields, resource.Field{Name: path, Create: &resource.Patch{Set: set}})
+}

--- a/internal/resource/patch/value_test.go
+++ b/internal/resource/patch/value_test.go
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package patch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"unikraft.com/cli/internal/resource"
+)
+
+// createFields builds the field tree the value accessors read.
+func createFields() []resource.Field {
+	return []resource.Field{
+		{Name: "autostart", Create: &resource.Patch{Set: true}},
+		{Name: "replicas", Create: &resource.Patch{}},
+		{Name: "features", Create: &resource.Patch{Add: []string{"a"}}},
+		{Name: "image"},
+		{Name: "resources", Create: &resource.Patch{}, Subfields: []resource.Field{
+			{Name: "vcpus", Create: &resource.Patch{Set: 4}},
+			{Name: "memory"},
+		}},
+	}
+}
+
+func TestCreateValue(t *testing.T) {
+	fields := createFields()
+
+	v, ok := CreateValue[bool](fields, "autostart")
+	assert.True(t, ok)
+	assert.True(t, v)
+
+	n, ok := CreateValue[int](fields, "resources.vcpus")
+	assert.True(t, ok)
+	assert.Equal(t, 4, n)
+
+	// A patch that sets nothing, a field with no patch at all and a field the
+	// tree does not carry all read as unset.
+	_, ok = CreateValue[int64](fields, "replicas")
+	assert.False(t, ok)
+	_, ok = CreateValue[string](fields, "image")
+	assert.False(t, ok)
+	_, ok = CreateValue[string](fields, "nothing")
+	assert.False(t, ok)
+	_, ok = CreateValue[[]string](fields, "features")
+	assert.False(t, ok)
+
+	// The type has to match, so a guard reading the wrong one sees no value.
+	_, ok = CreateValue[int32](fields, "resources.vcpus")
+	assert.False(t, ok)
+}
+
+func TestSetCreateValue(t *testing.T) {
+	t.Run("replaces the value a patch already sets", func(t *testing.T) {
+		fields := SetCreateValue(createFields(), "autostart", false)
+		require.Len(t, fields, 5)
+		v, ok := CreateValue[bool](fields, "autostart")
+		assert.True(t, ok)
+		assert.False(t, v)
+	})
+
+	t.Run("fills a patch that sets nothing yet", func(t *testing.T) {
+		fields := SetCreateValue(createFields(), "replicas", int64(3))
+		require.Len(t, fields, 5)
+		v, ok := CreateValue[int64](fields, "replicas")
+		assert.True(t, ok)
+		assert.Equal(t, int64(3), v)
+	})
+
+	t.Run("adds a path the fields do not carry", func(t *testing.T) {
+		fields := SetCreateValue(createFields(), "vsock", true)
+		require.Len(t, fields, 6)
+		v, ok := CreateValue[bool](fields, "vsock")
+		assert.True(t, ok)
+		assert.True(t, v)
+	})
+
+	t.Run("reaches a nested patch", func(t *testing.T) {
+		fields := SetCreateValue(createFields(), "resources.vcpus", 8)
+		require.Len(t, fields, 5)
+		v, ok := CreateValue[int](fields, "resources.vcpus")
+		assert.True(t, ok)
+		assert.Equal(t, 8, v)
+	})
+
+	t.Run("a field with no patch is not written through", func(t *testing.T) {
+		fields := SetCreateValue(createFields(), "image", "nginx")
+		require.Len(t, fields, 6)
+		assert.Equal(t, "image", fields[5].Name)
+	})
+}

--- a/internal/rollout/rollout.go
+++ b/internal/rollout/rollout.go
@@ -8,6 +8,7 @@ package rollout
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/cloud/sdk/platform/group"
@@ -15,25 +16,47 @@ import (
 
 	"unikraft.com/cli/internal/multimetro"
 	"unikraft.com/cli/internal/resource"
-	"unikraft.com/cli/internal/types"
 )
 
-// Platform defaults for an instance that sets neither, as the create request
-// documents them in the SDK.
-const (
-	defaultVcpus    = 1
-	defaultMemoryMb = 128
-)
+// Footprint is the live capacity a set of instances holds.
+type Footprint struct {
+	Instances int64
+	Vcpus     int64
+	MemoryMb  int64
+}
 
-// ValidateCapacity reports why the metro cannot take count more instances
-// while the ones they replace still run. The platform enforces the real limits.
-func ValidateCapacity(ctx context.Context, metro string, autoscale bool, count int64, fields []resource.Field) error {
+// Known reports whether the footprint carries a per-instance size.
+func (f Footprint) Known() bool {
+	return f.Vcpus > 0 && f.MemoryMb > 0
+}
+
+// CapacityOpts describes the capacity one rollout needs.
+type CapacityOpts struct {
+	Metro string
+	// Count is how many instances the rollout creates.
+	Count int64
+	// Concurrent says the new instances run alongside the ones they replace,
+	// so the rollout gets none of the replaced capacity back.
+	Concurrent bool
+	// Size is what one new instance takes.
+	Size Footprint
+	// Freed is the live capacity the replaced instances give up.
+	Freed Footprint
+}
+
+// ValidateCapacity reports why the metro cannot take the instances a rollout
+// adds. The platform enforces the real limits.
+func ValidateCapacity(ctx context.Context, opts CapacityOpts) error {
 	g, err := multimetro.NewClient(ctx)
 	if err != nil {
 		return err
 	}
+	if !slices.Contains(g.Names(), opts.Metro) {
+		return fmt.Errorf("metro %q is not configured", opts.Metro)
+	}
+
 	var quotas platform.Quotas
-	if err := group.DoMetro(ctx, g, metro, func(ctx context.Context, mc multimetro.MetroClient) error {
+	if err := group.DoMetro(ctx, g, opts.Metro, func(ctx context.Context, mc multimetro.MetroClient) error {
 		log.G(ctx).Trace().Msg("fetching quotas for the rollout")
 		resp, err := mc.GetUser(ctx)
 		if err != nil {
@@ -45,35 +68,45 @@ func ValidateCapacity(ctx context.Context, metro string, autoscale bool, count i
 		quotas = resp.Data.Quotas[0]
 		return nil
 	}); err != nil {
-		log.G(ctx).Debug().Err(err).Msg("skipping the rollout capacity check")
+		log.G(ctx).Warn().Err(err).
+			Msg("cannot read the quotas, skipping rollout capacity check")
 		return nil
 	}
-
-	vcpus := int64(defaultVcpus)
-	if v, ok := FieldValue[int](fields, "resources.vcpus"); ok && v > 0 {
-		vcpus = int64(v)
+	if !opts.Size.Known() {
+		log.G(ctx).Warn().
+			Msg("checking only the instance count")
 	}
-	memory := int64(defaultMemoryMb)
-	if v, ok := FieldValue[types.SizeMebibytes](fields, "resources.memory"); ok && v > 0 {
-		memory = int64(v)
-	}
+	return checkQuotas(quotas, opts)
+}
 
-	for _, q := range []struct {
-		what      string
-		used, max int64
-		need      int64
-	}{
-		{"instances", quotas.Used.Instances, quotas.Hard.Instances, count},
-		{"live instances", quotas.Used.LiveInstances, quotas.Hard.LiveInstances, count},
-		{"live vCPUs", quotas.Used.LiveVcpus, quotas.Hard.LiveVcpus, count * vcpus},
-		{"live memory in MiB", quotas.Used.LiveMemoryMb, quotas.Hard.LiveMemoryMb, count * memory},
-	} {
-		if q.max > 0 && q.used+q.need > q.max {
-			return fmt.Errorf("not enough room to roll %d instance(s): %d of %d %s in use, the rollout needs %d more", count, q.used, q.max, q.what, q.need)
+// quotaRow is one quota a rollout is checked against.
+type quotaRow struct {
+	what      string
+	used, max int64
+	need      int64
+}
+
+// checkQuotas reports which quota the instances a rollout adds go over. A
+// rollout that stops the instances it replaces gets their capacity back.
+func checkQuotas(quotas platform.Quotas, opts CapacityOpts) error {
+	freed := opts.Freed
+	if opts.Concurrent {
+		freed = Footprint{}
+	}
+	rows := []quotaRow{
+		{"instances", quotas.Used.Instances, quotas.Hard.Instances, opts.Count},
+		{"live instances", quotas.Used.LiveInstances, quotas.Hard.LiveInstances, opts.Count - freed.Instances},
+	}
+	if opts.Size.Known() {
+		rows = append(rows,
+			quotaRow{"live vCPUs", quotas.Used.LiveVcpus, quotas.Hard.LiveVcpus, opts.Count*opts.Size.Vcpus - freed.Vcpus},
+			quotaRow{"live memory in MiB", quotas.Used.LiveMemoryMb, quotas.Hard.LiveMemoryMb, opts.Count*opts.Size.MemoryMb - freed.MemoryMb},
+		)
+	}
+	for _, q := range rows {
+		if q.need > 0 && q.max > 0 && q.used+q.need > q.max {
+			return fmt.Errorf("not enough room to roll %d instance(s): %d of %d %s in use, the rollout needs %d more", opts.Count, q.used, q.max, q.what, q.need)
 		}
-	}
-	if limit := quotas.Limits.MaxAutoscaleSize; autoscale && limit > 0 && 2*count > limit {
-		return fmt.Errorf("not enough room to roll %d instance(s): both sets add up to %d instances, over the maximum autoscale group size of %d", count, 2*count, limit)
 	}
 	return nil
 }
@@ -91,23 +124,9 @@ func Undo(ctx context.Context, partition *resource.Partition, r resource.Deletab
 	name := r.Type().Name
 	log.G(ctx).Warn().
 		Strs(name+"s", keys).
-		Msgf("rollout failed, deleting the new %ss", name)
+		Msgf("unwinding the rollout, deleting the new %ss", name)
 	if err := partition.WrapDeletable(r).Delete(ctx, keys); err != nil {
-		return fmt.Errorf("deleting the new %ss after a failed rollout: %w", name, err)
+		return fmt.Errorf("deleting the new %ss after an unfinished rollout: %w", name, err)
 	}
 	return nil
-}
-
-// FieldValue reads the value a create sets at path.
-func FieldValue[T any](fields []resource.Field, path string) (T, bool) {
-	for _, field := range resource.GetFieldByPathString(fields, path) {
-		if field.Create == nil || field.Create.Set == nil {
-			continue
-		}
-		if v, ok := field.Create.Set.(T); ok {
-			return v, true
-		}
-	}
-	var zero T
-	return zero, false
 }

--- a/internal/rollout/rollout.go
+++ b/internal/rollout/rollout.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package rollout
+
+import (
+	"context"
+	"fmt"
+
+	"unikraft.com/cloud/sdk/platform"
+	"unikraft.com/cloud/sdk/platform/group"
+	"unikraft.com/x/log"
+
+	"unikraft.com/cli/internal/multimetro"
+	"unikraft.com/cli/internal/resource"
+	"unikraft.com/cli/internal/types"
+)
+
+// Platform defaults for an instance that sets neither, as the create request
+// documents them in the SDK.
+const (
+	defaultVcpus    = 1
+	defaultMemoryMb = 128
+)
+
+// ValidateCapacity reports why the metro cannot take count more instances
+// while the ones they replace still run. The platform enforces the real limits.
+func ValidateCapacity(ctx context.Context, metro string, autoscale bool, count int64, fields []resource.Field) error {
+	g, err := multimetro.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+	var quotas platform.Quotas
+	if err := group.DoMetro(ctx, g, metro, func(ctx context.Context, mc multimetro.MetroClient) error {
+		log.G(ctx).Trace().Msg("fetching quotas for the rollout")
+		resp, err := mc.GetUser(ctx)
+		if err != nil {
+			return err
+		}
+		if resp.Data == nil || len(resp.Data.Quotas) == 0 {
+			return fmt.Errorf("no quota data")
+		}
+		quotas = resp.Data.Quotas[0]
+		return nil
+	}); err != nil {
+		log.G(ctx).Debug().Err(err).Msg("skipping the rollout capacity check")
+		return nil
+	}
+
+	vcpus := int64(defaultVcpus)
+	if v, ok := FieldValue[int](fields, "resources.vcpus"); ok && v > 0 {
+		vcpus = int64(v)
+	}
+	memory := int64(defaultMemoryMb)
+	if v, ok := FieldValue[types.SizeMebibytes](fields, "resources.memory"); ok && v > 0 {
+		memory = int64(v)
+	}
+
+	for _, q := range []struct {
+		what      string
+		used, max int64
+		need      int64
+	}{
+		{"instances", quotas.Used.Instances, quotas.Hard.Instances, count},
+		{"live instances", quotas.Used.LiveInstances, quotas.Hard.LiveInstances, count},
+		{"live vCPUs", quotas.Used.LiveVcpus, quotas.Hard.LiveVcpus, count * vcpus},
+		{"live memory in MiB", quotas.Used.LiveMemoryMb, quotas.Hard.LiveMemoryMb, count * memory},
+	} {
+		if q.max > 0 && q.used+q.need > q.max {
+			return fmt.Errorf("not enough room to roll %d instance(s): %d of %d %s in use, the rollout needs %d more", count, q.used, q.max, q.what, q.need)
+		}
+	}
+	if limit := quotas.Limits.MaxAutoscaleSize; autoscale && limit > 0 && 2*count > limit {
+		return fmt.Errorf("not enough room to roll %d instance(s): both sets add up to %d instances, over the maximum autoscale group size of %d", count, 2*count, limit)
+	}
+	return nil
+}
+
+// Undo deletes the resources a failed rollout created, so the rollout leaves
+// only the resources it started with.
+func Undo(ctx context.Context, partition *resource.Partition, r resource.DeletableResource, created []resource.Resource) error {
+	if len(created) == 0 {
+		return nil
+	}
+	keys := make([]string, len(created))
+	for i, res := range created {
+		keys[i] = res.Key().String()
+	}
+	name := r.Type().Name
+	log.G(ctx).Warn().
+		Strs(name+"s", keys).
+		Msgf("rollout failed, deleting the new %ss", name)
+	if err := partition.WrapDeletable(r).Delete(ctx, keys); err != nil {
+		return fmt.Errorf("deleting the new %ss after a failed rollout: %w", name, err)
+	}
+	return nil
+}
+
+// FieldValue reads the value a create sets at path.
+func FieldValue[T any](fields []resource.Field, path string) (T, bool) {
+	for _, field := range resource.GetFieldByPathString(fields, path) {
+		if field.Create == nil || field.Create.Set == nil {
+			continue
+		}
+		if v, ok := field.Create.Set.(T); ok {
+			return v, true
+		}
+	}
+	var zero T
+	return zero, false
+}


### PR DESCRIPTION
~~Open to UI/UX suggestions, right now it prints every new instance that was rolled~~
Completely reworked, now, as discussed below, added extra:
* Two modes, `rolling/replace`, one starting + deleting, one stopping + starting + deleting
* A configurable wait time to recheck that state is ok `--rollout-healthy-after`
* Made only for instances in services

Notable ickies still open to suggestions:
* Code needed to be added in the cmd resource to make sure that fields are accessed only once instead of twice
* Not quite so plug-and-play: I split things in a rollout package, but still a lot of helpers were needed in the `instance.go` itself

Closes: TOOL-794