### PR TITLE
fix: Use default http client for secure image operations

### DIFF
--- a/internal/images/resolver.go
+++ b/internal/images/resolver.go
@@ -65,6 +65,7 @@ func resolverOptions(profile *config.Profile, insecureRegistries []string, allIn
 
 	dockerConfig := dockerconfig.LoadDefaultConfigFile(os.Stderr)
 	opts := []docker.RegistryOpt{
+		docker.WithClient(httpclient.DefaultHTTPClient),
 		docker.WithAuthorizer(docker.NewDockerAuthorizer(docker.WithAuthCreds(func(hostname string) (string, string, error) {
 			username, password, err := hostCreds(profile, hostname)
 			if err != nil {


### PR DESCRIPTION
We were overriding to use our custom http client for insecure image operations - but defaulting to containerd's http client for secure operations.

This was inconsistent, and actually resulted in us using a 30s timeout, instead of waiting indefinitely (which is technically what we want to be doing here, at least until we introduce an explicit `--timeout`).