### PR TITLE
feat(cmd)!: Add global timeout flag

### DIFF
--- a/cmd/unikraft/integration/build_test.go
+++ b/cmd/unikraft/integration/build_test.go
@@ -73,7 +73,7 @@ roms:
 			r.Run(t, []string{"unikraft", "build", "base", "--output", baseImage}, integ.WithWorkDir(dir))
 			r.Run(t, []string{"unikraft", "build", "rom", "--output", romImage}, integ.WithWorkDir(dir))
 			r.Run(t, []string{"unikraft", "run", "--name", "test-" + instName, "--metro", r.Config.MetroName, "--output", "quiet", "--image", baseImage, "--rom", romFlag})
-			r.Run(t, []string{"unikraft", "instance", "wait", "--until", "state==stopped", "--timeout", "10s", "test-" + instName})
+			r.Run(t, []string{"unikraft", "--timeout", "10s", "instance", "wait", "--until", "state==stopped", "test-" + instName})
 
 			out := r.Run(t, []string{"unikraft", "instance", "logs", "test-" + instName})
 			assert.Regexp(t, `Hello from ROM!`, out)
@@ -109,7 +109,7 @@ cmd: ["cat", "/rom/hello.txt"]
 
 		r.Run(t, []string{"unikraft", "build", "base", "--output", baseImage}, integ.WithWorkDir(dir))
 		r.Run(t, []string{"unikraft", "run", "--name", "test-" + instName, "--metro", r.Config.MetroName, "--output", "quiet", "--image", baseImage, "--rom", "dir=romdata,at=/rom"}, integ.WithWorkDir(dir))
-		r.Run(t, []string{"unikraft", "instance", "wait", "--until", "state==stopped", "--timeout", "10s", "test-" + instName})
+		r.Run(t, []string{"unikraft", "--timeout", "10s", "instance", "wait", "--until", "state==stopped", "test-" + instName})
 
 		out := r.Run(t, []string{"unikraft", "instance", "logs", "test-" + instName})
 		assert.Regexp(t, `Hello from ROM!`, out)
@@ -172,7 +172,7 @@ cmd: ["sh", "/entrypoint.sh"]
 
 						r.Run(t, []string{"unikraft", "image", "ls", image, "-okv"})
 						r.Run(t, []string{"unikraft", "run", "--name", "test-" + instName, "--metro", r.Config.MetroName, "--output", "quiet", "--image", image})
-						r.Run(t, []string{"unikraft", "instance", "wait", "--until", "state==stopped", "--timeout", "10s", "test-" + instName})
+						r.Run(t, []string{"unikraft", "--timeout", "10s", "instance", "wait", "--until", "state==stopped", "test-" + instName})
 
 						out = r.Run(t, []string{"unikraft", "instance", "logs", "test-" + instName})
 						assert.Regexp(t, `UNIKRAFT_E2E_OK`, out)

--- a/cmd/unikraft/integration/instance_test.go
+++ b/cmd/unikraft/integration/instance_test.go
@@ -71,7 +71,7 @@ func TestInstances(t *testing.T) {
 			"--set", "resources.vcpus=1",
 		})
 
-		out := r.Run(t, []string{"unikraft", "instance", "wait", "--until", "state==stopped", "--timeout", "10s", "test-" + instName})
+		out := r.Run(t, []string{"unikraft", "--timeout", "10s", "instance", "wait", "--until", "state==stopped", "test-" + instName})
 		assert.Regexp(t, `state:\s+stopped`, out)
 		assert.Regexp(t, `stop:`, out)
 		assert.Regexp(t, `reason:.*(page fault|out of memory)`, out)
@@ -102,7 +102,7 @@ func TestInstances(t *testing.T) {
 		})
 		fqdn := strings.TrimSpace(out)
 
-		r.Run(t, []string{"unikraft", "instance", "wait", "--until", "state==running", "--timeout", "10s", "test-" + instName})
+		r.Run(t, []string{"unikraft", "--timeout", "10s", "instance", "wait", "--until", "state==running", "test-" + instName})
 
 		body := integ.HTTPGet(t, "https://"+fqdn)
 		assert.Contains(t, body, "Welcome to nginx!")
@@ -416,18 +416,18 @@ func TestInstances(t *testing.T) {
 			"--set", "resources.vcpus=1",
 		})
 
-		r.Run(t, []string{"unikraft", "instance", "wait", "--until", "state==running", "--timeout", "30s", "test-" + instName})
+		r.Run(t, []string{"unikraft", "--timeout", "30s", "instance", "wait", "--until", "state==running", "test-" + instName})
 
 		// No scale-to-zero so state will show as stopped.
 		r.Run(t, []string{"unikraft", "instance", "suspend", "test-" + instName})
-		r.Run(t, []string{"unikraft", "instance", "wait", "--until", "state==stopped", "--timeout", "30s", "test-" + instName})
+		r.Run(t, []string{"unikraft", "--timeout", "30s", "instance", "wait", "--until", "state==stopped", "test-" + instName})
 		out := r.Run(t, []string{"unikraft", "instance", "inspect", "test-" + instName})
 		assert.Regexp(t, `state:\s+stopped`, out)
 		assert.Regexp(t, `stop:`, out)
 		assert.Regexp(t, `reason:.*user stop`, out)
 
 		r.Run(t, []string{"unikraft", "instance", "start", "test-" + instName})
-		r.Run(t, []string{"unikraft", "instance", "wait", "--until", "state==running", "--timeout", "30s", "test-" + instName})
+		r.Run(t, []string{"unikraft", "--timeout", "30s", "instance", "wait", "--until", "state==running", "test-" + instName})
 		out = r.Run(t, []string{"unikraft", "instance", "inspect", "test-" + instName})
 		assert.Regexp(t, `state:\s+running`, out)
 		assert.NotRegexp(t, `stop:`, out)
@@ -453,7 +453,7 @@ func TestInstances(t *testing.T) {
 			"--set", "resources.vcpus=1",
 		})
 
-		r.Run(t, []string{"unikraft", "instance", "wait", "--until", "state==running", "--timeout", "30s", "test-" + instName})
+		r.Run(t, []string{"unikraft", "--timeout", "30s", "instance", "wait", "--until", "state==running", "test-" + instName})
 
 		// Stop the instance so delete-on-stop removes it (deletion is async).
 		r.Run(t, []string{"unikraft", "instance", "stop", "test-" + instName})
@@ -527,5 +527,27 @@ func TestInstances(t *testing.T) {
 		assert.Regexp(t, `sched-priority:\s+high`, out)
 
 		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName})
+	})
+
+	t.Run("watch-timeout", func(t *testing.T) {
+		r := runner(t, true)
+		r.Run(t, []string{"unikraft", "--timeout=1s", "instance", "ls", "-w"}, integ.AllowFail())
+	})
+
+	t.Run("watch-no-timeout", func(t *testing.T) {
+		r := runner(t, true)
+
+		done := make(chan error, 1)
+		go func() {
+			_, err := r.RunRaw(t, []string{"unikraft", "instance", "ls", "-w"}, integ.AllowFail())
+			done <- err
+		}()
+
+		select {
+		case err := <-done:
+			t.Fatalf("expected command to still be running after 10 seconds, got: %v", err)
+		case <-time.After(10 * time.Second):
+			// Command still running
+		}
 	})
 }

--- a/cmd/unikraft/integration/volume_test.go
+++ b/cmd/unikraft/integration/volume_test.go
@@ -214,7 +214,7 @@ func TestVolumes(t *testing.T) {
 			})
 			fqdn := strings.TrimSpace(out)
 
-			r.Run(t, []string{"unikraft", "instance", "wait", "--until", "state==running", "--timeout", "30s", "test-" + instName})
+			r.Run(t, []string{"unikraft", "--timeout", "30s", "instance", "wait", "--until", "state==running", "test-" + instName})
 
 			body := integ.HTTPGet(t, "https://"+fqdn)
 			assert.Contains(t, body, "hello from volume import")

--- a/cmd/unikraft/testdata/TestHelp/api
+++ b/cmd/unikraft/testdata/TestHelp/api
@@ -62,3 +62,5 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).

--- a/cmd/unikraft/testdata/TestHelp/auth
+++ b/cmd/unikraft/testdata/TestHelp/auth
@@ -8,9 +8,6 @@ Usage:
 Flags:
       --check
           Check if the user is already logged in.
-  -t, --timeout
-          Timeout for the login request.
-          [default: 5m]
       --controlplane
           Control plane URL to use for login.
           [default: https://controlplane.unikraft.cloud]
@@ -39,6 +36,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft logout --help
 
@@ -63,6 +62,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft profile --help
 
@@ -100,6 +101,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft profile get --help
 
@@ -145,6 +148,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft profile list --help
 
@@ -196,6 +201,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft profile use --help
 
@@ -227,6 +234,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft metro --help
 
@@ -280,6 +289,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft metro get --help
 
@@ -343,6 +354,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft metro list --help
 
@@ -418,3 +431,5 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).

--- a/cmd/unikraft/testdata/TestHelp/build
+++ b/cmd/unikraft/testdata/TestHelp/build
@@ -56,3 +56,5 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).

--- a/cmd/unikraft/testdata/TestHelp/certificates
+++ b/cmd/unikraft/testdata/TestHelp/certificates
@@ -47,6 +47,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft certificate get --help
 
@@ -101,6 +103,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft certificate list --help
 
@@ -161,6 +165,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft certificate wait --help
 
@@ -194,9 +200,6 @@ Flags:
       --interval
           Polling interval.
           [default: 2s]
-      --timeout
-          Timeout before giving up.
-          [default: 0]
   -f, --field
           Specify which fields to include in the output.
   -o, --output
@@ -218,6 +221,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft certificate create --help
 
@@ -285,6 +290,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 Create flags:
       --metro=<metro>
@@ -358,3 +365,5 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).

--- a/cmd/unikraft/testdata/TestHelp/config
+++ b/cmd/unikraft/testdata/TestHelp/config
@@ -34,6 +34,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft config get --help
 
@@ -83,3 +85,5 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).

--- a/cmd/unikraft/testdata/TestHelp/general
+++ b/cmd/unikraft/testdata/TestHelp/general
@@ -86,6 +86,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 Run "unikraft <command> --help" for more information on a command.
 
@@ -184,6 +186,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 Run "unikraft <command> --help" for more information on a command.
 
@@ -283,6 +287,8 @@ Examples:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 Run "unikraft <command> --help" for more information on a command.
 
@@ -380,6 +386,8 @@ Examples:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 Run "unikraft <command> --help" for more information on a command.
 

--- a/cmd/unikraft/testdata/TestHelp/images
+++ b/cmd/unikraft/testdata/TestHelp/images
@@ -36,6 +36,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft image get --help
 
@@ -90,6 +92,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft image list --help
 
@@ -144,6 +148,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft image copy --help
 
@@ -189,3 +195,5 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).

--- a/cmd/unikraft/testdata/TestHelp/instances
+++ b/cmd/unikraft/testdata/TestHelp/instances
@@ -80,6 +80,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft instance get --help
 
@@ -151,6 +153,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft instance list --help
 
@@ -228,6 +232,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft instance wait --help
 
@@ -278,9 +284,6 @@ Flags:
       --interval
           Polling interval.
           [default: 2s]
-      --timeout
-          Timeout before giving up.
-          [default: 0]
   -f, --field
           Specify which fields to include in the output.
   -o, --output
@@ -302,6 +305,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft instance create --help
 
@@ -389,6 +394,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 Create flags:
       --metro=<metro>
@@ -542,6 +549,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 Edit flags:
       --image=<name>:<tag>
@@ -647,6 +656,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft instance template --help
 
@@ -701,6 +712,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft instance template get --help
 
@@ -759,6 +772,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft instance template list --help
 
@@ -823,6 +838,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft instance template create --help
 
@@ -889,6 +906,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft instance template edit --help
 
@@ -959,6 +978,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 Edit flags:
       --tags=<tag>
@@ -1029,6 +1050,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft instance logs --help
 
@@ -1076,6 +1099,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft instance start --help
 
@@ -1114,6 +1139,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft instance stop --help
 
@@ -1163,6 +1190,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft instance suspend --help
 
@@ -1207,6 +1236,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft instance restart --help
 
@@ -1253,3 +1284,5 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).

--- a/cmd/unikraft/testdata/TestHelp/resources
+++ b/cmd/unikraft/testdata/TestHelp/resources
@@ -37,6 +37,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft resource delete --help
 
@@ -82,3 +84,5 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).

--- a/cmd/unikraft/testdata/TestHelp/services
+++ b/cmd/unikraft/testdata/TestHelp/services
@@ -49,6 +49,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft service get --help
 
@@ -103,6 +105,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft service list --help
 
@@ -163,6 +167,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft service wait --help
 
@@ -196,9 +202,6 @@ Flags:
       --interval
           Polling interval.
           [default: 2s]
-      --timeout
-          Timeout before giving up.
-          [default: 0]
   -f, --field
           Specify which fields to include in the output.
   -o, --output
@@ -220,6 +223,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft service create --help
 
@@ -282,6 +287,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 Create flags:
       --metro=<metro>
@@ -367,6 +374,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 Edit flags:
       --soft-limit=<n>
@@ -440,3 +449,5 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).

--- a/cmd/unikraft/testdata/TestHelp/volumes
+++ b/cmd/unikraft/testdata/TestHelp/volumes
@@ -59,6 +59,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft volume get --help
 
@@ -115,6 +117,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft volume list --help
 
@@ -177,6 +181,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft volume wait --help
 
@@ -212,9 +218,6 @@ Flags:
       --interval
           Polling interval.
           [default: 2s]
-      --timeout
-          Timeout before giving up.
-          [default: 0]
   -f, --field
           Specify which fields to include in the output.
   -o, --output
@@ -236,6 +239,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft volume create --help
 
@@ -299,6 +304,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 Create flags:
       --metro=<metro>
@@ -358,6 +365,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 flag-clone
   -n, --name=<name>
@@ -412,6 +421,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft volume edit --help
 
@@ -480,6 +491,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 Edit flags:
       --size=<size>
@@ -549,6 +562,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft volume template --help
 
@@ -598,6 +613,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft volume template get --help
 
@@ -651,6 +668,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft volume template list --help
 
@@ -710,6 +729,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft volume template create --help
 
@@ -771,6 +792,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft volume template edit --help
 
@@ -836,6 +859,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 Edit flags:
       --tags=<tag>
@@ -901,3 +926,5 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).

--- a/internal/cmd/login/login.go
+++ b/internal/cmd/login/login.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	jujuerrors "github.com/juju/errors"
 	"github.com/pkg/browser"
@@ -24,8 +23,7 @@ import (
 )
 
 type LoginCmd struct {
-	Check   bool          `name:"check" help:"Check if the user is already logged in."`
-	Timeout time.Duration `short:"t" name:"timeout" default:"5m" help:"Timeout for the login request."`
+	Check bool `name:"check" help:"Check if the user is already logged in."`
 
 	ControlPlane  string `name:"controlplane" default:"https://controlplane.unikraft.cloud" help:"Control plane URL to use for login."`
 	AllowInsecure bool   `name:"allow-insecure" short:"k" help:"Allow insecure server connections when using SSL."`
@@ -293,33 +291,6 @@ func (cmd *LoginCmd) getAuth(ctx context.Context, profile *config.Profile) (*con
 		return nil, jujuerrors.Annotate(err, "checking authorization")
 	}
 
-	timeout := time.NewTimer(cmd.Timeout)
-	ctx, cancel := context.WithCancel(ctx)
-
-	var event *controlplane.Response[controlplane.CheckAuthorizationResponseData]
-	go func() {
-		defer cancel()
-		for {
-			select {
-			case <-timeout.C:
-				log.G(ctx).
-					Error().
-					Err(jujuerrors.New("login timed out, please try again"))
-				return
-			case event = <-checkResp:
-				if event == nil {
-					continue
-				}
-				return
-			case <-ctx.Done():
-				log.G(ctx).
-					Error().
-					Err(jujuerrors.Errorf("operation cancelled"))
-				return
-			}
-		}
-	}()
-
 	if !cmd.NoBrowser {
 		if err := browser.OpenURL(signinResp.Data.AuthorizationUrl); err != nil {
 			log.G(ctx).
@@ -330,17 +301,17 @@ func (cmd *LoginCmd) getAuth(ctx context.Context, profile *config.Profile) (*con
 	}
 
 	// TODO: run a spinner here
-	log.G(ctx).
-		Info().
-		Str("timeout", cmd.Timeout.String()).
-		Msg("waiting for confirmation")
-	<-ctx.Done()
-
-	if event == nil {
-		return nil, jujuerrors.New("no event received, please try again")
+	for {
+		select {
+		case event := <-checkResp:
+			if event == nil {
+				continue
+			}
+			return event, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
-
-	return event, nil
 }
 
 func (cmd *LoginCmd) getOrg(ctx context.Context, profile *config.Profile) (string, error) {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -15,6 +15,8 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/alecthomas/kong"
 	ctrdlog "github.com/containerd/log"
@@ -107,7 +109,8 @@ type globalFlags struct {
 
 	Profile string `group:"flag-global" name:"profile" env:"UNIKRAFT_PROFILE" help:"Set the current profile." placeholder:"name"`
 
-	Telemetry bool `group:"flag-global" name:"telemetry" env:"UNIKRAFT_TELEMETRY" help:"Toggle anonymous usage analytics." default:"true" negatable:""`
+	Telemetry bool          `group:"flag-global" name:"telemetry" env:"UNIKRAFT_TELEMETRY" help:"Toggle anonymous usage analytics." default:"true" negatable:""`
+	Timeout   time.Duration `group:"flag-global" name:"timeout" env:"UNIKRAFT_TIMEOUT" help:"Set a deadline for the command (e.g. 30s, 5m, 1h)." placeholder:"duration" optional:""`
 }
 
 func NewRootCmd(ctx context.Context, args []string, stdio config.Stdio) (context.Context, *kong.Context, *UnikraftCLI, func() error, error) {
@@ -209,10 +212,16 @@ func NewRootCmd(ctx context.Context, args []string, stdio config.Stdio) (context
 	ctx = config.WithConfig(ctx, cfg)
 	kctx.Bind(cfg)
 
+	cancelTimeout := func() {}
+	if cli.Timeout > 0 {
+		ctx, cancelTimeout = newTimedOutContext(ctx, cli.Timeout)
+	}
+
 	kctx.BindTo(ctx, (*context.Context)(nil))
 
 	sandbox, err := resource.LoadSandboxFromEnv(SandboxedResources...)
 	if err != nil {
+		cancelTimeout()
 		return ctx, nil, nil, nil, jujuerrors.Annotate(err, "loading sandbox from environment")
 	}
 	if sandbox != nil {
@@ -227,6 +236,7 @@ func NewRootCmd(ctx context.Context, args []string, stdio config.Stdio) (context
 	kctx.Bind(kctx)
 
 	cleanup := func() error {
+		cancelTimeout()
 		if err := sandbox.Save(); err != nil {
 			return jujuerrors.Annotate(err, "saving sandbox")
 		}
@@ -361,6 +371,75 @@ var SandboxedResources = []resource.Resource{
 	VolumeTemplate{},
 	ServiceGroup{},
 	Certificate{},
+}
+
+type timedOutContext struct {
+	context.Context // parent
+	done            chan struct{}
+	mu              sync.Mutex
+	ctxErr          error
+	deadline        time.Time
+}
+
+func (c *timedOutContext) Done() <-chan struct{} { return c.done }
+
+func (c *timedOutContext) Err() error {
+	select {
+	case <-c.done:
+	default:
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.ctxErr
+}
+
+func (c *timedOutContext) Deadline() (time.Time, bool) {
+	return c.deadline, true
+}
+
+func newTimedOutContext(parent context.Context, timeout time.Duration) (context.Context, func()) {
+	c := &timedOutContext{
+		Context:  parent,
+		done:     make(chan struct{}),
+		deadline: time.Now().Add(timeout),
+	}
+
+	stopCh := make(chan struct{}, 1)
+
+	var (
+		once     sync.Once
+		stopOnce sync.Once
+	)
+
+	closeWithErr := func(err error) {
+		once.Do(func() {
+			c.mu.Lock()
+			c.ctxErr = err
+			c.mu.Unlock()
+			close(c.done)
+		})
+	}
+
+	timer := time.NewTimer(timeout)
+	go func() {
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			closeWithErr(fmt.Errorf("timed out"))
+		case <-parent.Done():
+			closeWithErr(parent.Err())
+		case <-stopCh:
+			// cleanup canceled
+		}
+	}()
+
+	stopFn := func() {
+		once.Do(func() {})
+		stopOnce.Do(func() { stopCh <- struct{}{} }) // signal goroutine to exit
+	}
+
+	return c, stopFn
 }
 
 type staticKey string

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -12,9 +12,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"path/filepath"
 	"slices"
 	"strconv"
+	"time"
 
 	"github.com/alecthomas/kong"
 	"github.com/docker/go-units"
@@ -583,12 +585,11 @@ func volumePatchSpec(path string, _ patchOp, value any) (platform.MutableVolumeP
 // temporarily spinning up a volimport instance, streaming a CPIO archive
 // over TLS, and cleaning up the instance afterwards.
 type VolumeImportCmd struct {
-	Volume  string `arg:"" completion-predictor:"resource-key-volume" help:"Name or UUID of the volume to import into." create:"set,required"`
-	Source  string `short:"s" help:"Data source: local directory, CPIO archive, or Dockerfile." placeholder:"path" create:"set,required"`
-	Force   bool   `short:"f" help:"Force import even if the data might exceed volume capacity."`
-	Port    int    `short:"p" default:"42069" help:"Port to connect to the volume import service on." placeholder:"port" hidden:"true"`
-	Image   string `default:"official/utils/volimport:1.0" help:"Volume import image to use." placeholder:"image" hidden:"true"`
-	Timeout uint64 `short:"t" default:"10" help:"Inactivity timeout in seconds for the import service." placeholder:"seconds" hidden:"true"`
+	Volume string `arg:"" completion-predictor:"resource-key-volume" help:"Name or UUID of the volume to import into." create:"set,required"`
+	Source string `short:"s" help:"Data source: local directory, CPIO archive, or Dockerfile." placeholder:"path" create:"set,required"`
+	Force  bool   `short:"f" help:"Force import even if the data might exceed volume capacity."`
+	Port   int    `short:"p" default:"42069" help:"Port to connect to the volume import service on." placeholder:"port" hidden:"true"`
+	Image  string `default:"official/utils/volimport:1.0" help:"Volume import image to use." placeholder:"image" hidden:"true"`
 }
 
 func (VolumeImportCmd) Examples() []kingkong.Example {
@@ -705,7 +706,17 @@ func (c *VolumeImportCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *
 	var instUUID, instFQDN string
 	if err := group.DoMetro(ctx, g, vol.Metro.Name, func(ctx context.Context, mc multimetro.MetroClient) error {
 		var merr error
-		instUUID, instFQDN, merr = volimport.Start(ctx, mc, c.Image, vol.UUID, authStr, c.Timeout, c.Port)
+		volimportTimeout := uint64(10)
+		if deadline, ok := ctx.Deadline(); ok {
+			t := max(
+				// don't run past deadline (+2s for tolerance)
+				time.Until(deadline)+2*time.Second,
+				// set reasonable max timeout
+				10*time.Second,
+			)
+			volimportTimeout = uint64(math.Ceil(t.Seconds()))
+		}
+		instUUID, instFQDN, merr = volimport.Start(ctx, mc, c.Image, vol.UUID, authStr, volimportTimeout, c.Port)
 		return merr
 	}); err != nil {
 		return fmt.Errorf("spawning volume data import instance: %w", err)

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -279,7 +279,6 @@ type ResourceWaitCmd[R resource.GettableResource] struct {
 	Until   []string `help:"Filter expression to wait for." example:"state==running,state!=stopped" sep:"none" required:"" aliases:"filter"`
 
 	Interval time.Duration `long:"interval" default:"2s" help:"Polling interval."`
-	Timeout  time.Duration `long:"timeout" default:"0" help:"Timeout before giving up."`
 
 	FormatOpts
 }
@@ -308,12 +307,6 @@ func (cmd *ResourceWaitCmd[R]) Run(ctx context.Context, stdio config.Stdio, sand
 		return err
 	}
 	ctx = resource.WithFilter(ctx, filter)
-
-	if cmd.Timeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, cmd.Timeout)
-		defer cancel()
-	}
 
 	ticker := time.NewTicker(cmd.Interval)
 	defer ticker.Stop()

--- a/internal/resource/cmd/cmd_test.go
+++ b/internal/resource/cmd/cmd_test.go
@@ -1009,7 +1009,6 @@ func TestWait(t *testing.T) {
 		cmd := &ResourceWaitCmd[resourcet.TestResource]{
 			Targets:  []string{"test1", "test2"},
 			Until:    []string{"state==ready"},
-			Timeout:  time.Second,
 			Interval: 10 * time.Millisecond,
 		}
 		err := cmd.Run(ctx, testStdio(&bytes.Buffer{}), sandbox)
@@ -1019,11 +1018,12 @@ func TestWait(t *testing.T) {
 	t.Run("timeout", func(t *testing.T) {
 		env := setupTestEnv()
 		ctx := resourcet.WithTestEnv(context.Background(), env)
+		ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+		defer cancel()
 
 		cmd := &ResourceWaitCmd[resourcet.TestResource]{
 			Targets:  []string{"test1", "test2"},
 			Until:    []string{"state==ready"},
-			Timeout:  1 * time.Second,
 			Interval: 10 * time.Millisecond,
 		}
 		err := cmd.Run(ctx, testStdio(&bytes.Buffer{}), sandbox)


### PR DESCRIPTION
This allows cancelling any ongoing command by cancelling the running context for everything.

This also removes existing `--timeout` flags in login, wait, and volume import.
These flags had duplicate effects and are now centralised.

Closes: TOOL-818