### PR TITLE
fix(builder): Allow custom dockerfile names when building

### DIFF
--- a/cmd/unikraft/integration/build_test.go
+++ b/cmd/unikraft/integration/build_test.go
@@ -193,4 +193,45 @@ cmd: ["sh", "/entrypoint.sh"]
 			})
 		}
 	})
+
+	t.Run("busybox-custom-dockerfile", func(t *testing.T) {
+		r := runner(t, true)
+		imagePrefix := r.Config.Profile.Organization + "/busybox-custom-df-e2e"
+		imageTag := uniq()
+		instName := uniq()
+		image := imagePrefix + ":" + imageTag
+
+		dir := t.TempDir()
+		require.NoError(t, fstest.Apply(
+			fstest.CreateFile("App.dockerfile", []byte(`
+FROM busybox:latest
+COPY <<EOF /entrypoint.sh
+#!/bin/sh
+echo UNIKRAFT_E2E_OK
+EOF
+RUN chmod +x /entrypoint.sh
+`), 0o644),
+			fstest.CreateFile("Kraftfile", []byte(`
+spec: v0.7
+name: busybox-custom-df-e2e
+runtime: base-compat:latest
+rootfs:
+  format: erofs
+  source:
+    path: .
+    dockerfile: App.dockerfile
+cmd: ["sh", "/entrypoint.sh"]
+`), 0o644),
+		).Apply(dir))
+
+		r.Run(t, []string{"unikraft", "build", ".", "--output", image}, integ.WithWorkDir(dir))
+		r.Run(t, []string{"unikraft", "run", "--name", "test-" + instName, "--metro", r.Config.MetroName, "--output", "quiet", "--image", image})
+		r.Run(t, []string{"unikraft", "instance", "wait", "--until", "state==stopped", "--timeout", "10s", "test-" + instName})
+
+		out := r.Run(t, []string{"unikraft", "instance", "logs", "test-" + instName})
+		assert.Regexp(t, `UNIKRAFT_E2E_OK`, out)
+
+		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName})
+		r.Run(t, []string{"unikraft", "image", "delete", image})
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	unikraft.com/x/image-spec v0.0.0-20260508142614-1049e0f32dfa
 	unikraft.com/x/joinerrgroup v0.0.0-20260304162956-523940cab1de
 	unikraft.com/x/kingkong v0.0.0-20260331102539-2c733927b46f
-	unikraft.com/x/kraftfile v0.0.0-20260501125416-502eb6c9c39d
+	unikraft.com/x/kraftfile v0.0.0-20260522114044-e2da24d09716
 	unikraft.com/x/log v0.0.0-20260126171022-af62c17fcdf7
 	unikraft.com/x/ptr v0.0.0-20260126094137-ab6e717e5679
 )

--- a/go.sum
+++ b/go.sum
@@ -505,8 +505,8 @@ unikraft.com/x/joinerrgroup v0.0.0-20260304162956-523940cab1de h1:cm4FnPvnahRIK0
 unikraft.com/x/joinerrgroup v0.0.0-20260304162956-523940cab1de/go.mod h1:XND1VvLxwqKFGrmdwUTWps4WEpMm7HTHPQg9HWQtrxg=
 unikraft.com/x/kingkong v0.0.0-20260331102539-2c733927b46f h1:pT+qeeK2nWgSlRaIEKgkY2NoyptIrXc+Rr47ktoB5Fg=
 unikraft.com/x/kingkong v0.0.0-20260331102539-2c733927b46f/go.mod h1:x/sY2g/oA3GKDTZyOFC1xArmd6ZySwc4KZlp1MO8a2k=
-unikraft.com/x/kraftfile v0.0.0-20260501125416-502eb6c9c39d h1:x10/Kuf67r6UTYT0BuTbEkLdxHglWGY3eV+59WQFpWc=
-unikraft.com/x/kraftfile v0.0.0-20260501125416-502eb6c9c39d/go.mod h1:OYaIMOzV1IpbZCe2J3SuC5jvT4tAfR0XG9uOPPD+p50=
+unikraft.com/x/kraftfile v0.0.0-20260522114044-e2da24d09716 h1:xgZcUAs2QrPKNVXZDlx9ew0cN+kbStzbdLqJbuKsmxE=
+unikraft.com/x/kraftfile v0.0.0-20260522114044-e2da24d09716/go.mod h1:htyMc5oT22e2Z+yWbw1Pz61NAtEdJJTwRy5kRpKKJDE=
 unikraft.com/x/log v0.0.0-20260126171022-af62c17fcdf7 h1:kFOE7rmK33PiJ2GbWFd3v0WrE8DeAaQsPjrUQ+15CIU=
 unikraft.com/x/log v0.0.0-20260126171022-af62c17fcdf7/go.mod h1:f/+5628rnWTnRaRrCDD9mOMf7OV5QmkGIgARlTu4XGE=
 unikraft.com/x/ptr v0.0.0-20260126094137-ab6e717e5679 h1:ohptI7loX492JCbbn6yk13hAxysZHyGIZWN8hTw3080=

--- a/internal/builder/build.go
+++ b/internal/builder/build.go
@@ -32,7 +32,6 @@ type BuildOpts struct {
 	Labels map[string]string
 
 	// Buildkit params
-	// Dockerfile string
 	BuildArg []string
 	Target   string
 	Secrets  []*Secret
@@ -42,8 +41,9 @@ type BuildOpts struct {
 }
 
 type FSOpts struct {
-	Path string
-	Type kraftfile.SourceType
+	Path       string
+	Type       kraftfile.SourceType
+	Dockerfile string
 
 	// Output params
 	Format     kraftfile.FsType

--- a/internal/builder/build_test.go
+++ b/internal/builder/build_test.go
@@ -87,18 +87,18 @@ EOF
 `
 	rootfsPath := writeDockerfile(t, dockerfile)
 	opts := BuildOpts{
-		Runtime: "unikraft.io/unikraft.org/base",
+		Runtime: "unikraft.io/official/base-compat",
 		Rootfs: FSOpts{
 			Format: kraftfile.FsTypeCpio,
 			Type:   kraftfile.SourceTypeDockerfile,
 			Path:   rootfsPath,
 		},
-		Platform: []ocispec.Platform{{OS: "fc", Architecture: "x86_64"}},
+		Platform: []ocispec.Platform{{OS: "kraftcloud", Architecture: "x86_64"}},
 	}
 
 	imgs := runBuild(t, ctx, opts)
 	require.Len(t, imgs, 1)
-	assertPlatforms(t, imgs, []string{"fc/x86_64"})
+	assertPlatforms(t, imgs, []string{"kraftcloud/x86_64"})
 }
 
 func TestBuildSinglePlatformErofsIntegration(t *testing.T) {
@@ -112,18 +112,18 @@ EOF
 `
 	rootfsPath := writeDockerfile(t, dockerfile)
 	opts := BuildOpts{
-		Runtime: "unikraft.io/unikraft.org/base",
+		Runtime: "unikraft.io/official/base-compat",
 		Rootfs: FSOpts{
 			Format: kraftfile.FsTypeErofs,
 			Type:   kraftfile.SourceTypeDockerfile,
 			Path:   rootfsPath,
 		},
-		Platform: []ocispec.Platform{{OS: "fc", Architecture: "x86_64"}},
+		Platform: []ocispec.Platform{{OS: "kraftcloud", Architecture: "x86_64"}},
 	}
 
 	imgs := runBuild(t, ctx, opts)
 	require.Len(t, imgs, 1)
-	assertPlatforms(t, imgs, []string{"fc/x86_64"})
+	assertPlatforms(t, imgs, []string{"kraftcloud/x86_64"})
 }
 
 func TestBuildDefaultErofsFormatBaseCompatIntegration(t *testing.T) {
@@ -169,18 +169,18 @@ RUN ln -s /etc/passwd /another-test-link
 `
 	rootfsPath := writeDockerfile(t, dockerfile)
 	opts := BuildOpts{
-		Runtime: "unikraft.io/unikraft.org/base",
+		Runtime: "unikraft.io/official/base-compat",
 		Rootfs: FSOpts{
 			Format: kraftfile.FsTypeCpio,
 			Type:   kraftfile.SourceTypeDockerfile,
 			Path:   rootfsPath,
 		},
-		Platform: []ocispec.Platform{{OS: "fc", Architecture: "x86_64"}},
+		Platform: []ocispec.Platform{{OS: "kraftcloud", Architecture: "x86_64"}},
 	}
 
 	imgs := runBuild(t, ctx, opts)
 	require.Len(t, imgs, 1)
-	assertPlatforms(t, imgs, []string{"fc/x86_64"})
+	assertPlatforms(t, imgs, []string{"kraftcloud/x86_64"})
 
 	// Inspect the CPIO archive to verify symlink targets
 	initrd := imgs[0].Initrd
@@ -270,18 +270,18 @@ RUN --mount=type=secret,id=api_key cat /run/secrets/api_key | grep -q s3cr3t
 	require.NoError(t, err)
 
 	opts := BuildOpts{
-		Runtime: "unikraft.io/unikraft.org/base",
+		Runtime: "unikraft.io/official/base-compat",
 		Rootfs: FSOpts{
 			Format: kraftfile.FsTypeCpio,
 			Type:   kraftfile.SourceTypeDockerfile,
 			Path:   rootfsPath,
 		},
 		Secrets:  secrets,
-		Platform: []ocispec.Platform{{OS: "fc", Architecture: "x86_64"}},
+		Platform: []ocispec.Platform{{OS: "kraftcloud", Architecture: "x86_64"}},
 	}
 	imgs := runBuild(t, ctx, opts)
 	require.Len(t, imgs, 1)
-	assertPlatforms(t, imgs, []string{"fc/x86_64"})
+	assertPlatforms(t, imgs, []string{"kraftcloud/x86_64"})
 }
 
 func TestBuildCmdEnvLabelsIntegration(t *testing.T) {
@@ -294,13 +294,13 @@ CMD ["/dockerfile-cmd"]
 `
 	rootfsPath := writeDockerfile(t, dockerfile)
 	opts := BuildOpts{
-		Runtime: "unikraft.io/unikraft.org/base",
+		Runtime: "unikraft.io/official/base-compat",
 		Rootfs: FSOpts{
 			Format: kraftfile.FsTypeCpio,
 			Type:   kraftfile.SourceTypeDockerfile,
 			Path:   rootfsPath,
 		},
-		Platform: []ocispec.Platform{{OS: "fc", Architecture: "x86_64"}},
+		Platform: []ocispec.Platform{{OS: "kraftcloud", Architecture: "x86_64"}},
 		Cmd:      []string{"/unikraft-cmd", "--from-opts"},
 		Env: kraftfile.Map{
 			{Key: "OPTS_ENV", Value: "from-opts"},
@@ -398,18 +398,18 @@ RUN mknod /testfile c 220 220
 `
 	rootfsPath := writeDockerfile(t, dockerfile)
 	opts := BuildOpts{
-		Runtime: "unikraft.io/unikraft.org/base",
+		Runtime: "unikraft.io/official/base-compat",
 		Rootfs: FSOpts{
 			Format: kraftfile.FsTypeErofs,
 			Type:   kraftfile.SourceTypeDockerfile,
 			Path:   rootfsPath,
 		},
-		Platform: []ocispec.Platform{{OS: "fc", Architecture: "x86_64"}},
+		Platform: []ocispec.Platform{{OS: "kraftcloud", Architecture: "x86_64"}},
 	}
 
 	imgs := runBuild(t, ctx, opts)
 	require.Len(t, imgs, 1)
-	assertPlatforms(t, imgs, []string{"fc/x86_64"})
+	assertPlatforms(t, imgs, []string{"kraftcloud/x86_64"})
 
 	erofsImg := openErofsInitrdImage(t, imgs[0])
 	inodes := walkErofsInodes(t, erofsImg)
@@ -431,22 +431,54 @@ EOF
 `
 	rootfsPath := writeDockerfile(t, dockerfile)
 	opts := BuildOpts{
-		Runtime: "unikraft.io/unikraft.org/base",
+		Runtime: "unikraft.io/official/base-compat",
 		Rootfs: FSOpts{
 			Format: kraftfile.FsTypeErofs,
 			Type:   kraftfile.SourceTypeDockerfile,
 			Path:   rootfsPath,
 		},
-		Platform: []ocispec.Platform{{OS: "fc", Architecture: "x86_64"}},
+		Platform: []ocispec.Platform{{OS: "kraftcloud", Architecture: "x86_64"}},
 	}
 
 	imgs := runBuild(t, ctx, opts)
 	require.Len(t, imgs, 1)
-	assertPlatforms(t, imgs, []string{"fc/x86_64"})
+	assertPlatforms(t, imgs, []string{"kraftcloud/x86_64"})
 
 	files := readErofsInitrd(t, imgs[0])
 	require.Contains(t, files, ".hidden", "hidden file must be preserved with its leading dot")
 	require.Equal(t, "hidden content\n", files[".hidden"])
+}
+
+func TestBuildCustomDockerfileNameViaPathIntegration(t *testing.T) {
+	ctx := integrationContext(t)
+	dockerfile := `
+FROM scratch
+
+COPY <<'EOF' /hello.txt
+hello
+EOF
+`
+	dir := t.TempDir()
+	dockerfilePath := filepath.Join(dir, "MyDockerfile")
+	require.NoError(t, os.WriteFile(dockerfilePath, []byte(dockerfile), 0o644))
+
+	opts := BuildOpts{
+		Runtime: "unikraft.io/official/base-compat",
+		Rootfs: FSOpts{
+			Format: kraftfile.FsTypeErofs,
+			Type:   kraftfile.SourceTypeDockerfile,
+			Path:   dockerfilePath,
+		},
+		Platform: []ocispec.Platform{{OS: "kraftcloud", Architecture: "x86_64"}},
+	}
+
+	imgs := runBuild(t, ctx, opts)
+	require.Len(t, imgs, 1)
+	assertPlatforms(t, imgs, []string{"kraftcloud/x86_64"})
+
+	files := readErofsInitrd(t, imgs[0])
+	require.Contains(t, files, "hello.txt")
+	require.Equal(t, "hello\n", files["hello.txt"])
 }
 
 // openErofsInitrdImage opens the initrd from img as an erofs.Image.

--- a/internal/builder/kraftfile.go
+++ b/internal/builder/kraftfile.go
@@ -55,12 +55,15 @@ func KraftfileToBuildOpts(dir string, kf *kraftfile.Kraftfile) (BuildOpts, error
 	}
 
 	for _, rom := range kf.Roms {
-		romPath := filepath.Join(dir, rom.Source)
+		if rom.Source == nil || rom.Source.Path == "" {
+			return BuildOpts{}, fmt.Errorf("rom entry is missing a source path")
+		}
+		romPath := filepath.Join(dir, rom.Source.Path)
 		romFormat := cmp.Or(rom.Format, kraftfile.FsTypeErofs)
 		romOpt := FSOpts{
 			Path:   romPath,
 			Format: romFormat,
-			Type:   rom.Type,
+			Type:   rom.Source.Type,
 			// Pad the file to page-size alignment. This is required by the platform
 			// which rejects ROM files that are not page-aligned.
 			Pad: 4096,
@@ -68,7 +71,7 @@ func KraftfileToBuildOpts(dir string, kf *kraftfile.Kraftfile) (BuildOpts, error
 		if romOpt.Type == "" {
 			typ, err := DetectSourceType(romPath)
 			if err != nil {
-				return BuildOpts{}, fmt.Errorf("detecting rom type for %q: %w", rom.Source, err)
+				return BuildOpts{}, fmt.Errorf("detecting rom type for %q: %w", romPath, err)
 			}
 			romOpt.Type = typ
 		}
@@ -76,13 +79,19 @@ func KraftfileToBuildOpts(dir string, kf *kraftfile.Kraftfile) (BuildOpts, error
 	}
 
 	if kf.Rootfs != nil {
-		opts.Rootfs.Path = filepath.Join(dir, kf.Rootfs.Source)
+		if kf.Rootfs.Source == nil || kf.Rootfs.Source.Path == "" {
+			return BuildOpts{}, fmt.Errorf("rootfs entry is missing a source path")
+		}
+		opts.Rootfs.Path = filepath.Join(dir, kf.Rootfs.Source.Path)
 		opts.Rootfs.Format = kf.Rootfs.Format
-		opts.Rootfs.Type = kf.Rootfs.Type
-		if opts.Rootfs.Type == "" {
+		opts.Rootfs.Type = kf.Rootfs.Source.Type
+		opts.Rootfs.Dockerfile = kf.Rootfs.Source.Dockerfile
+		if opts.Rootfs.Dockerfile != "" && opts.Rootfs.Type == "" {
+			opts.Rootfs.Type = kraftfile.SourceTypeDockerfile
+		} else if opts.Rootfs.Type == "" {
 			typ, err := DetectSourceType(opts.Rootfs.Path)
 			if err != nil {
-				return BuildOpts{}, fmt.Errorf("detecting rootfs type for %q: %w", kf.Rootfs.Source, err)
+				return BuildOpts{}, fmt.Errorf("detecting rootfs type for %q: %w", opts.Rootfs.Path, err)
 			}
 			opts.Rootfs.Type = typ
 		}

--- a/internal/builder/kraftfile_test.go
+++ b/internal/builder/kraftfile_test.go
@@ -25,7 +25,9 @@ func TestKraftfileToBuildOpts(t *testing.T) {
 		Runtime: &runtime,
 		Rootfs: &kraftfile.FS{
 			Format: kraftfile.FsTypeErofs,
-			Source: rootfsPath,
+			Source: &kraftfile.FSSource{
+				Path: rootfsPath,
+			},
 		},
 		Targets: []kraftfile.Target{
 			{
@@ -67,7 +69,9 @@ func TestKraftfileToBuildOptsRootfsSourceError(t *testing.T) {
 		Runtime: &runtime,
 		Rootfs: &kraftfile.FS{
 			Format: kraftfile.FsTypeCpio,
-			Source: rootfsPath,
+			Source: &kraftfile.FSSource{
+				Path: rootfsPath,
+			},
 		},
 	}
 
@@ -83,7 +87,9 @@ func TestKraftfileToBuildOptsRootfsPathJoined(t *testing.T) {
 		Runtime: &runtime,
 		Rootfs: &kraftfile.FS{
 			Format: kraftfile.FsTypeErofs,
-			Source: "Dockerfile",
+			Source: &kraftfile.FSSource{
+				Path: "Dockerfile",
+			},
 		},
 	}
 
@@ -91,6 +97,54 @@ func TestKraftfileToBuildOptsRootfsPathJoined(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, rootfsDir+"/Dockerfile", opts.Rootfs.Path,
 		"rootfs path must be joined with the kraftfile directory")
+}
+
+func TestKraftfileToBuildOptsDockerfileWithType(t *testing.T) {
+	rootfsDir := t.TempDir()
+
+	runtime := kraftfile.Runtime("unikraft.io/unikraft.org/base")
+	kf := &kraftfile.Kraftfile{
+		Runtime: &runtime,
+		Rootfs: &kraftfile.FS{
+			Format: kraftfile.FsTypeErofs,
+			Source: &kraftfile.FSSource{
+				Path:       "context",
+				Dockerfile: "MyDockerfile",
+				Type:       kraftfile.SourceTypeDockerfile,
+			},
+		},
+	}
+
+	opts, err := KraftfileToBuildOpts(rootfsDir, kf)
+	require.NoError(t, err)
+	require.Equal(t, rootfsDir+"/context", opts.Rootfs.Path)
+	require.Equal(t, "MyDockerfile", opts.Rootfs.Dockerfile)
+	require.Equal(t, kraftfile.SourceTypeDockerfile, opts.Rootfs.Type)
+	require.Equal(t, kraftfile.FsTypeErofs, opts.Rootfs.Format)
+}
+
+func TestKraftfileToBuildOptsDockerfileWithoutType(t *testing.T) {
+	rootfsDir := t.TempDir()
+
+	runtime := kraftfile.Runtime("unikraft.io/unikraft.org/base")
+	kf := &kraftfile.Kraftfile{
+		Runtime: &runtime,
+		Rootfs: &kraftfile.FS{
+			Format: kraftfile.FsTypeErofs,
+			Source: &kraftfile.FSSource{
+				Path:       "context",
+				Dockerfile: "MyDockerfile",
+			},
+		},
+	}
+
+	opts, err := KraftfileToBuildOpts(rootfsDir, kf)
+	require.NoError(t, err)
+	require.Equal(t, rootfsDir+"/context", opts.Rootfs.Path)
+	require.Equal(t, "MyDockerfile", opts.Rootfs.Dockerfile)
+	require.Equal(t, kraftfile.SourceTypeDockerfile, opts.Rootfs.Type,
+		"type must be inferred as dockerfile when dockerfile field is set")
+	require.Equal(t, kraftfile.FsTypeErofs, opts.Rootfs.Format)
 }
 
 func TestKraftfileToBuildOptsNoRootfs(t *testing.T) {

--- a/internal/builder/rootfs.go
+++ b/internal/builder/rootfs.go
@@ -170,6 +170,11 @@ func BuildRootfs(ctx context.Context, opts BuildOpts) (_ []*imagespec.Image, rer
 		} else {
 			opts.Rootfs.Format = expected[opts.Rootfs.Type]
 		}
+		if opts.Rootfs.Type == kraftfile.SourceTypeCpio && !gocpio.IsValidPath(opts.Rootfs.Path) ||
+			opts.Rootfs.Type == kraftfile.SourceTypeErofs && !goerofs.IsValidPath(opts.Rootfs.Path) {
+			return nil, fmt.Errorf("malformed rootfs %s file %q", opts.Rootfs.Type, opts.Rootfs.Path)
+		}
+
 		return buildRootfsPackaged(ctx, opts)
 	case kraftfile.SourceTypeDirectory:
 		return buildRootfsDirectory(ctx, opts)

--- a/internal/builder/rootfs.go
+++ b/internal/builder/rootfs.go
@@ -172,20 +172,24 @@ func BuildRootfs(ctx context.Context, opts BuildOpts) (_ []*imagespec.Image, rer
 		}
 		return buildRootfsPackaged(ctx, opts)
 	case kraftfile.SourceTypeDirectory:
-		opts.Rootfs.Format = cmp.Or(opts.Rootfs.Format, kraftfile.FsTypeCpio)
 		return buildRootfsDirectory(ctx, opts)
 	case kraftfile.SourceTypeTarball:
-		opts.Rootfs.Format = cmp.Or(opts.Rootfs.Format, kraftfile.FsTypeCpio)
 		return buildRootfsTarball(ctx, opts)
 	case kraftfile.SourceTypeDockerfile:
-		opts.Rootfs.Format = cmp.Or(opts.Rootfs.Format, kraftfile.FsTypeCpio)
-		if f, err := os.Stat(opts.Rootfs.Path); err != nil {
+		if _, err := os.Stat(opts.Rootfs.Path); err != nil {
 			if os.IsNotExist(err) {
-				return nil, fmt.Errorf("dockerfile does not exist")
+				return nil, fmt.Errorf("dockerfile context does not exist")
 			}
-			return nil, fmt.Errorf("checking dockerfile path %q: %w", opts.Rootfs.Path, err)
-		} else if !f.IsDir() {
-			opts.Rootfs.Path = filepath.Dir(opts.Rootfs.Path)
+			return nil, fmt.Errorf("checking dockerfile context path %q: %w", opts.Rootfs.Path, err)
+		}
+		if opts.Rootfs.Dockerfile != "" {
+			dockerfilePath := filepath.Join(opts.Rootfs.Path, opts.Rootfs.Dockerfile)
+			if _, err := os.Stat(dockerfilePath); err != nil {
+				if os.IsNotExist(err) {
+					return nil, fmt.Errorf("dockerfile %q does not exist in context %q", opts.Rootfs.Dockerfile, opts.Rootfs.Path)
+				}
+				return nil, fmt.Errorf("checking dockerfile path %q: %w", dockerfilePath, err)
+			}
 		}
 		return buildRootfsDockerfile(ctx, opts)
 	default:
@@ -524,8 +528,15 @@ func applyBuildOpts(attrs map[string]string, localDirs map[string]string, sessio
 		attrs["platform"] = strings.Join(ps, ",")
 	}
 
-	localDirs["context"] = opts.Rootfs.Path
-	localDirs["dockerfile"] = opts.Rootfs.Path
+	if opts.Rootfs.Dockerfile != "" {
+		localDirs["context"] = opts.Rootfs.Path
+		localDirs["dockerfile"] = filepath.Join(opts.Rootfs.Path, filepath.Dir(opts.Rootfs.Dockerfile))
+		attrs["filename"] = filepath.Base(opts.Rootfs.Dockerfile)
+	} else {
+		localDirs["context"] = filepath.Dir(opts.Rootfs.Path)
+		localDirs["dockerfile"] = filepath.Dir(opts.Rootfs.Path)
+		attrs["filename"] = filepath.Base(opts.Rootfs.Path)
+	}
 	if opts.Target != "" {
 		attrs["target"] = opts.Target
 	}

--- a/internal/builder/rootfs_test.go
+++ b/internal/builder/rootfs_test.go
@@ -263,6 +263,34 @@ EOF
 	require.Equal(t, "hello\n", files["hello.txt"])
 }
 
+func TestRootfsDockerfileCustomNameIntegration(t *testing.T) {
+	ctx := rootfsIntegrationContext(t)
+	dockerfile := `
+FROM scratch
+
+COPY <<'EOF' /hello.txt
+hello
+EOF
+`
+	contextDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(contextDir, "MyDockerfile"), []byte(dockerfile), 0o644))
+
+	imgs := runBuildRootfsIntegration(t, ctx, BuildOpts{
+		Rootfs: FSOpts{
+			Format:     kraftfile.FsTypeCpio,
+			Path:       contextDir,
+			Dockerfile: "MyDockerfile",
+			Type:       kraftfile.SourceTypeDockerfile,
+		},
+		Platform: []ocispec.Platform{{OS: "fc", Architecture: "x86_64"}},
+	})
+	require.Len(t, imgs, 1)
+
+	files := readCpioInitrd(t, imgs[0])
+	require.Contains(t, files, "./hello.txt")
+	require.Equal(t, "hello\n", files["./hello.txt"])
+}
+
 func TestRootfsDockerfileWithDeviceNodeIntegration(t *testing.T) {
 	ctx := rootfsIntegrationContext(t)
 	// Build an image that contains a device node. The local exporter


### PR DESCRIPTION
Previously, the name was cut from the path, so it used the default 'Dockerfile' name breaking functionality.

~~Depends on: https://github.com/unikraft-cloud/x/pull/253~~
Merged

Closes: TOOL-855

~~TODOs left:~~
~~* Bump the library after merging~~
~~* Update the golden files for tests when they start behaving~~