### PR TITLE
fix: Use colorprofile detection on stdout/stderr

### DIFF
--- a/cmd/unikraft/main.go
+++ b/cmd/unikraft/main.go
@@ -18,6 +18,8 @@ import (
 	"github.com/alecthomas/kong"
 	jujuerrors "github.com/juju/errors"
 
+	"github.com/charmbracelet/colorprofile"
+
 	"unikraft.com/cli/internal/cmd"
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/logfmt"
@@ -39,8 +41,8 @@ func main() {
 		args  = os.Args[1:]
 		stdio = config.Stdio{
 			Stdin:  os.Stdin,
-			Stdout: os.Stdout,
-			Stderr: os.Stderr,
+			Stdout: colorprofile.NewWriter(os.Stdout, os.Environ()),
+			Stderr: colorprofile.NewWriter(os.Stderr, os.Environ()),
 		}
 	)
 


### PR DESCRIPTION
So that then we automatically downsample for all our normal outputs.

e.g. by setting `TERM=xterm COLORTERM=`, you can mimic a 16 color terminal, and get automatic downsampling.
<img width="592" height="361" alt="image" src="https://github.com/user-attachments/assets/24bf1297-f215-420f-aa1f-21dc7f6c0904" />
