### PR TITLE
feat(internal): Show boot time field by default

### DIFF
--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -173,7 +173,7 @@ type Instance struct {
 
 	Timing struct {
 		Uptime   types.DurationMS `mirror:"instance.uptime_ms"`
-		BootTime types.DurationUS `mirror:"instance.boot_time_us"`
+		BootTime types.DurationUS `mirror:"instance.boot_time_us" field:",long"`
 		NetTime  types.DurationUS `mirror:"instance.net_time_us"`
 	}
 

--- a/internal/cmd/testdata/TestOutput/instances
+++ b/internal/cmd/testdata/TestOutput/instances
@@ -34,6 +34,8 @@ scale-to-zero:
   stateful:      true
   cooldown-time: 500ms
   notify-time:   100ms
+timing:
+  boot-time:     250ms
 sched-priority:  high
 stop:
   reason:        crashed
@@ -653,7 +655,7 @@ fra    my-instance  running  nginx  ["arg1", "arg2"]  256MiB  2      example.uni
       {
         "name": "boot-time",
         "value": "250ms",
-        "verbosity": "hidden"
+        "verbosity": "long"
       },
       {
         "name": "net-time",
@@ -661,7 +663,7 @@ fra    my-instance  running  nginx  ["arg1", "arg2"]  256MiB  2      example.uni
         "verbosity": "hidden"
       }
     ],
-    "verbosity": "hidden"
+    "verbosity": "long"
   },
   {
     "name": "restart",

--- a/internal/types/duration.go
+++ b/internal/types/duration.go
@@ -94,7 +94,11 @@ func (d DurationMS) MarshalJSON() ([]byte, error) {
 }
 
 func (d DurationMS) String() string {
-	return (time.Duration(d) * time.Millisecond).String()
+	dur := time.Duration(d) * time.Millisecond
+	if d >= 1000 {
+		dur = dur.Round(10 * time.Millisecond)
+	}
+	return dur.String()
 }
 
 // DurationUS is a time wrapper that represents a duration in microseconds.
@@ -137,5 +141,12 @@ func (d DurationUS) MarshalJSON() ([]byte, error) {
 }
 
 func (d DurationUS) String() string {
-	return (time.Duration(d) * time.Microsecond).String()
+	dur := time.Duration(d) * time.Microsecond
+	switch {
+	case d >= 1_000_000: // >= 1s: round to 10 milliseconds
+		dur = dur.Round(10 * time.Millisecond)
+	case d >= 1000: // >= 1ms: round to 10 microseconds
+		dur = dur.Round(10 * time.Microsecond)
+	}
+	return dur.String()
 }


### PR DESCRIPTION
Shows boot time by default.

Shows at the end right now. Maybe we should move?

Bonus thing: I find it ugly that values are not rounded to two decimals. Especially since you use the nearest measurement unit, you can get things like `1.0858s` boot time. Should we change this? 
**I added it as a separate commit, let me know.**

~~TODO: Integration update once it starts behaving. Will mark as ready afterwards~~

Closes: TOOL-853
Supersedes: #250 
Closes: #250 

It's basically the same thing as #250 but that was not merged for some reason.
I will adopt and adapt it here.