### PR TITLE
fix: Remove rom file helper

### DIFF
--- a/cmd/unikraft/build_test.go
+++ b/cmd/unikraft/build_test.go
@@ -130,39 +130,6 @@ cmd: ["cat", "/rom/hello.txt"]
 			})
 	})
 
-	t.Run("rom-file", func(t *testing.T) {
-		var baseImage string
-		if r.cfg != nil {
-			baseImage = fmt.Sprintf("%s/busybox-romfile-e2e:$UNIQ_IMAGE", r.cfg.Profile.Organization)
-		}
-
-		r.
-			online().
-			withCleaners(buildCleaners).
-			withContext(map[string]string{
-				// Base image context: busybox with cat.
-				"base/Dockerfile": `FROM busybox:latest`,
-				"base/Kraftfile": `
-spec: v0.7
-name: busybox-romfile-e2e
-runtime: base-compat:latest
-rootfs:
-  format: erofs
-  source: ./Dockerfile
-cmd: ["cat", "/etc/consoled/config.yaml"]
-`,
-				// Single file with a different name than the destination.
-				"console.yaml": "greeting: Hello from ROM file!\n",
-			}).
-			run(t, []command{
-				{args: []string{unikraftCmd, "build", "base", "--output", baseImage}},
-				{args: []string{unikraftCmd, "run", "--name", "test-$UNIQ_INST", "--metro", metroName, "--output", "quiet", "--image", baseImage, "--rom", "file=console.yaml,at=/etc/consoled/config.yaml"}},
-				{args: []string{unikraftCmd, "instance", "wait", "--until", "state==stopped", "--timeout", "10s", "test-$UNIQ_INST"}},
-				{args: []string{unikraftCmd, "instance", "logs", "test-$UNIQ_INST"}},
-				{args: []string{unikraftCmd, "instance", "delete", "test-$UNIQ_INST"}},
-			})
-	})
-
 	t.Run("busybox", func(t *testing.T) {
 		if r.cfg == nil {
 			t.Skip("busybox tests require online config")

--- a/cmd/unikraft/testdata/TestGolden/instances/help
+++ b/cmd/unikraft/testdata/TestGolden/instances/help
@@ -49,7 +49,7 @@ stdout:
 	  service.soft-limit, service.hard-limit
 	  volumes, volumes.*, volumes.*.name, volumes.*.uuid, volumes.*.at,
 	  volumes.*.readonly, volumes.*.size
-	  roms, roms.*, roms.*.name, roms.*.image, roms.*.dir, roms.*.file, roms.*.at
+	  roms, roms.*, roms.*.name, roms.*.image, roms.*.dir, roms.*.at
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped
 	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
@@ -112,7 +112,7 @@ stdout:
 	  service.soft-limit, service.hard-limit
 	  volumes, volumes.*, volumes.*.name, volumes.*.uuid, volumes.*.at,
 	  volumes.*.readonly, volumes.*.size
-	  roms, roms.*, roms.*.name, roms.*.image, roms.*.dir, roms.*.file, roms.*.at
+	  roms, roms.*, roms.*.name, roms.*.image, roms.*.dir, roms.*.at
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped
 	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
@@ -183,7 +183,7 @@ stdout:
 	  service.soft-limit, service.hard-limit
 	  volumes, volumes.*, volumes.*.name, volumes.*.uuid, volumes.*.at,
 	  volumes.*.readonly, volumes.*.size
-	  roms, roms.*, roms.*.name, roms.*.image, roms.*.dir, roms.*.file, roms.*.at
+	  roms, roms.*, roms.*.name, roms.*.image, roms.*.dir, roms.*.at
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped
 	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
@@ -256,7 +256,7 @@ stdout:
 	  service.soft-limit, service.hard-limit
 	  volumes, volumes.*, volumes.*.name, volumes.*.uuid, volumes.*.at,
 	  volumes.*.readonly, volumes.*.size
-	  roms, roms.*, roms.*.name, roms.*.image, roms.*.dir, roms.*.file, roms.*.at
+	  roms, roms.*, roms.*.name, roms.*.image, roms.*.dir, roms.*.at
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped
 	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
@@ -327,13 +327,6 @@ stdout:
 	  	  --metro fra \
 	  	  --template my-template
 
-	  # Create an instance with a ROM file
-	  unikraft instance create \
-	  	  --name demo-instance \
-	  	  --metro fra \
-	  	  --image my-app:latest \
-	  	  --rom file=./config.yaml,at=/etc/app/config.yaml
-
 	Fields:
 	  metro
 	  name
@@ -349,7 +342,7 @@ stdout:
 	  service.soft-limit, service.hard-limit
 	  volumes, volumes.*, volumes.*.name, volumes.*.uuid, volumes.*.at,
 	  volumes.*.readonly, volumes.*.size
-	  roms, roms.*, roms.*.name, roms.*.image, roms.*.dir, roms.*.file, roms.*.at
+	  roms, roms.*, roms.*.name, roms.*.image, roms.*.dir, roms.*.at
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped
 	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
@@ -422,7 +415,7 @@ stdout:
 	          [examples: my-vol:/data, cache:/tmp:ro, data:/mnt:size=10GiB]
 	      --rom=image=<ref>,at=<path>
 	          Attach ROM.
-	          [examples: image=myuser/my-rom:latest,at=/rom0,name=my-rom, dir=./mydata,at=/rom, file=./config.yaml,at=/etc/app/config.yaml]
+	          [examples: image=myuser/my-rom:latest,at=/rom0,name=my-rom, dir=./mydata,at=/rom]
 	      --service=<name>
 	          Service group name or key.
 	  -p, --publish=<src>:<dest>[/<handlers>]
@@ -467,13 +460,13 @@ stdout:
 	  # Resize instance memory
 	  unikraft instance edit demo-instance --memory 256
 
-	  # Attach a ROM file to an instance
+	  # Attach a ROM image to an instance
 	  unikraft instance edit demo-instance \
-	  	  --set roms=file=./config.yaml,at=/etc/app/config.yaml
+	  	  --set roms=image=myuser/my-rom:latest,at=/rom0
 
 	  # Add a ROM to an instance without replacing existing ones
 	  unikraft instance edit demo-instance \
-	  	  --add roms=file=./extra.yaml,at=/etc/app/extra.yaml
+	  	  --add roms=dir=./mydata,at=/rom
 
 	  # Remove a ROM from an instance by name
 	  unikraft instance edit demo-instance --del roms=name=my-rom
@@ -493,7 +486,7 @@ stdout:
 	  service.soft-limit, service.hard-limit
 	  volumes, volumes.*, volumes.*.name, volumes.*.uuid, volumes.*.at,
 	  volumes.*.readonly, volumes.*.size
-	  roms, roms.*, roms.*.name, roms.*.image, roms.*.dir, roms.*.file, roms.*.at
+	  roms, roms.*, roms.*.name, roms.*.image, roms.*.dir, roms.*.at
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped
 	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
@@ -562,7 +555,7 @@ stdout:
 	          [examples: 1, 2, 4]
 	      --rom=image=<ref>,at=<path>
 	          Attach ROM.
-	          [examples: image=myuser/my-rom:latest,at=/rom0,name=my-rom, dir=./mydata,at=/rom, file=./config.yaml,at=/etc/app/config.yaml]
+	          [examples: image=myuser/my-rom:latest,at=/rom0,name=my-rom, dir=./mydata,at=/rom]
 	      --scale-to-zero=<key>=<value>
 	          Scale-to-zero options.
 	            policy: on | off
@@ -602,7 +595,7 @@ stdout:
 	  service.soft-limit, service.hard-limit
 	  volumes, volumes.*, volumes.*.name, volumes.*.uuid, volumes.*.at,
 	  volumes.*.readonly, volumes.*.size
-	  roms, roms.*, roms.*.name, roms.*.image, roms.*.dir, roms.*.file, roms.*.at
+	  roms, roms.*, roms.*.name, roms.*.image, roms.*.dir, roms.*.at
 	  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
 	  timestamps, timestamps.created, timestamps.started, timestamps.stopped
 	  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -15,7 +15,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	pathpkg "path"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -80,7 +79,7 @@ type InstanceCreateCmd struct {
 	Vcpus  int                 `group:"flag-create" shortcut:"resources.vcpus" help:"Number of vCPUs." placeholder:"n" example:"1,2,4"`
 
 	Volume []InstanceVolume `group:"flag-create" shortcut:"volumes" short:"v" help:"Attach volume." placeholder:"<name>:<path>[:<options>]" example:"my-vol:/data,cache:/tmp:ro,data:/mnt:size=10GiB"`
-	Rom    []InstanceRom    `group:"flag-create" shortcut:"roms" sep:"none" help:"Attach ROM." placeholder:"image=<ref>,at=<path>" example:"image=myuser/my-rom:latest\\,at=/rom0\\,name=my-rom,dir=./mydata\\,at=/rom,file=./config.yaml\\,at=/etc/app/config.yaml"`
+	Rom    []InstanceRom    `group:"flag-create" shortcut:"roms" sep:"none" help:"Attach ROM." placeholder:"image=<ref>,at=<path>" example:"image=myuser/my-rom:latest\\,at=/rom0\\,name=my-rom,dir=./mydata\\,at=/rom"`
 
 	Service InstanceService `group:"flag-create" shortcut:"service" help:"Service group name or key." placeholder:"name"`
 	Publish []Service       `group:"flag-create" shortcut:"service.services" short:"p" help:"Publish port." placeholder:"<src>:<dest>[/<handlers>]" example:"443:8080/http+tls,80:8080/http"`
@@ -119,7 +118,7 @@ type InstanceEditCmd struct {
 	Memory types.SizeMebibytes `group:"flag-edit" shortcut:"resources.memory" short:"m" help:"Memory allocation." placeholder:"size" example:"128MiB,1GiB"`
 	Vcpus  int                 `group:"flag-edit" shortcut:"resources.vcpus" help:"Number of vCPUs." placeholder:"n" example:"1,2,4"`
 
-	Rom []InstanceRom `group:"flag-edit" shortcut:"roms" sep:"none" help:"Attach ROM." placeholder:"image=<ref>,at=<path>" example:"image=myuser/my-rom:latest\\,at=/rom0\\,name=my-rom,dir=./mydata\\,at=/rom,file=./config.yaml\\,at=/etc/app/config.yaml"`
+	Rom []InstanceRom `group:"flag-edit" shortcut:"roms" sep:"none" help:"Attach ROM." placeholder:"image=<ref>,at=<path>" example:"image=myuser/my-rom:latest\\,at=/rom0\\,name=my-rom,dir=./mydata\\,at=/rom"`
 
 	ScaleToZero InstanceScaleToZero `group:"flag-edit" shortcut:"scale-to-zero" help:"Scale-to-zero options.\n  policy: on | off\n  cooldown-time: cooldown in ms before scaling to zero\n  notify-time: notification time in ms before scaling to zero\n  stateful: true | false" placeholder:"<key>=<value>" example:"on,policy=on\\,cooldown-time=300,policy=on\\,stateful=true\\,cooldown-time=500\\,notify-time=100"`
 }
@@ -337,12 +336,10 @@ func (v *InstanceVolume) UnmarshalText(data []byte) error {
 //
 //	image=<ref>,at=<path>[,name=<name>]
 //	dir=<localpath>,at=<path>[,name=<name>]
-//	file=<localpath>,at=<destpath>[,name=<name>]
 type InstanceRom struct {
 	Name  string `name:"name" mirror:"name" json:"name,omitempty" field:",long"`
 	Image string `name:"image" mirror:"image" json:"image,omitempty" field:",long"`
 	Dir   string `name:"dir" json:"-" field:"dir,invisible,long"`
-	File  string `name:"file" json:"-" field:"file,invisible,long"`
 	At    string `name:"at" mirror:"at" json:"at,omitempty" field:",long"`
 }
 
@@ -404,28 +401,6 @@ func inlineFilesFromDir(dir string) ([]platform.InlineFile, error) {
 		return nil, fmt.Errorf("directory %q is empty", dir)
 	}
 	return files, nil
-}
-
-// inlineFileFromPath reads a single local file and returns it as a
-// base64-encoded InlineFile with the given destination path inside the ROM.
-func inlineFileFromPath(src string, destPath string) (platform.InlineFile, error) {
-	stat, err := os.Stat(src)
-	if err != nil {
-		return platform.InlineFile{}, err
-	}
-	if !stat.Mode().Type().IsRegular() {
-		return platform.InlineFile{}, fmt.Errorf("non-regular file %q not allow in ROM directory", src)
-	}
-	data, err := os.ReadFile(src)
-	if err != nil {
-		return platform.InlineFile{}, err
-	}
-	enc := platform.InlineFileEncodingBase64
-	return platform.InlineFile{
-		Path:     destPath,
-		Encoding: &enc,
-		Data:     base64.StdEncoding.EncodeToString(data),
-	}, nil
 }
 
 type InstanceScaleToZero struct {
@@ -736,27 +711,6 @@ func (Instance) Edit(ctx context.Context, target resource.Resource, fields []res
 		}
 	}
 
-	// Validate that file= ROMs have at= specified.
-	for _, field := range resource.GetFieldByPath(fields, resource.FieldPath{"roms"}) {
-		if field.Edit == nil {
-			continue
-		}
-		var romSets []any
-		if field.Edit.Set != nil {
-			romSets = append(romSets, field.Edit.Set)
-		}
-		if field.Edit.Add != nil {
-			romSets = append(romSets, field.Edit.Add)
-		}
-		for _, v := range romSets {
-			for _, rom := range v.([]*InstanceRom) {
-				if rom.File != "" && rom.At == "" {
-					return nil, fmt.Errorf("rom file=%q requires at= to specify the destination path", rom.File)
-				}
-			}
-		}
-	}
-
 	patches, err := patchRequests(fields, instancePatchSpec)
 	if err != nil {
 		return nil, err
@@ -851,23 +805,12 @@ func instancePatchSpec(path string, op patchOp, value any) (platform.UpdateInsta
 		}
 		var reqRoms []map[string]any
 		for _, rom := range roms {
-			if rom.Image == "" && rom.Dir == "" && rom.File == "" {
+			if rom.Image == "" && rom.Dir == "" {
 				continue
 			}
 
-			romAt := rom.At
-			if rom.File != "" && romAt != "" {
-				romAt = pathpkg.Dir(romAt)
-			}
-
 			reqRom := map[string]any{}
-			if rom.File != "" {
-				file, err := inlineFileFromPath(rom.File, "/"+pathpkg.Base(rom.At))
-				if err != nil {
-					return zero, nil, fmt.Errorf("reading rom file %q: %w", rom.File, err)
-				}
-				reqRom["files"] = []platform.InlineFile{file}
-			} else if rom.Dir != "" {
+			if rom.Dir != "" {
 				files, err := inlineFilesFromDir(rom.Dir)
 				if err != nil {
 					return zero, nil, fmt.Errorf("reading rom dir %q: %w", rom.Dir, err)
@@ -879,8 +822,8 @@ func instancePatchSpec(path string, op patchOp, value any) (platform.UpdateInsta
 			if rom.Name != "" {
 				reqRom["name"] = rom.Name
 			}
-			if romAt != "" {
-				reqRom["at"] = romAt
+			if rom.At != "" {
+				reqRom["at"] = rom.At
 			}
 			reqRoms = append(reqRoms, reqRom)
 		}
@@ -966,34 +909,15 @@ func (Instance) Create(ctx context.Context, fields []resource.Field) ([]resource
 				if rom.Dir != "" {
 					sources++
 				}
-				if rom.File != "" {
-					sources++
-				}
 				if sources > 1 {
-					return nil, fmt.Errorf("cannot specify more than one of image=, dir=, or file= for a ROM")
+					return nil, fmt.Errorf("cannot specify more than one of image= or dir= for a ROM")
 				}
 				if sources == 0 {
-					return nil, fmt.Errorf("must specify one of image=, dir=, or file= for a ROM")
-				}
-				if rom.File != "" && rom.At == "" {
-					return nil, fmt.Errorf("rom file=%q requires at= to specify the destination path", rom.File)
-				}
-
-				// For file= mode, the at= is the full destination path.
-				// We split it into the mountpoint (dir) and the filename.
-				romAt := rom.At
-				if rom.File != "" && romAt != "" {
-					romAt = pathpkg.Dir(romAt)
+					return nil, fmt.Errorf("must specify one of image= or dir= for a ROM")
 				}
 
 				var reqRom platform.CreateInstanceRequestRom
-				if rom.File != "" {
-					file, err := inlineFileFromPath(rom.File, "/"+pathpkg.Base(rom.At))
-					if err != nil {
-						return nil, fmt.Errorf("reading rom file %q: %w", rom.File, err)
-					}
-					reqRom.Files = []platform.InlineFile{file}
-				} else if rom.Dir != "" {
+				if rom.Dir != "" {
 					files, err := inlineFilesFromDir(rom.Dir)
 					if err != nil {
 						return nil, fmt.Errorf("reading rom dir %q: %w", rom.Dir, err)
@@ -1005,8 +929,8 @@ func (Instance) Create(ctx context.Context, fields []resource.Field) ([]resource
 				if rom.Name != "" {
 					reqRom.Name = &rom.Name
 				}
-				if romAt != "" {
-					atJSON, _ := json.Marshal(romAt)
+				if rom.At != "" {
+					atJSON, _ := json.Marshal(rom.At)
 					if reqRom.AdditionalProperties == nil {
 						reqRom.AdditionalProperties = make(map[string]json.RawMessage)
 					}
@@ -1190,16 +1114,6 @@ func (Instance) Examples() map[cmd.CmdType][]kingkong.Example {
 	  --template my-template`,
 				},
 			},
-			{
-				Description: "Create an instance with a ROM file",
-				Commands: []string{
-					`unikraft instance create \
-	  --name demo-instance \
-	  --metro fra \
-	  --image my-app:latest \
-	  --rom file=./config.yaml,at=/etc/app/config.yaml`,
-				},
-			},
 		},
 		cmd.CmdTypeEdit: {
 			{
@@ -1210,17 +1124,17 @@ func (Instance) Examples() map[cmd.CmdType][]kingkong.Example {
 				},
 			},
 			{
-				Description: "Attach a ROM file to an instance",
+				Description: "Attach a ROM image to an instance",
 				Commands: []string{
 					`unikraft instance edit demo-instance \
-	  --set roms=file=./config.yaml,at=/etc/app/config.yaml`,
+	  --set roms=image=myuser/my-rom:latest,at=/rom0`,
 				},
 			},
 			{
 				Description: "Add a ROM to an instance without replacing existing ones",
 				Commands: []string{
 					`unikraft instance edit demo-instance \
-	  --add roms=file=./extra.yaml,at=/etc/app/extra.yaml`,
+	  --add roms=dir=./mydata,at=/rom`,
 				},
 			},
 			{

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -95,12 +95,6 @@ func (RunCmd) Examples() []kingkong.Example {
 				"unikraft run --metro=dal --image=my-app:latest --restart=on-failure",
 			},
 		},
-		{
-			Description: "Deploy a new instance with a single config file as a ROM",
-			Commands: []string{
-				"unikraft run --metro=fra --image=my-app:latest --rom file=./config.yaml,at=/etc/app/config.yaml",
-			},
-		},
 	}
 }
 


### PR DESCRIPTION
This feature has super weird behavior:
- If I mount a `file` ROM to /etc/foo.txt, it'll replace the existing contents of /etc.
- If I mount two separate ROMs, one as /mnt/a.txt and another as /mnt/b.txt, this tries to create two mounts at /mnt, which conflict.

This feature really just needs platform support, so we should remove it from the CLI for now, and not try and hack it in.