### PR TITLE
feat: Add api subcommand

### DIFF
--- a/cmd/unikraft/help_test.go
+++ b/cmd/unikraft/help_test.go
@@ -42,6 +42,7 @@ func TestHelp(t *testing.T) {
 	run("resources", resourceHelpTests)
 	run("build", buildHelpTests)
 	run("config", configHelpTests)
+	run("api", apiHelpTests)
 }
 
 // TestVersion checks that `unikraft version` output contains expected fields.
@@ -190,6 +191,13 @@ func configHelpTests(t *testing.T, unikraftPath string) {
 	integ.Gild(t, cli(r),
 		[]string{"unikraft", "config", "--help"},
 		[]string{"unikraft", "config", "get", "--help"},
+	)
+}
+
+func apiHelpTests(t *testing.T, unikraftPath string) {
+	r := integ.NewTestEnv(t, unikraftPath)
+	integ.Gild(t, cli(r),
+		[]string{"unikraft", "api", "--help"},
 	)
 }
 

--- a/cmd/unikraft/integration/api_test.go
+++ b/cmd/unikraft/integration/api_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package integration
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	integ "unikraft.com/cli/internal/integration"
+)
+
+func TestAPI(t *testing.T) {
+	t.Run("healthz", func(t *testing.T) {
+		r := runner(t, true)
+
+		out := r.Run(t, []string{"unikraft", "api", "--metro=" + r.Config.MetroName, "/v1/healthz"})
+		// Response should be valid JSON, pretty-printed (multi-line).
+		assert.True(t, json.Valid([]byte(out)), "expected JSON response, got: %s", out)
+		assert.Contains(t, out, "\n", "expected pretty-printed (multi-line) JSON, got: %s", out)
+	})
+
+	t.Run("quotas", func(t *testing.T) {
+		r := runner(t, true)
+
+		out := r.Run(t, []string{"unikraft", "api", "--metro=" + r.Config.MetroName, "/v1/users/quotas"})
+		require.True(t, json.Valid([]byte(out)), "expected JSON response, got: %s", out)
+		// Quotas responses include a "data" envelope.
+		assert.Contains(t, out, `"data"`)
+	})
+
+	t.Run("instances list", func(t *testing.T) {
+		r := runner(t, true)
+
+		out := r.Run(t, []string{"unikraft", "api", "--metro=" + r.Config.MetroName, "/v1/instances"})
+		assert.True(t, json.Valid([]byte(out)), "expected JSON response, got: %s", out)
+	})
+
+	t.Run("full url with insecure", func(t *testing.T) {
+		r := runner(t, true)
+
+		endpoint := strings.TrimRight(r.Config.Metro.Endpoint, "/") + "/v1/healthz"
+		out := r.Run(t, []string{"unikraft", "api", "-k", endpoint})
+		assert.True(t, json.Valid([]byte(out)), "expected JSON response, got: %s", out)
+	})
+
+	t.Run("missing endpoint fails", func(t *testing.T) {
+		r := runner(t, true)
+
+		out := r.Run(t, []string{"unikraft", "api", "--metro=" + r.Config.MetroName, "/v1/this-endpoint-does-not-exist"}, integ.ExpectFail())
+		assert.Regexp(t, `HTTP 4\d\d`, out)
+	})
+}

--- a/cmd/unikraft/testdata/TestHelp/api
+++ b/cmd/unikraft/testdata/TestHelp/api
@@ -1,0 +1,64 @@
+$ unikraft api --help
+
+Make an authenticated HTTP request to the Unikraft Cloud API.
+
+Usage:
+  unikraft api <endpoint> [flags]
+
+Arguments:
+  <endpoint>
+          API endpoint path (e.g. /v1/instances). May be a full URL, in which case the metro endpoint is ignored.
+
+Examples:
+  # List instances in the default metro
+  unikraft api /v1/instances
+
+  # Get the current user's quotas
+  unikraft api /v1/users/quotas
+
+  # Inspect a specific instance by UUID
+  unikraft api /v1/instances/abc123-...-def456
+
+  # Create a new 256MB volume in a specific metro
+  unikraft api /v1/volumes --metro=fra -d '{"name":"data","size_mb":256}'
+
+  # Create resources from a JSON file
+  unikraft api /v1/volumes -d @volume.json
+
+  # Delete an instance by UUID
+  unikraft api /v1/instances/abc123-...-def456 -X DELETE
+
+  # Pipe a request body in from stdin
+  unikraft api /v1/volumes -d @-
+
+  # Check the health of the API
+  unikraft api /v1/healthz
+
+Flags:
+  -X, --method=<method>
+          HTTP method to use. Defaults to GET, or POST if --data is set.
+      --metro=<name>
+          Metro to target. Defaults to the profile's default metro.
+  -H, --header
+          Add an HTTP header in 'Key: Value' format. May be repeated.
+  -d, --data
+          HTTP request body. Use @path to read from a file, or @- to read from stdin.
+  -k, --insecure
+          Skip TLS certificate verification.
+
+Global flags:
+  -h, --help
+          Show context-sensitive help.
+      --config=<file> ($UNIKRAFT_CONFIG)
+          Path to the configuration file.
+      --log-level=<level> ($UNIKRAFT_LOG_LEVEL)
+          Set the logging level.
+          [default: info, choices: trace, debug, info, warn, error, fatal]
+      --log-type=<type> ($UNIKRAFT_LOG_TYPE)
+          Set the log type.
+          [default: text, choices: text, json]
+      --profile=<name> ($UNIKRAFT_PROFILE)
+          Set the current profile.
+      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+          Toggle anonymous usage analytics.
+          [default: true]

--- a/cmd/unikraft/testdata/TestHelp/general
+++ b/cmd/unikraft/testdata/TestHelp/general
@@ -33,6 +33,16 @@ Resources:
   images, image, img, imgs
           Manage Unikraft Cloud images.
 
+Utilities:
+  api
+          Make an authenticated HTTP request to the Unikraft Cloud API.
+  completion
+          Outputs shell code for initialising tab completions.
+  version, ver, v
+          Show version information.
+  upgrade
+          Upgrade the Unikraft CLI to the latest version.
+
 Config:
   login
           Login to Unikraft Cloud.
@@ -42,14 +52,6 @@ Config:
           Manage Unikraft Cloud profiles.
   config, conf, cfg
           Manage CLI configuration.
-
-Utilities:
-  completion
-          Outputs shell code for initialising tab completions.
-  version, ver, v
-          Show version information.
-  upgrade
-          Upgrade the Unikraft CLI to the latest version.
 
 Examples:
   # Login to Unikraft Cloud
@@ -129,6 +131,16 @@ Resources:
   images, image, img, imgs
           Manage Unikraft Cloud images.
 
+Utilities:
+  api
+          Make an authenticated HTTP request to the Unikraft Cloud API.
+  completion
+          Outputs shell code for initialising tab completions.
+  version, ver, v
+          Show version information.
+  upgrade
+          Upgrade the Unikraft CLI to the latest version.
+
 Config:
   login
           Login to Unikraft Cloud.
@@ -138,14 +150,6 @@ Config:
           Manage Unikraft Cloud profiles.
   config, conf, cfg
           Manage CLI configuration.
-
-Utilities:
-  completion
-          Outputs shell code for initialising tab completions.
-  version, ver, v
-          Show version information.
-  upgrade
-          Upgrade the Unikraft CLI to the latest version.
 
 Examples:
   # Login to Unikraft Cloud
@@ -227,6 +231,16 @@ Resources:
   images, image, img, imgs
           Manage Unikraft Cloud images.
 
+Utilities:
+  api
+          Make an authenticated HTTP request to the Unikraft Cloud API.
+  completion
+          Outputs shell code for initialising tab completions.
+  version, ver, v
+          Show version information.
+  upgrade
+          Upgrade the Unikraft CLI to the latest version.
+
 Config:
   login
           Login to Unikraft Cloud.
@@ -236,14 +250,6 @@ Config:
           Manage Unikraft Cloud profiles.
   config, conf, cfg
           Manage CLI configuration.
-
-Utilities:
-  completion
-          Outputs shell code for initialising tab completions.
-  version, ver, v
-          Show version information.
-  upgrade
-          Upgrade the Unikraft CLI to the latest version.
 
 Examples:
   # Login to Unikraft Cloud
@@ -322,6 +328,16 @@ Resources:
   images, image, img, imgs
           Manage Unikraft Cloud images.
 
+Utilities:
+  api
+          Make an authenticated HTTP request to the Unikraft Cloud API.
+  completion
+          Outputs shell code for initialising tab completions.
+  version, ver, v
+          Show version information.
+  upgrade
+          Upgrade the Unikraft CLI to the latest version.
+
 Config:
   login
           Login to Unikraft Cloud.
@@ -331,14 +347,6 @@ Config:
           Manage Unikraft Cloud profiles.
   config, conf, cfg
           Manage CLI configuration.
-
-Utilities:
-  completion
-          Outputs shell code for initialising tab completions.
-  version, ver, v
-          Show version information.
-  upgrade
-          Upgrade the Unikraft CLI to the latest version.
 
 Examples:
   # Login to Unikraft Cloud

--- a/internal/cmd/api.go
+++ b/internal/cmd/api.go
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	jujuerrors "github.com/juju/errors"
+	"unikraft.com/x/kingkong"
+	"unikraft.com/x/log"
+	"unikraft.com/x/ptr"
+
+	"unikraft.com/cli/internal/config"
+	"unikraft.com/cli/internal/httpclient"
+)
+
+type APICmd struct {
+	Endpoint string   `arg:"" help:"API endpoint path (e.g. /v1/instances). May be a full URL, in which case the metro endpoint is ignored."`
+	Method   string   `short:"X" name:"method" help:"HTTP method to use. Defaults to GET, or POST if --data is set." placeholder:"method"`
+	Metro    string   `help:"Metro to target. Defaults to the profile's default metro." placeholder:"name"`
+	Header   []string `short:"H" name:"header" help:"Add an HTTP header in 'Key: Value' format. May be repeated."`
+	Data     string   `short:"d" name:"data" help:"HTTP request body. Use @path to read from a file, or @- to read from stdin."`
+	Insecure bool     `short:"k" name:"insecure" help:"Skip TLS certificate verification."`
+}
+
+func (c *APICmd) Run(ctx context.Context, stdio config.Stdio) error {
+	profile, err := config.G(ctx).CurrentProfile()
+	if err != nil {
+		return err
+	}
+
+	var (
+		reqURL   string
+		insecure bool
+		trusted  bool
+	)
+	if strings.HasPrefix(c.Endpoint, "http://") || strings.HasPrefix(c.Endpoint, "https://") {
+		reqURL = c.Endpoint
+		// Only attach credentials if the host matches a configured metro for
+		// the current profile, to avoid leaking the bearer token to
+		// arbitrary hosts.
+		u, err := url.Parse(reqURL)
+		if err != nil {
+			return jujuerrors.Annotate(err, "parsing endpoint URL")
+		}
+		for i := range profile.Metros {
+			mu, err := url.Parse(profile.Metros[i].Endpoint)
+			if err != nil {
+				continue
+			}
+			if mu.Host == u.Host {
+				trusted = true
+				insecure = ptr.ZeroIfNil(profile.Metros[i].Insecure)
+				break
+			}
+		}
+	} else {
+		metroName := c.Metro
+		if metroName == "" {
+			metroName = profile.GetDefaultMetro()
+		}
+		if metroName == "" {
+			return jujuerrors.New("no metro specified and no default metro set for the current profile")
+		}
+
+		var metro *config.Metro
+		for i := range profile.Metros {
+			if profile.Metros[i].Name == metroName {
+				metro = &profile.Metros[i]
+				break
+			}
+		}
+		if metro == nil {
+			return jujuerrors.Errorf("metro %q is not configured in profile %q", metroName, profile.Name)
+		}
+
+		path := c.Endpoint
+		if !strings.HasPrefix(path, "/") {
+			path = "/" + path
+		}
+		reqURL = strings.TrimRight(metro.Endpoint, "/") + path
+		insecure = ptr.ZeroIfNil(metro.Insecure)
+		trusted = true
+	}
+	if c.Insecure {
+		insecure = true
+	}
+
+	// Resolve the request body.
+	var body io.Reader
+	if c.Data != "" {
+		switch {
+		case c.Data == "@-":
+			body = stdio.Stdin
+		case strings.HasPrefix(c.Data, "@"):
+			f, err := os.Open(c.Data[1:])
+			if err != nil {
+				return jujuerrors.Annotate(err, "reading request body")
+			}
+			defer f.Close()
+			body = f
+		default:
+			body = strings.NewReader(c.Data)
+		}
+	}
+
+	method := strings.ToUpper(c.Method)
+	if method == "" {
+		if c.Data != "" {
+			method = http.MethodPost
+		} else {
+			method = http.MethodGet
+		}
+	}
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
+	if err != nil {
+		return err
+	}
+	if trusted {
+		req.Header.Set("Authorization", "Bearer "+profile.Token)
+	}
+	req.Header.Set("Accept", "application/json")
+	if c.Data != "" && req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for _, h := range c.Header {
+		k, v, ok := strings.Cut(h, ":")
+		if !ok {
+			return jujuerrors.Errorf("invalid header %q: expected 'Key: Value'", h)
+		}
+		req.Header.Set(strings.TrimSpace(k), strings.TrimSpace(v))
+	}
+
+	log.G(ctx).
+		Debug().
+		Str("method", method).
+		Str("url", reqURL).
+		Msg("sending API request")
+
+	resp, err := httpclient.GetClient(insecure).Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if len(raw) > 0 {
+		if json.Valid(raw) {
+			var pretty bytes.Buffer
+			if err := json.Indent(&pretty, raw, "", "  "); err == nil {
+				pretty.WriteByte('\n')
+				if _, err := stdio.Stdout.Write(pretty.Bytes()); err != nil {
+					return err
+				}
+			} else {
+				if _, err := stdio.Stdout.Write(raw); err != nil {
+					return err
+				}
+			}
+		} else {
+			if _, err := stdio.Stdout.Write(raw); err != nil {
+				return err
+			}
+			if !bytes.HasSuffix(raw, []byte("\n")) {
+				fmt.Fprintln(stdio.Stdout)
+			}
+		}
+	}
+
+	if resp.StatusCode >= 400 {
+		return jujuerrors.Errorf("HTTP %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+	}
+	return nil
+}
+
+func (APICmd) Examples() []kingkong.Example {
+	return []kingkong.Example{
+		{
+			Description: "List instances in the default metro",
+			Commands: []string{
+				"unikraft api /v1/instances",
+			},
+		},
+		{
+			Description: "Get the current user's quotas",
+			Commands: []string{
+				"unikraft api /v1/users/quotas",
+			},
+		},
+		{
+			Description: "Inspect a specific instance by UUID",
+			Commands: []string{
+				"unikraft api /v1/instances/abc123-...-def456",
+			},
+		},
+		{
+			Description: "Create a new 256MB volume in a specific metro",
+			Commands: []string{
+				`unikraft api /v1/volumes --metro=fra -d '{"name":"data","size_mb":256}'`,
+			},
+		},
+		{
+			Description: "Create resources from a JSON file",
+			Commands: []string{
+				"unikraft api /v1/volumes -d @volume.json",
+			},
+		},
+		{
+			Description: "Delete an instance by UUID",
+			Commands: []string{
+				"unikraft api /v1/instances/abc123-...-def456 -X DELETE",
+			},
+		},
+		{
+			Description: "Pipe a request body in from stdin",
+			Commands: []string{
+				"unikraft api /v1/volumes -d @-",
+			},
+		},
+		{
+			Description: "Check the health of the API",
+			Commands: []string{
+				"unikraft api /v1/healthz",
+			},
+		},
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -50,6 +50,8 @@ type UnikraftCLI struct {
 	Images       ImagesCmd       `cmd:"" group:"cmd-resources" help:"Manage Unikraft Cloud images." aliases:"image,images,img,imgs" set:"name=image" set:"names=images"`
 	Resources    AnyResourceCmd  `cmd:"" group:"cmd-resources" hidden:"" help:"Manage any Unikraft Cloud resource." aliases:"resource,resources" set:"name=resource" set:"names=resources"`
 
+	API APICmd `cmd:"" group:"cmd-utilities" help:"Make an authenticated HTTP request to the Unikraft Cloud API."`
+
 	Login   login.LoginCmd  `cmd:"" group:"cmd-config" help:"Login to Unikraft Cloud."`
 	Logout  login.LogoutCmd `cmd:"" group:"cmd-config" help:"Logout from Unikraft Cloud."`
 	Profile ProfileCmd      `cmd:"" group:"cmd-config" help:"Manage Unikraft Cloud profiles." aliases:"profile,profiles" set:"name=profile" set:"names=profiles"`


### PR DESCRIPTION
Kinda like `gh api`. It's a nice half-way point between accessing the API raw and using the nice functionality in the rest of the CLI.

It uses the metros and config of the CLI, sets headers correctly, etc, and so should be a definite improvement over `curl` based commands.