### PR TITLE
fix(cmd): Fallback to old API on listing

### DIFF
--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -353,8 +353,13 @@ func listPlatformImages(ctx context.Context) ([]resource.Resource, error) {
 
 		resp, err := c.GetImageStore(ctx, nil, platform.GetImageStoreOpts{})
 		if err != nil {
-			log.G(ctx).Trace().Err(err).Msg("skipping image-store listing")
-			return nil, nil
+			log.G(ctx).Warn().Err(err).Msg("image-store listing failed, falling back to /v1/images")
+			var fallbackErr error
+			resp, fallbackErr = c.GetImages(ctx, nil, platform.GetImagesOpts{})
+			if fallbackErr != nil {
+				log.G(ctx).Trace().Err(fallbackErr).Msg("skipping image listing")
+				return nil, nil
+			}
 		}
 
 		var results []resource.Resource


### PR DESCRIPTION
This is to accommodate old nodes with the CLI.
Ideally we can remove this code in the near future.
For now add it back as fallback.