### PR TITLE
feat(volumes): Add attach and detach subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ unikraft instances logs my-instance
 | `tui`          | Browse resources in a TUI                                                      |
 | `metros`       | List available metro locations                                                 |
 | `instances`    | Manage instances (list, get, create, edit, delete, logs, start, stop, restart) |
-| `volumes`      | Manage persistent volumes (list, get, create, edit, delete, clone)             |
+| `volumes`      | Manage persistent volumes (list, get, create, edit, delete, clone, attach, detach) |
 | `services`     | Manage service groups (list, get, create, edit, delete)                        |
 | `certificates` | Manage TLS certificates (list, get, create, delete)                            |
 | `images`       | Manage images (list, get, copy)                                                |

--- a/cmd/unikraft/testdata/TestHelp/volumes
+++ b/cmd/unikraft/testdata/TestHelp/volumes
@@ -22,10 +22,6 @@ Resources:
           Clone a volume.
   import
           Import data into a volume.
-  attach
-          Attach a volume.
-  detach
-          Detach a volume.
 
 Templates:
   template, templates
@@ -42,9 +38,14 @@ Fields:
   quota-policy
   persistent
   timestamps, timestamps.created
-  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid, attached-
-  to.*.read-only, attached-to.*.mount-at
-
+  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
+  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
+  by.*.read-only
+  attach-to
+  attach-at
+  attach-read-only
+  detach-from
+        
 Global flags:
   -h, --help
           Show context-sensitive help.
@@ -88,8 +89,13 @@ Fields:
   quota-policy
   persistent
   timestamps, timestamps.created
-  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid, attached-
-  to.*.read-only, attached-to.*.mount-at
+  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
+  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
+  by.*.read-only
+  attach-to
+  attach-at
+  attach-read-only
+  detach-from
 
 Flags:
   -w, --watch=<duration>
@@ -142,8 +148,13 @@ Fields:
   quota-policy
   persistent
   timestamps, timestamps.created
-  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid, attached-
-  to.*.read-only, attached-to.*.mount-at
+  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
+  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
+  by.*.read-only
+  attach-to
+  attach-at
+  attach-read-only
+  detach-from
 
 Flags:
       --filter
@@ -198,8 +209,13 @@ Fields:
   quota-policy
   persistent
   timestamps, timestamps.created
-  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid, attached-
-  to.*.read-only, attached-to.*.mount-at
+  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
+  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
+  by.*.read-only
+  attach-to
+  attach-at
+  attach-read-only
+  detach-from
 
 Flags:
       --until, --filter
@@ -258,8 +274,13 @@ Fields:
   quota-policy
   persistent
   timestamps, timestamps.created
-  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid, attached-
-  to.*.read-only, attached-to.*.mount-at
+  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
+  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
+  by.*.read-only
+  attach-to
+  attach-at
+  attach-read-only
+  detach-from
 
 Flags:
       --set=<name>=<value>, --set-file=<name>=<filename>
@@ -430,8 +451,13 @@ Fields:
   quota-policy
   persistent
   timestamps, timestamps.created
-  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid, attached-
-  to.*.read-only, attached-to.*.mount-at
+  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
+  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
+  by.*.read-only
+  attach-to
+  attach-at
+  attach-read-only
+  detach-from
 
 Flags:
       --set=<name>=<value>, --set-file=<name>=<filename>
@@ -504,8 +530,13 @@ Fields:
   quota-policy
   persistent
   timestamps, timestamps.created
-  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid, attached-
-  to.*.read-only, attached-to.*.mount-at
+  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
+  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
+  by.*.read-only
+  attach-to
+  attach-at
+  attach-read-only
+  detach-from
 
 Flags:
       --all

--- a/cmd/unikraft/testdata/TestHelp/volumes
+++ b/cmd/unikraft/testdata/TestHelp/volumes
@@ -22,6 +22,10 @@ Resources:
           Clone a volume.
   import
           Import data into a volume.
+  attach
+          Attach a volume.
+  detach
+          Detach a volume.
 
 Templates:
   template, templates
@@ -38,9 +42,8 @@ Fields:
   quota-policy
   persistent
   timestamps, timestamps.created
-  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
-  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
-  by.*.read-only
+  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid, attached-
+  to.*.read-only, attached-to.*.mount-at
 
 Global flags:
   -h, --help
@@ -85,9 +88,8 @@ Fields:
   quota-policy
   persistent
   timestamps, timestamps.created
-  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
-  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
-  by.*.read-only
+  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid, attached-
+  to.*.read-only, attached-to.*.mount-at
 
 Flags:
   -w, --watch=<duration>
@@ -140,9 +142,8 @@ Fields:
   quota-policy
   persistent
   timestamps, timestamps.created
-  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
-  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
-  by.*.read-only
+  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid, attached-
+  to.*.read-only, attached-to.*.mount-at
 
 Flags:
       --filter
@@ -197,9 +198,8 @@ Fields:
   quota-policy
   persistent
   timestamps, timestamps.created
-  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
-  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
-  by.*.read-only
+  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid, attached-
+  to.*.read-only, attached-to.*.mount-at
 
 Flags:
       --until, --filter
@@ -258,9 +258,8 @@ Fields:
   quota-policy
   persistent
   timestamps, timestamps.created
-  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
-  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
-  by.*.read-only
+  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid, attached-
+  to.*.read-only, attached-to.*.mount-at
 
 Flags:
       --set=<name>=<value>, --set-file=<name>=<filename>
@@ -431,9 +430,8 @@ Fields:
   quota-policy
   persistent
   timestamps, timestamps.created
-  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
-  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
-  by.*.read-only
+  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid, attached-
+  to.*.read-only, attached-to.*.mount-at
 
 Flags:
       --set=<name>=<value>, --set-file=<name>=<filename>
@@ -506,9 +504,8 @@ Fields:
   quota-policy
   persistent
   timestamps, timestamps.created
-  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
-  mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
-  by.*.read-only
+  attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid, attached-
+  to.*.read-only, attached-to.*.mount-at
 
 Flags:
       --all

--- a/cmd/unikraft/testdata/TestHelp/volumes
+++ b/cmd/unikraft/testdata/TestHelp/volumes
@@ -22,6 +22,10 @@ Resources:
           Clone a volume.
   import
           Import data into a volume.
+  attach
+          Attach a volume.
+  detach
+          Detach a volume.
 
 Templates:
   template, templates
@@ -45,7 +49,7 @@ Fields:
   attach-at
   attach-read-only
   detach-from
-        
+
 Global flags:
   -h, --help
           Show context-sensitive help.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -323,6 +323,14 @@ func NewParser(cli *UnikraftCLI) (*kong.Kong, error) {
 				Key:   "flag-edit",
 				Title: kingkong.Underline("Edit flags") + ":",
 			},
+			{
+				Key:   "flag-attach",
+				Title: kingkong.Underline("Attach flags") + ":",
+			},
+			{
+				Key:   "flag-detach",
+				Title: kingkong.Underline("Detach flags") + ":",
+			},
 			globalFlagGroup,
 			{
 				Key:   "flag-local",

--- a/internal/cmd/testdata/TestOutput/volumes
+++ b/internal/cmd/testdata/TestOutput/volumes
@@ -21,7 +21,6 @@ persistent:   true
 timestamps:
   created:    never
 attached-to:
-mounted-by:
 
 ==================================== table =====================================
 METRO  NAME       STATE      SIZE   CREATED
@@ -130,35 +129,38 @@ fra    my-volume  available  50MiB  never
           "name": "uuid",
           "value": "",
           "verbosity": "long"
-        }
-      ],
-      "verbosity": "long"
-    },
-    "verbosity": "long"
-  },
-  {
-    "name": "mounted-by",
-    "elem": {
-      "name": "",
-      "subfields": [
-        {
-          "name": "name",
-          "value": "",
-          "verbosity": "long"
-        },
-        {
-          "name": "uuid",
-          "value": "",
-          "verbosity": "long"
         },
         {
           "name": "read-only",
           "value": false,
-          "verbosity": "long"
+          "verbosity": "long",
+          "create": {
+            "set": false
+          },
+          "edit": {
+            "set": false
+          }
+        },
+        {
+          "name": "mount-at",
+          "value": "",
+          "verbosity": "hidden",
+          "create": {
+            "set": ""
+          },
+          "edit": {
+            "set": ""
+          }
         }
       ],
       "verbosity": "long"
     },
-    "verbosity": "long"
+    "verbosity": "long",
+    "create": {
+      "set": null
+    },
+    "edit": {
+      "set": null
+    }
   }
 ]

--- a/internal/cmd/testdata/TestOutput/volumes
+++ b/internal/cmd/testdata/TestOutput/volumes
@@ -21,6 +21,7 @@ persistent:   true
 timestamps:
   created:    never
 attached-to:
+mounted-by:
 
 ==================================== table =====================================
 METRO  NAME       STATE      SIZE   CREATED
@@ -129,38 +130,67 @@ fra    my-volume  available  50MiB  never
           "name": "uuid",
           "value": "",
           "verbosity": "long"
-        },
-        {
-          "name": "read-only",
-          "value": false,
-          "verbosity": "long",
-          "create": {
-            "set": false
-          },
-          "edit": {
-            "set": false
-          }
-        },
-        {
-          "name": "mount-at",
-          "value": "",
-          "verbosity": "hidden",
-          "create": {
-            "set": ""
-          },
-          "edit": {
-            "set": ""
-          }
         }
       ],
       "verbosity": "long"
     },
-    "verbosity": "long",
-    "create": {
-      "set": null
+    "verbosity": "long"
+  },
+  {
+    "name": "mounted-by",
+    "elem": {
+      "name": "",
+      "subfields": [
+        {
+          "name": "name",
+          "value": "",
+          "verbosity": "long"
+        },
+        {
+          "name": "uuid",
+          "value": "",
+          "verbosity": "long"
+        },
+        {
+          "name": "read-only",
+          "value": false,
+          "verbosity": "long"
+        }
+      ],
+      "verbosity": "long"
     },
-    "edit": {
-      "set": null
+    "verbosity": "long"
+  },
+  {
+    "name": "attach-to",
+    "value": "",
+    "verbosity": "invisible",
+    "create": {
+      "set": ""
+    }
+  },
+  {
+    "name": "attach-at",
+    "value": "",
+    "verbosity": "invisible",
+    "create": {
+      "set": ""
+    }
+  },
+  {
+    "name": "attach-read-only",
+    "value": false,
+    "verbosity": "invisible",
+    "create": {
+      "set": false
+    }
+  },
+  {
+    "name": "detach-from",
+    "value": "",
+    "verbosity": "invisible",
+    "create": {
+      "set": ""
     }
   }
 ]

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -86,9 +86,9 @@ func (c *VolumeCreateCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *
 type VolumeAttachCmd struct {
 	cmd.ResourceAttachCmd[Volume]
 
-	AttachTo string `group:"flag-attach" name:"to" shortcut:"attached-to" help:"The instance the volume should be attached to." placeholder:"name"`
-	MountAt  string `group:"flag-attach" name:"at" shortcut:"attached-to.0.mount-at" help:"The path the volume should be mounted to." placeholder:"path" example:"/mnt"`
-	ReadOnly bool   `group:"flag-attach" name:"readonly" shortcut:"attached-to.0.read-only" short:"r" help:"Mount the volume read-only."`
+	AttachTo string `group:"flag-attach" name:"to" shortcut:"attach-to" help:"The instance the volume should be attached to." placeholder:"instance-name"`
+	At       string `group:"flag-attach" name:"at" shortcut:"attach-at" help:"The path the volume should be mounted to." placeholder:"path" example:"/mnt"`
+	ReadOnly bool   `group:"flag-attach" name:"readonly" shortcut:"attach-read-only" short:"r" help:"Mount the volume read-only."`
 }
 
 // Run applies any shortcut flags as --set arguments and then defers to the standard attach command implementation.
@@ -106,7 +106,7 @@ func (c *VolumeAttachCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *
 type VolumeDetachCmd struct {
 	cmd.ResourceDetachCmd[Volume]
 
-	From string `group:"flag-detach" name:"from" shortcut:"attached-to" help:"The instance the volume should be detached from." placeholder:"name"`
+	From string `group:"flag-detach" name:"from" shortcut:"detach-from" help:"The instance the volume should be detached from." placeholder:"instance-name"`
 }
 
 // Run applies any shortcut flags as --set arguments and then defers to the standard attach command implementation.
@@ -276,12 +276,6 @@ func (c *VolumesCloneCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *
 	return errors.Join(opErr, getErr)
 }
 
-type VolumeAttachTo struct {
-	Link[Instance]
-	ReadOnly bool   `mirror:"volume.read_only" field:",long" create:"set" edit:"set"`
-	MountAt  string `mirror:"volume.mount_at" create:"set" edit:"set"`
-}
-
 type Volume struct {
 	MetroName LinkName[Metro] `mirror:"metro.name" field:"metro,short" create:"set,required"`
 	Name      string          `mirror:"volume.name" field:",short" create:"set"`
@@ -299,7 +293,20 @@ type Volume struct {
 		Created types.RelativeTime `mirror:"volume.created_at" field:",short"`
 	}
 
-	AttachedTo []*VolumeAttachTo `mirror:"volume.attached_to" field:",embed" create:"set" edit:"set"`
+	AttachedTo []*struct {
+		Link[Instance]
+	} `mirror:"volume.attached_to"`
+
+	MountedBy []struct {
+		Link[Instance]
+		ReadOnly bool `mirror:"read_only" field:",long"`
+	} `mirror:"volume.mounted_by"`
+
+	AttachTo       Link[Instance] `mirror:"volume.attach_to" field:",invisible" create:"set"`
+	AttachAt       string         `mirror:"volume.attach_at" field:",invisible" create:"set"`
+	AttachReadOnly bool           `mirror:"volume.attach_read_only" field:",invisible" create:"set"`
+
+	DetachFrom Link[Instance] `mirror:"volume.detach_from" field:",invisible" create:"set"`
 
 	Volume platform.Volume `field:"-" json:"volume"`
 	Metro  *config.Metro   `field:"-" json:"metro"`
@@ -375,6 +382,7 @@ func (Volume) Get(ctx context.Context, keys []string) ([]resource.Resource, erro
 				errs = append(errs, err)
 				continue
 			}
+
 			found = append(found, group.Ref{
 				Metro: c.Metro.Name,
 				Name:  result.Name,
@@ -543,18 +551,18 @@ func (Volume) Attach(ctx context.Context, key string, fields []resource.Field) e
 			for key, field := range resource.IterFields(fields) {
 				if field.Create != nil && field.Create.Set != nil {
 					switch key.String() {
-					case "attached-to":
-						if attach, ok := field.Create.Set.([]*VolumeAttachTo); ok && len(attach) > 0 {
-							if uuid := attach[0].UUID; uuid != "" {
+					case "attach-to":
+						if instance, ok := field.Create.Set.(Link[Instance]); ok {
+							if uuid := instance.UUID; uuid != "" {
 								req.AttachTo = platform.NameOrUUID{Uuid: &uuid}
-							} else if name := attach[0].Name; name != "" {
+							} else if name := instance.Name; name != "" {
 								req.AttachTo = platform.NameOrUUID{Name: &name}
 							}
 						}
-					case "attached-to.0.read-only":
+					case "attach-read-only":
 						readonly := true
 						req.Readonly = &readonly
-					case "attached-to.0.mount-at":
+					case "attach-at":
 						req.At = field.Create.Set.(string)
 					}
 				}
@@ -602,11 +610,11 @@ func (Volume) Detach(ctx context.Context, key string, fields []resource.Field) e
 			for key, field := range resource.IterFields(fields) {
 				if field.Create != nil && field.Create.Set != nil {
 					switch key.String() {
-					case "attached-to":
-						if attach, ok := field.Create.Set.([]*VolumeAttachTo); ok && len(attach) > 0 {
-							if uuid := attach[0].UUID; uuid != "" {
+					case "detach-from":
+						if instance, ok := field.Create.Set.(Link[Instance]); ok {
+							if uuid := instance.UUID; uuid != "" {
 								req.From = &platform.NameOrUUID{Uuid: &uuid}
-							} else if name := attach[0].Name; name != "" {
+							} else if name := instance.Name; name != "" {
 								req.From = &platform.NameOrUUID{Name: &name}
 							}
 						}

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -302,8 +302,8 @@ type Volume struct {
 		ReadOnly bool `mirror:"read_only" field:",long"`
 	} `mirror:"volume.mounted_by"`
 
-	AttachTo       Link[Instance] `mirror:"volume.attach_to" field:",invisible" create:"set"`
-	AttachAt       string         `mirror:"volume.attach_at" field:",invisible" create:"set"`
+	AttachTo       Link[Instance] `mirror:"volume.attach_to" field:",invisible" create:"set,required"`
+	AttachAt       string         `mirror:"volume.attach_at" field:",invisible" create:"set,required"`
 	AttachReadOnly bool           `mirror:"volume.attach_read_only" field:",invisible" create:"set"`
 
 	DetachFrom Link[Instance] `mirror:"volume.detach_from" field:",invisible" create:"set"`

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -545,9 +545,9 @@ func (Volume) Attach(ctx context.Context, key string, fields []resource.Field) e
 					switch key.String() {
 					case "attached-to":
 						if attach, ok := field.Create.Set.([]*VolumeAttachTo); ok && len(attach) > 0 {
-							if uuid := attach[0].Link.UUID; uuid != "" {
+							if uuid := attach[0].UUID; uuid != "" {
 								req.AttachTo = platform.NameOrUUID{Uuid: &uuid}
-							} else if name := attach[0].Link.Name; name != "" {
+							} else if name := attach[0].Name; name != "" {
 								req.AttachTo = platform.NameOrUUID{Name: &name}
 							}
 						}
@@ -558,7 +558,6 @@ func (Volume) Attach(ctx context.Context, key string, fields []resource.Field) e
 						req.At = field.Create.Set.(string)
 					}
 				}
-
 			}
 
 			reqs = append(reqs, req)
@@ -605,15 +604,14 @@ func (Volume) Detach(ctx context.Context, key string, fields []resource.Field) e
 					switch key.String() {
 					case "attached-to":
 						if attach, ok := field.Create.Set.([]*VolumeAttachTo); ok && len(attach) > 0 {
-							if uuid := attach[0].Link.UUID; uuid != "" {
+							if uuid := attach[0].UUID; uuid != "" {
 								req.From = &platform.NameOrUUID{Uuid: &uuid}
-							} else if name := attach[0].Link.Name; name != "" {
+							} else if name := attach[0].Name; name != "" {
 								req.From = &platform.NameOrUUID{Name: &name}
 							}
 						}
 					}
 				}
-
 			}
 
 			reqs = append(reqs, req)

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -293,7 +293,7 @@ type Volume struct {
 		Created types.RelativeTime `mirror:"volume.created_at" field:",short"`
 	}
 
-	AttachedTo []*struct {
+	AttachedTo []struct {
 		Link[Instance]
 	} `mirror:"volume.attached_to"`
 

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -109,7 +109,7 @@ type VolumeDetachCmd struct {
 	From string `group:"flag-detach" name:"from" shortcut:"detach-from" help:"The instance the volume should be detached from." placeholder:"instance-name"`
 }
 
-// Run applies any shortcut flags as --set arguments and then defers to the standard attach command implementation.
+// Run applies any shortcut flags as --set arguments and then defers to the standard detach command implementation.
 func (c *VolumeDetachCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox, kctx *kong.Context) error {
 	if err := cmd.ApplyShortcutFlags(&c.SetArgs, kctx.Flags()); err != nil {
 		return err
@@ -537,37 +537,43 @@ func (Volume) Attach(ctx context.Context, key string, fields []resource.Field) e
 	}
 
 	return group.DoRefs(ctx, g, parsedKeys.Refs(), func(ctx context.Context, c multimetro.MetroClient, refs group.Refs) (group.Refs, error) {
+		var (
+			attachTo platform.NameOrUUID
+			attachAt string
+			readOnly *bool
+		)
+		for key, field := range resource.IterFields(fields) {
+			if field.Create == nil || field.Create.Set == nil {
+				continue
+			}
+			switch key.String() {
+			case "attach-to":
+				if instance, ok := field.Create.Set.(Link[Instance]); ok {
+					attachTo = instance.Ref().NameOrUUID()
+				}
+			case "attach-read-only":
+				if ro, ok := field.Create.Set.(bool); ok {
+					readOnly = &ro
+				}
+			case "attach-at":
+				if at, ok := field.Create.Set.(string); ok {
+					attachAt = at
+				}
+			}
+		}
+
 		reqs := make([]platform.AttachVolumesRequestItem, 0, len(refs))
-
 		for _, ref := range refs {
-			var req platform.AttachVolumesRequestItem
-
+			req := platform.AttachVolumesRequestItem{
+				AttachTo: attachTo,
+				At:       attachAt,
+				Readonly: readOnly,
+			}
 			if ref.UUID != "" {
 				req.Uuid = &ref.UUID
 			} else {
 				req.Name = &ref.Name
 			}
-
-			for key, field := range resource.IterFields(fields) {
-				if field.Create != nil && field.Create.Set != nil {
-					switch key.String() {
-					case "attach-to":
-						if instance, ok := field.Create.Set.(Link[Instance]); ok {
-							if uuid := instance.UUID; uuid != "" {
-								req.AttachTo = platform.NameOrUUID{Uuid: &uuid}
-							} else if name := instance.Name; name != "" {
-								req.AttachTo = platform.NameOrUUID{Name: &name}
-							}
-						}
-					case "attach-read-only":
-						readonly := true
-						req.Readonly = &readonly
-					case "attach-at":
-						req.At = field.Create.Set.(string)
-					}
-				}
-			}
-
 			reqs = append(reqs, req)
 		}
 
@@ -596,32 +602,27 @@ func (Volume) Detach(ctx context.Context, key string, fields []resource.Field) e
 	}
 
 	return group.DoRefs(ctx, g, parsedKeys.Refs(), func(ctx context.Context, c multimetro.MetroClient, refs group.Refs) (group.Refs, error) {
+		var from *platform.NameOrUUID
+		for key, field := range resource.IterFields(fields) {
+			if field.Create == nil || field.Create.Set == nil {
+				continue
+			}
+			if key.String() == "detach-from" {
+				if instance, ok := field.Create.Set.(Link[Instance]); ok {
+					nou := instance.Ref().NameOrUUID()
+					from = &nou
+				}
+			}
+		}
+
 		reqs := make([]platform.DetachVolumesRequestItem, 0, len(refs))
-
 		for _, ref := range refs {
-			var req platform.DetachVolumesRequestItem
-
+			req := platform.DetachVolumesRequestItem{From: from}
 			if ref.UUID != "" {
 				req.Uuid = &ref.UUID
 			} else {
 				req.Name = &ref.Name
 			}
-
-			for key, field := range resource.IterFields(fields) {
-				if field.Create != nil && field.Create.Set != nil {
-					switch key.String() {
-					case "detach-from":
-						if instance, ok := field.Create.Set.(Link[Instance]); ok {
-							if uuid := instance.UUID; uuid != "" {
-								req.From = &platform.NameOrUUID{Uuid: &uuid}
-							} else if name := instance.Name; name != "" {
-								req.From = &platform.NameOrUUID{Name: &name}
-							}
-						}
-					}
-				}
-			}
-
 			reqs = append(reqs, req)
 		}
 

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -52,6 +52,10 @@ type VolumesCmd struct {
 
 	Clone  VolumesCloneCmd `cmd:"" help:"Clone a volume."`
 	Import VolumeImportCmd `cmd:"" help:"Import data into a volume."`
+
+	// Attach and Detach are implemented as resource-level operations rather than action commands to allow for multiple volumes to be attached or detached in a single command, which is a common use case when managing volumes. The attach and detach fields are specified as part of the volume resource, allowing for more flexible and efficient management of volume attachments.
+	Attach VolumeAttachCmd `cmd:"" help:"Attach a volume."`
+	Detach VolumeDetachCmd `cmd:"" help:"Detach a volume."`
 }
 
 // VolumeCreateCmd extends the generic resource create command with shortcut
@@ -72,7 +76,46 @@ func (c *VolumeCreateCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *
 	if err := cmd.ApplyShortcutFlags(&c.SetArgs, kctx.Flags()); err != nil {
 		return err
 	}
+
 	return c.ResourceCreateCmd.Run(ctx, stdio, sandbox)
+}
+
+// VolumeAttachCmd extends the generic resource attach command with shortcut flags for
+// commonly used attachable volume fields. Each field tagged with `shortcut:"<path>"` is
+// translated into a --set <path>=<value> entry before the standard attach pipeline runs.
+type VolumeAttachCmd struct {
+	cmd.ResourceAttachCmd[Volume]
+
+	AttachTo string `group:"flag-attach" name:"to" shortcut:"attached-to" help:"The instance the volume should be attached to." placeholder:"name"`
+	MountAt  string `group:"flag-attach" name:"at" shortcut:"attached-to.0.mount-at" help:"The path the volume should be mounted to." placeholder:"path" example:"/mnt"`
+	ReadOnly bool   `group:"flag-attach" name:"readonly" shortcut:"attached-to.0.read-only" short:"r" help:"Mount the volume read-only."`
+}
+
+// Run applies any shortcut flags as --set arguments and then defers to the standard attach command implementation.
+func (c *VolumeAttachCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox, kctx *kong.Context) error {
+	if err := cmd.ApplyShortcutFlags(&c.SetArgs, kctx.Flags()); err != nil {
+		return err
+	}
+
+	return c.ResourceAttachCmd.Run(ctx, stdio, sandbox)
+}
+
+// VolumeDetachCmd extends the generic resource detach command with shortcut flags for
+// commonly used detachable volume fields. Each field tagged with `shortcut:"<path>"` is
+// translated into a --set <path>=<value> entry before the standard detach pipeline runs.
+type VolumeDetachCmd struct {
+	cmd.ResourceDetachCmd[Volume]
+
+	From string `group:"flag-detach" name:"from" shortcut:"attached-to" help:"The instance the volume should be detached from." placeholder:"name"`
+}
+
+// Run applies any shortcut flags as --set arguments and then defers to the standard attach command implementation.
+func (c *VolumeDetachCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox, kctx *kong.Context) error {
+	if err := cmd.ApplyShortcutFlags(&c.SetArgs, kctx.Flags()); err != nil {
+		return err
+	}
+
+	return c.ResourceDetachCmd.Run(ctx, stdio, sandbox)
 }
 
 // VolumeEditCmd extends the generic resource edit command with shortcut
@@ -90,6 +133,7 @@ func (c *VolumeEditCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *re
 	if err := cmd.ApplyShortcutFlags(&c.SetArgs, kctx.Flags()); err != nil {
 		return err
 	}
+
 	return c.ResourceEditCmd.Run(ctx, stdio, sandbox)
 }
 
@@ -232,6 +276,12 @@ func (c *VolumesCloneCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *
 	return errors.Join(opErr, getErr)
 }
 
+type VolumeAttachTo struct {
+	Link[Instance]
+	ReadOnly bool   `mirror:"volume.read_only" field:",long" create:"set" edit:"set"`
+	MountAt  string `mirror:"volume.mount_at" create:"set" edit:"set"`
+}
+
 type Volume struct {
 	MetroName LinkName[Metro] `mirror:"metro.name" field:"metro,short" create:"set,required"`
 	Name      string          `mirror:"volume.name" field:",short" create:"set"`
@@ -249,14 +299,7 @@ type Volume struct {
 		Created types.RelativeTime `mirror:"volume.created_at" field:",short"`
 	}
 
-	AttachedTo []struct {
-		Link[Instance]
-	} `mirror:"volume.attached_to"`
-
-	MountedBy []struct {
-		Link[Instance]
-		ReadOnly bool `mirror:"read_only" field:",long"`
-	} `mirror:"volume.mounted_by"`
+	AttachedTo []*VolumeAttachTo `mirror:"volume.attached_to" field:",embed" create:"set" edit:"set"`
 
 	Volume platform.Volume `field:"-" json:"volume"`
 	Metro  *config.Metro   `field:"-" json:"metro"`
@@ -475,6 +518,121 @@ func (Volume) Create(ctx context.Context, fields []resource.Field) ([]resource.R
 	return results, nil
 }
 
+// Attach attempts to attach the specified volume to an instance. The volume and instance can be identified by either name or UUID,
+// but the instance must be specified in the attach fields rather than the key.
+func (Volume) Attach(ctx context.Context, key string, fields []resource.Field) error {
+	parsedKeys := multimetro.ParseKeys([]string{key})
+
+	g, err := multimetro.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	return group.DoRefs(ctx, g, parsedKeys.Refs(), func(ctx context.Context, c multimetro.MetroClient, refs group.Refs) (group.Refs, error) {
+		reqs := make([]platform.AttachVolumesRequestItem, 0, len(refs))
+
+		for _, ref := range refs {
+			var req platform.AttachVolumesRequestItem
+
+			if ref.UUID != "" {
+				req.Uuid = &ref.UUID
+			} else {
+				req.Name = &ref.Name
+			}
+
+			for key, field := range resource.IterFields(fields) {
+				if field.Create != nil && field.Create.Set != nil {
+					switch key.String() {
+					case "attached-to":
+						if attach, ok := field.Create.Set.([]*VolumeAttachTo); ok && len(attach) > 0 {
+							if uuid := attach[0].Link.UUID; uuid != "" {
+								req.AttachTo = platform.NameOrUUID{Uuid: &uuid}
+							} else if name := attach[0].Link.Name; name != "" {
+								req.AttachTo = platform.NameOrUUID{Name: &name}
+							}
+						}
+					case "attached-to.0.read-only":
+						readonly := true
+						req.Readonly = &readonly
+					case "attached-to.0.mount-at":
+						req.At = field.Create.Set.(string)
+					}
+				}
+
+			}
+
+			reqs = append(reqs, req)
+		}
+
+		log.G(ctx).Trace().Msg("attaching volume")
+
+		_, err := c.AttachVolumes(ctx, reqs)
+		if err != nil {
+			if platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
+				return nil, nil
+			}
+			return nil, err
+		}
+
+		return refs, nil
+	})
+}
+
+// Detach attempts to detach the specified volume from an instance. The volume can be identified by either name or UUID,
+// but the instance must be specified in the detach fields rather than the key.
+func (Volume) Detach(ctx context.Context, key string, fields []resource.Field) error {
+	parsedKeys := multimetro.ParseKeys([]string{key})
+
+	g, err := multimetro.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	return group.DoRefs(ctx, g, parsedKeys.Refs(), func(ctx context.Context, c multimetro.MetroClient, refs group.Refs) (group.Refs, error) {
+		reqs := make([]platform.DetachVolumesRequestItem, 0, len(refs))
+
+		for _, ref := range refs {
+			var req platform.DetachVolumesRequestItem
+
+			if ref.UUID != "" {
+				req.Uuid = &ref.UUID
+			} else {
+				req.Name = &ref.Name
+			}
+
+			for key, field := range resource.IterFields(fields) {
+				if field.Create != nil && field.Create.Set != nil {
+					switch key.String() {
+					case "attached-to":
+						if attach, ok := field.Create.Set.([]*VolumeAttachTo); ok && len(attach) > 0 {
+							if uuid := attach[0].Link.UUID; uuid != "" {
+								req.From = &platform.NameOrUUID{Uuid: &uuid}
+							} else if name := attach[0].Link.Name; name != "" {
+								req.From = &platform.NameOrUUID{Name: &name}
+							}
+						}
+					}
+				}
+
+			}
+
+			reqs = append(reqs, req)
+		}
+
+		log.G(ctx).Trace().Msg("detaching volume")
+
+		_, err := c.DetachVolumes(ctx, reqs)
+		if err != nil {
+			if platform.ErrorContainsOnly(err, platform.APIHTTPErrorNotFound) {
+				return nil, nil
+			}
+			return nil, err
+		}
+
+		return refs, nil
+	})
+}
+
 func (Volume) Edit(ctx context.Context, key string, fields []resource.Field) error {
 	parsedKeys := multimetro.ParseKeys([]string{key})
 	patches, err := patchRequests(fields, volumePatchSpec)
@@ -557,6 +715,26 @@ func (Volume) Examples() map[cmd.CmdType][]kingkong.Example {
 			{
 				Description: "Delete a volume by name or UUID",
 				Commands:    []string{"unikraft volume delete demo-volume"},
+			},
+		},
+		cmd.CmdTypeAttach: {
+			{
+				Description: "Attach a volume",
+				Commands: []string{
+					`unikraft volume attach demo-volume \
+	  --at /mnt \
+	  --readonly \
+	  --to instance-name`,
+				},
+			},
+		},
+		cmd.CmdTypeDetach: {
+			{
+				Description: "Detach a volume",
+				Commands: []string{
+					`unikraft volume detach demo-volume \
+	  --from instance-name`,
+				},
 			},
 		},
 	}

--- a/internal/multimetro/client.go
+++ b/internal/multimetro/client.go
@@ -38,6 +38,7 @@ func NewClient(ctx context.Context) (*group.Group[MetroClient], error) {
 	for _, metro := range metros {
 		metroNames = append(metroNames, metro.Name)
 	}
+
 	log.G(ctx).
 		Trace().
 		Strs("metros", metroNames).

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -682,13 +682,9 @@ func (cmd *ResourceBulkRemoveCmd[R]) Run(ctx context.Context, stdio config.Stdio
 	}
 }
 
-// ResourceSetCmd is a shared implementation for editing fields of a resource, used by both edit and attach/detach commands.
+// ResourceMutateCmd is a shared implementation for editing fields of a resource, used by both edit and attach/detach commands.
 // The create command is similar but has enough differences that it gets its own implementation.
-type ResourceSetCmd[R resource.GettableResource] struct {
-	SetArgs
-	AddArgs
-	DelArgs
-
+type ResourceMutateCmd[R resource.GettableResource] struct {
 	Visual bool   `xor:"edit-mode" help:"Open an editor to modify fields visually."`
 	Cmd    string `xor:"edit-mode" help:"Run a command to edit fields (receives YAML on stdin, outputs edited YAML on stdout)."`
 	Load   []byte `xor:"edit-mode" collapse:"file-mode" type:"filecontent" help:"Load fields from a YAML file."`
@@ -699,64 +695,180 @@ type ResourceSetCmd[R resource.GettableResource] struct {
 	FormatOpts
 }
 
-func (cmd *ResourceSetCmd[R]) toPatchSpec(createField bool) (patch.PatchSpec, error) {
-	spec := patch.PatchSpec{
-		Create: createField,
-		Set:    make(map[string][]string),
-		Add:    make(map[string][]string),
-		Del:    make(map[string][]string),
+func (cmd ResourceMutateCmd[R]) getDefault(ctx context.Context) (resource.Resource, error) {
+	var empty R
+
+	def, ok := any(empty).(resource.DefaultResource)
+	if !ok {
+		return nil, fmt.Errorf("parsing arguments: no %s specified", empty.Type().Names)
 	}
-	if err := cmd.SetArgs.Apply(&spec); err != nil {
-		return spec, err
-	}
-	if err := cmd.AddArgs.Apply(&spec); err != nil {
-		return spec, err
-	}
-	if err := cmd.DelArgs.Apply(&spec); err != nil {
-		return spec, err
-	}
-	return spec, nil
+
+	return def.Default(ctx)
 }
 
-func (cmd ResourceSetCmd[R]) HelpSections() []kingkong.HelpSection {
+func (cmd ResourceMutateCmd[R]) getFields(ctx context.Context, stdio config.Stdio, spec *patch.PatchSpec, item resource.Resource) ([]resource.Field, error) {
+	var (
+		editor patch.EditorFunc
+		err    error
+	)
+
+	fields, err := item.Fields(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get fields: %w", err)
+	}
+
+	patched, err := patch.PatchedFields(fields, spec)
+	if err != nil {
+		return nil, err
+	}
+
+	// Handle --save: write YAML to file and exit
+	if cmd.Save != "" {
+		err := saveYAML(cmd.Save, stdio, item, fields, patched, false)
+		return nil, err
+	}
+
+	// Handle different editing modes (mutually exclusive via xor:"edit-mode" tag)
+	switch {
+	case cmd.Visual:
+		editor, err = patch.VisualCommandEditorFunc()
+		if err != nil {
+			return nil, err
+		}
+	case cmd.Cmd != "":
+		editor = patch.CommandEditorFunc(cmd.Cmd)
+	case len(cmd.Load) > 0:
+		editor = patch.ContentEditorFunc(cmd.Load)
+	}
+
+	if editor != nil {
+		if spec.Create {
+			patched, err = patch.Create(ctx, item, fields, patched, editor)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			patched, err = patch.Edit(ctx, item, fields, patched, editor)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if spec.Create {
+		patched = patch.FilterCreateFields(patched)
+	} else {
+		patched = patch.FilterEditFields(patched)
+	}
+
+	if cmd.DryRun {
+		err := PrintPatches(stdio.Stdout, patched, false)
+		return nil, err
+	}
+
+	return patched, nil
+}
+
+func (cmd ResourceMutateCmd[R]) getItemByKey(ctx context.Context, key string, res resource.MutableResource) (resource.Resource, error) {
+	if key == "" {
+		return cmd.getDefault(ctx)
+	}
+
+	items, err := res.Get(ctx, []string{key})
+	if err != nil {
+		return nil, err
+	}
+	if len(items) == 0 {
+		return nil, fmt.Errorf("resource not found: %s", key)
+	}
+	if len(items) > 1 {
+		var keys []string
+		for _, res := range items {
+			keys = append(keys, res.Key().String())
+		}
+		return nil, fmt.Errorf("ambiguous resource name: %s (found %v)", key, keys)
+	}
+
+	return items[0], nil
+}
+
+func (cmd ResourceMutateCmd[R]) setItem(ctx context.Context, stdio config.Stdio, res resource.MutableResource, fields []resource.Field, item resource.Resource) error {
+	updated := []resource.Resource{item}
+	if len(fields) > 0 {
+		editKey := item.Key().String()
+		if err := res.Set(ctx, editKey, fields); err != nil {
+			return err
+		}
+		// Re-fetch the resource to get the updated state.
+		getKey := item.Key().String()
+
+		results, err := res.Get(ctx, []string{getKey})
+		if err != nil {
+			return err
+		}
+		if len(results) > 0 {
+			updated = results[:1]
+		}
+	} else {
+		log.G(ctx).Warn().
+			Str("resource", item.Key().String()).
+			Msg("no mutates made")
+	}
+
+	var empty R
+	return Diff(ctx, stdio.Stdout, cmd.FormatOpts, empty, []resource.Resource{item}, updated)
+}
+
+func (cmd ResourceMutateCmd[R]) HelpSections() []kingkong.HelpSection {
 	return ResourceCmd[R]{}.HelpSections()
 }
 
-func (cmd *ResourceSetCmd[R]) Run(ctx context.Context, stdio config.Stdio, r resource.SettableResource, target string, createField bool) error {
-	spec, err := cmd.toPatchSpec(createField)
+func (cmd *ResourceMutateCmd[R]) Run(ctx context.Context, stdio config.Stdio, res resource.MutableResource, target string, spec *patch.PatchSpec) error {
+	item, err := cmd.getItemByKey(ctx, target, res)
 	if err != nil {
 		return err
 	}
 
-	var empty R
+	fields, err := cmd.getFields(ctx, stdio, spec, item)
+	if err != nil {
+		return err
+	}
 
-	var res resource.Resource
+	return cmd.setItem(ctx, stdio, res, fields, item)
+}
 
-	if target == "" {
-		def, ok := any(empty).(resource.DefaultResource)
-		if !ok {
-			return fmt.Errorf("parsing arguments: no %s specified", empty.Type().Names)
-		}
-		res, err = def.Default(ctx)
-		if err != nil {
-			return err
-		}
-	} else {
-		resources, err := r.Get(ctx, []string{target})
-		if err != nil {
-			return err
-		}
-		if len(resources) == 0 {
-			return fmt.Errorf("resource not found: %s", target)
-		}
-		if len(resources) > 1 {
-			var keys []string
-			for _, res := range resources {
-				keys = append(keys, res.Key().String())
-			}
-			return fmt.Errorf("ambiguous resource name: %s (found %v)", target, keys)
-		}
-		res = resources[0]
+type ResourceEditCmd[R resource.EditableResource] struct {
+	ResourceMutateCmd[R]
+
+	SetArgs
+	AddArgs
+	DelArgs
+
+	Target string `arg:"" name:"target" completion-predictor:"resource-key-${name}" help:"Target ${name} to edit."`
+}
+
+func (cmd ResourceEditCmd[R]) Examples() []kingkong.Example {
+	var r R
+	if ep, ok := any(r).(ExampledResource); ok {
+		return ep.Examples()[CmdTypeEdit]
+	}
+	return nil
+}
+
+func (cmd *ResourceEditCmd[R]) toPatchSpec() (*patch.PatchSpec, error) {
+	spec := &patch.PatchSpec{
+		Set: make(map[string][]string),
+		Add: make(map[string][]string),
+		Del: make(map[string][]string),
+	}
+	if err := cmd.SetArgs.Apply(spec); err != nil {
+		return spec, err
+	}
+	if err := cmd.AddArgs.Apply(spec); err != nil {
+		return spec, err
+	}
+	if err := cmd.DelArgs.Apply(spec); err != nil {
+		return spec, err
 	}
 
 	allFields := make(map[string]int)
@@ -771,105 +883,53 @@ func (cmd *ResourceSetCmd[R]) Run(ctx context.Context, stdio config.Stdio, r res
 	}
 	for k, count := range allFields {
 		if count > 1 {
-			return fmt.Errorf("field %s has multiple patch operations", k)
+			return nil, fmt.Errorf("field %s has multiple patch operations", k)
 		}
 	}
 
-	fields, err := res.Fields(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get fields: %w", err)
-	}
-
-	patched, err := patch.PatchedFields(fields, spec)
-	if err != nil {
-		return err
-	}
-
-	// Handle --save: write YAML to file and exit
-	if cmd.Save != "" {
-		return saveYAML(cmd.Save, stdio, res, fields, patched, false)
-	}
-
-	// Handle different editing modes (mutually exclusive via xor:"edit-mode" tag)
-	var editor patch.EditorFunc
-	switch {
-	case cmd.Visual:
-		editor, err = patch.VisualCommandEditorFunc()
-		if err != nil {
-			return err
-		}
-	case cmd.Cmd != "":
-		editor = patch.CommandEditorFunc(cmd.Cmd)
-	case len(cmd.Load) > 0:
-		editor = patch.ContentEditorFunc(cmd.Load)
-	}
-	if editor != nil {
-		patched, err = patch.Edit(ctx, res, fields, patched, editor)
-		if err != nil {
-			return err
-		}
-	}
-	if createField {
-		patched = patch.FilterCreateFields(patched)
-	} else {
-		patched = patch.FilterEditFields(patched)
-	}
-
-	if cmd.DryRun {
-		return PrintPatches(stdio.Stdout, patched, false)
-	}
-
-	updated := []resource.Resource{res}
-	if len(patched) > 0 {
-		editKey := res.Key().String()
-		if err := r.Set(ctx, editKey, patched); err != nil {
-			return err
-		}
-		// Re-fetch the resource to get the updated state.
-		getKey := target
-		if getKey == "" {
-			getKey = res.Key().String()
-		}
-		results, err := r.Get(ctx, []string{getKey})
-		if err != nil {
-			return err
-		}
-		if len(results) > 0 {
-			updated = results[:1]
-		}
-	} else {
-		log.G(ctx).Warn().
-			Str("resource", res.Key().String()).
-			Msg("no edits made")
-	}
-	return Diff(ctx, stdio.Stdout, cmd.FormatOpts, empty, []resource.Resource{res}, updated)
-}
-
-type ResourceEditCmd[R resource.EditableResource] struct {
-	ResourceSetCmd[R]
-
-	Target string `arg:"" name:"target" completion-predictor:"resource-key-${name}" help:"Target ${name} to edit."`
-}
-
-func (cmd ResourceEditCmd[R]) Examples() []kingkong.Example {
-	var r R
-	if ep, ok := any(r).(ExampledResource); ok {
-		return ep.Examples()[CmdTypeEdit]
-	}
-	return nil
+	return spec, nil
 }
 
 func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox) error {
 	var empty R
-	r := sandbox.WrapEditable(empty)
+	res := sandbox.WrapEditable(empty)
 
-	return cmd.ResourceSetCmd.Run(ctx, stdio, r, cmd.Target, false)
+	spec, err := cmd.toPatchSpec()
+	if err != nil {
+		return err
+	}
+
+	return cmd.ResourceMutateCmd.Run(ctx, stdio, res, cmd.Target, spec)
 }
 
 type ResourceAttachCmd[R resource.AttachableResource] struct {
-	ResourceSetCmd[R]
+	ResourceMutateCmd[R]
+
+	SetArgs
 
 	Target string `arg:"" name:"target" completion-predictor:"resource-key-${name}" help:"Target ${name} to attach."`
+}
+
+func (cmd *ResourceAttachCmd[R]) toPatchSpec() (*patch.PatchSpec, error) {
+	spec := &patch.PatchSpec{
+		Create: true,
+		Set:    make(map[string][]string),
+	}
+	if err := cmd.Apply(spec); err != nil {
+		return spec, err
+	}
+
+	allFields := make(map[string]int)
+	for k := range spec.Set {
+		allFields[k]++
+	}
+	for k, count := range allFields {
+		if count > 1 {
+			return nil, fmt.Errorf("field %s has multiple patch operations", k)
+		}
+	}
+
+	return spec, nil
 }
 
 func (cmd ResourceAttachCmd[R]) Examples() []kingkong.Example {
@@ -882,15 +942,44 @@ func (cmd ResourceAttachCmd[R]) Examples() []kingkong.Example {
 
 func (cmd *ResourceAttachCmd[R]) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox) error {
 	var empty R
-	r := sandbox.WrapAttachable(empty)
+	res := sandbox.WrapAttachable(empty)
 
-	return cmd.ResourceSetCmd.Run(ctx, stdio, r, cmd.Target, true)
+	spec, err := cmd.toPatchSpec()
+	if err != nil {
+		return err
+	}
+
+	return cmd.ResourceMutateCmd.Run(ctx, stdio, res, cmd.Target, spec)
 }
 
 type ResourceDetachCmd[R resource.DetachableResource] struct {
-	ResourceSetCmd[R]
+	ResourceMutateCmd[R]
+
+	SetArgs
 
 	Target string `arg:"" name:"target" completion-predictor:"resource-key-${name}" help:"Target ${name} to detach."`
+}
+
+func (cmd *ResourceDetachCmd[R]) toPatchSpec() (*patch.PatchSpec, error) {
+	spec := &patch.PatchSpec{
+		Create: true,
+		Set:    make(map[string][]string),
+	}
+	if err := cmd.Apply(spec); err != nil {
+		return spec, err
+	}
+
+	allFields := make(map[string]int)
+	for k := range spec.Set {
+		allFields[k]++
+	}
+	for k, count := range allFields {
+		if count > 1 {
+			return nil, fmt.Errorf("field %s has multiple patch operations", k)
+		}
+	}
+
+	return spec, nil
 }
 
 func (cmd ResourceDetachCmd[R]) Examples() []kingkong.Example {
@@ -903,22 +992,42 @@ func (cmd ResourceDetachCmd[R]) Examples() []kingkong.Example {
 
 func (cmd *ResourceDetachCmd[R]) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox) error {
 	var empty R
-	r := sandbox.WrapDetachable(empty)
+	res := sandbox.WrapDetachable(empty)
 
-	return cmd.ResourceSetCmd.Run(ctx, stdio, r, cmd.Target, true)
+	spec, err := cmd.toPatchSpec()
+	if err != nil {
+		return err
+	}
+
+	return cmd.ResourceMutateCmd.Run(ctx, stdio, res, cmd.Target, spec)
 }
 
 type ResourceCreateCmd[R resource.CreatableResource] struct {
+	ResourceMutateCmd[R]
+
 	SetArgs
+}
 
-	Visual bool   `xor:"edit-mode" help:"Open an editor to modify fields visually."`
-	Cmd    string `xor:"edit-mode" help:"Run a command to edit fields (receives YAML on stdin, outputs edited YAML on stdout)."`
-	Load   []byte `xor:"edit-mode" collapse:"file-mode" type:"filecontent" help:"Load fields from a YAML file."`
-	Save   string `xor:"edit-mode" collapse:"file-mode" placeholder:"FILE" help:"Save creatable fields as YAML to a file (use - for stdout)."`
+func (cmd *ResourceCreateCmd[R]) toPatchSpec() (*patch.PatchSpec, error) {
+	spec := &patch.PatchSpec{
+		Create: true,
+		Set:    make(map[string][]string),
+	}
+	if err := cmd.Apply(spec); err != nil {
+		return spec, err
+	}
 
-	DryRun bool `help:"Print patches without applying them."`
+	allFields := make(map[string]int)
+	for k := range spec.Set {
+		allFields[k]++
+	}
+	for k, count := range allFields {
+		if count > 1 {
+			return nil, fmt.Errorf("field %s has multiple patch operations", k)
+		}
+	}
 
-	FormatOpts
+	return spec, nil
 }
 
 func (cmd ResourceCreateCmd[R]) HelpSections() []kingkong.HelpSection {
@@ -931,17 +1040,6 @@ func (cmd ResourceCreateCmd[R]) Examples() []kingkong.Example {
 		return ep.Examples()[CmdTypeCreate]
 	}
 	return nil
-}
-
-func (cmd *ResourceCreateCmd[R]) toPatchSpec() (patch.PatchSpec, error) {
-	spec := patch.PatchSpec{
-		Create: true,
-		Set:    make(map[string][]string),
-	}
-	if err := cmd.Apply(&spec); err != nil {
-		return spec, err
-	}
-	return spec, nil
 }
 
 func (cmd *ResourceCreateCmd[R]) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox) error {

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -681,12 +681,14 @@ func (cmd *ResourceBulkRemoveCmd[R]) Run(ctx context.Context, stdio config.Stdio
 	}
 }
 
-type ResourceEditCmd[R resource.EditableResource] struct {
-	Target string `arg:"" name:"target" completion-predictor:"resource-key-${name}" help:"Target ${name} to edit."`
-
+// ResourceSetCmd is a shared implementation for editing fields of a resource, used by both edit and attach/detach commands.
+// The create command is similar but has enough differences that it gets its own implementation.
+type ResourceSetCmd[R resource.GettableResource] struct {
 	SetArgs
 	AddArgs
 	DelArgs
+
+	Target string `arg:"" name:"target" completion-predictor:"resource-key-${name}" help:"Target ${name} to edit."`
 
 	Visual bool   `xor:"edit-mode" help:"Open an editor to modify fields visually."`
 	Cmd    string `xor:"edit-mode" help:"Run a command to edit fields (receives YAML on stdin, outputs edited YAML on stdout)."`
@@ -698,23 +700,12 @@ type ResourceEditCmd[R resource.EditableResource] struct {
 	FormatOpts
 }
 
-func (cmd ResourceEditCmd[R]) HelpSections() []kingkong.HelpSection {
-	return ResourceCmd[R]{}.HelpSections()
-}
-
-func (cmd ResourceEditCmd[R]) Examples() []kingkong.Example {
-	var r R
-	if ep, ok := any(r).(ExampledResource); ok {
-		return ep.Examples()[CmdTypeEdit]
-	}
-	return nil
-}
-
-func (cmd *ResourceEditCmd[R]) toPatchSpec() (patch.PatchSpec, error) {
+func (cmd *ResourceSetCmd[R]) toPatchSpec(createField bool) (patch.PatchSpec, error) {
 	spec := patch.PatchSpec{
-		Set: make(map[string][]string),
-		Add: make(map[string][]string),
-		Del: make(map[string][]string),
+		Create: createField,
+		Set:    make(map[string][]string),
+		Add:    make(map[string][]string),
+		Del:    make(map[string][]string),
 	}
 	if err := cmd.SetArgs.Apply(&spec); err != nil {
 		return spec, err
@@ -728,14 +719,17 @@ func (cmd *ResourceEditCmd[R]) toPatchSpec() (patch.PatchSpec, error) {
 	return spec, nil
 }
 
-func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox) error {
-	spec, err := cmd.toPatchSpec()
+func (cmd ResourceSetCmd[R]) HelpSections() []kingkong.HelpSection {
+	return ResourceCmd[R]{}.HelpSections()
+}
+
+func (cmd *ResourceSetCmd[R]) Run(ctx context.Context, stdio config.Stdio, r resource.SettableResource, createField bool) error {
+	spec, err := cmd.toPatchSpec(createField)
 	if err != nil {
 		return err
 	}
 
 	var empty R
-	r := sandbox.WrapEditable(empty)
 
 	var res resource.Resource
 	if cmd.Target == "" {
@@ -823,7 +817,7 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, stdio config.Stdio, sand
 	updated := []resource.Resource{res}
 	if len(patched) > 0 {
 		editKey := res.Key().String()
-		if err := r.Edit(ctx, editKey, patched); err != nil {
+		if err := r.Set(ctx, editKey, patched); err != nil {
 			return err
 		}
 		// Re-fetch the resource to get the updated state.
@@ -844,6 +838,63 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, stdio config.Stdio, sand
 			Msg("no edits made")
 	}
 	return Diff(ctx, stdio.Stdout, cmd.FormatOpts, empty, []resource.Resource{res}, updated)
+}
+
+type ResourceEditCmd[R resource.EditableResource] struct {
+	ResourceSetCmd[R]
+}
+
+func (cmd ResourceEditCmd[R]) Examples() []kingkong.Example {
+	var r R
+	if ep, ok := any(r).(ExampledResource); ok {
+		return ep.Examples()[CmdTypeEdit]
+	}
+	return nil
+}
+
+func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox) error {
+	var empty R
+	r := sandbox.WrapEditable(empty)
+
+	return cmd.ResourceSetCmd.Run(ctx, stdio, r, false)
+}
+
+type ResourceAttachCmd[R resource.AttachableResource] struct {
+	ResourceSetCmd[R]
+}
+
+func (cmd ResourceAttachCmd[R]) Examples() []kingkong.Example {
+	var r R
+	if ep, ok := any(r).(ExampledResource); ok {
+		return ep.Examples()[CmdTypeAttach]
+	}
+	return nil
+}
+
+func (cmd *ResourceAttachCmd[R]) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox) error {
+	var empty R
+	r := sandbox.WrapAttachable(empty)
+
+	return cmd.ResourceSetCmd.Run(ctx, stdio, r, true)
+}
+
+type ResourceDetachCmd[R resource.DetachableResource] struct {
+	ResourceSetCmd[R]
+}
+
+func (cmd ResourceDetachCmd[R]) Examples() []kingkong.Example {
+	var r R
+	if ep, ok := any(r).(ExampledResource); ok {
+		return ep.Examples()[CmdTypeDetach]
+	}
+	return nil
+}
+
+func (cmd *ResourceDetachCmd[R]) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox) error {
+	var empty R
+	r := sandbox.WrapDetachable(empty)
+
+	return cmd.ResourceSetCmd.Run(ctx, stdio, r, true)
 }
 
 type ResourceCreateCmd[R resource.CreatableResource] struct {

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -808,7 +808,11 @@ func (cmd *ResourceSetCmd[R]) Run(ctx context.Context, stdio config.Stdio, r res
 			return err
 		}
 	}
-	patched = patch.FilterEditFields(patched)
+	if createField {
+		patched = patch.FilterCreateFields(patched)
+	} else {
+		patched = patch.FilterEditFields(patched)
+	}
 
 	if cmd.DryRun {
 		return PrintPatches(stdio.Stdout, patched, false)

--- a/internal/resource/cmd/cmd.go
+++ b/internal/resource/cmd/cmd.go
@@ -105,6 +105,7 @@ func (cmd ResourceCmd[R]) HelpSections() []kingkong.HelpSection {
 				}
 				parts = append(parts, kingkong.DimmedMoreColor(part))
 			}
+
 			paths = append(paths, strings.Join(parts, kingkong.DimmedColor(".")))
 		}
 		fmt.Fprintln(buf, strings.Join(paths, kingkong.DimmedColor(", ")))
@@ -688,8 +689,6 @@ type ResourceSetCmd[R resource.GettableResource] struct {
 	AddArgs
 	DelArgs
 
-	Target string `arg:"" name:"target" completion-predictor:"resource-key-${name}" help:"Target ${name} to edit."`
-
 	Visual bool   `xor:"edit-mode" help:"Open an editor to modify fields visually."`
 	Cmd    string `xor:"edit-mode" help:"Run a command to edit fields (receives YAML on stdin, outputs edited YAML on stdout)."`
 	Load   []byte `xor:"edit-mode" collapse:"file-mode" type:"filecontent" help:"Load fields from a YAML file."`
@@ -723,7 +722,7 @@ func (cmd ResourceSetCmd[R]) HelpSections() []kingkong.HelpSection {
 	return ResourceCmd[R]{}.HelpSections()
 }
 
-func (cmd *ResourceSetCmd[R]) Run(ctx context.Context, stdio config.Stdio, r resource.SettableResource, createField bool) error {
+func (cmd *ResourceSetCmd[R]) Run(ctx context.Context, stdio config.Stdio, r resource.SettableResource, target string, createField bool) error {
 	spec, err := cmd.toPatchSpec(createField)
 	if err != nil {
 		return err
@@ -732,7 +731,8 @@ func (cmd *ResourceSetCmd[R]) Run(ctx context.Context, stdio config.Stdio, r res
 	var empty R
 
 	var res resource.Resource
-	if cmd.Target == "" {
+
+	if target == "" {
 		def, ok := any(empty).(resource.DefaultResource)
 		if !ok {
 			return fmt.Errorf("parsing arguments: no %s specified", empty.Type().Names)
@@ -742,19 +742,19 @@ func (cmd *ResourceSetCmd[R]) Run(ctx context.Context, stdio config.Stdio, r res
 			return err
 		}
 	} else {
-		resources, err := r.Get(ctx, []string{cmd.Target})
+		resources, err := r.Get(ctx, []string{target})
 		if err != nil {
 			return err
 		}
 		if len(resources) == 0 {
-			return fmt.Errorf("resource not found: %s", cmd.Target)
+			return fmt.Errorf("resource not found: %s", target)
 		}
 		if len(resources) > 1 {
 			var keys []string
 			for _, res := range resources {
 				keys = append(keys, res.Key().String())
 			}
-			return fmt.Errorf("ambiguous resource name: %s (found %v)", cmd.Target, keys)
+			return fmt.Errorf("ambiguous resource name: %s (found %v)", target, keys)
 		}
 		res = resources[0]
 	}
@@ -779,6 +779,7 @@ func (cmd *ResourceSetCmd[R]) Run(ctx context.Context, stdio config.Stdio, r res
 	if err != nil {
 		return fmt.Errorf("failed to get fields: %w", err)
 	}
+
 	patched, err := patch.PatchedFields(fields, spec)
 	if err != nil {
 		return err
@@ -825,7 +826,7 @@ func (cmd *ResourceSetCmd[R]) Run(ctx context.Context, stdio config.Stdio, r res
 			return err
 		}
 		// Re-fetch the resource to get the updated state.
-		getKey := cmd.Target
+		getKey := target
 		if getKey == "" {
 			getKey = res.Key().String()
 		}
@@ -846,6 +847,8 @@ func (cmd *ResourceSetCmd[R]) Run(ctx context.Context, stdio config.Stdio, r res
 
 type ResourceEditCmd[R resource.EditableResource] struct {
 	ResourceSetCmd[R]
+
+	Target string `arg:"" name:"target" completion-predictor:"resource-key-${name}" help:"Target ${name} to edit."`
 }
 
 func (cmd ResourceEditCmd[R]) Examples() []kingkong.Example {
@@ -860,11 +863,13 @@ func (cmd *ResourceEditCmd[R]) Run(ctx context.Context, stdio config.Stdio, sand
 	var empty R
 	r := sandbox.WrapEditable(empty)
 
-	return cmd.ResourceSetCmd.Run(ctx, stdio, r, false)
+	return cmd.ResourceSetCmd.Run(ctx, stdio, r, cmd.Target, false)
 }
 
 type ResourceAttachCmd[R resource.AttachableResource] struct {
 	ResourceSetCmd[R]
+
+	Target string `arg:"" name:"target" completion-predictor:"resource-key-${name}" help:"Target ${name} to attach."`
 }
 
 func (cmd ResourceAttachCmd[R]) Examples() []kingkong.Example {
@@ -879,11 +884,13 @@ func (cmd *ResourceAttachCmd[R]) Run(ctx context.Context, stdio config.Stdio, sa
 	var empty R
 	r := sandbox.WrapAttachable(empty)
 
-	return cmd.ResourceSetCmd.Run(ctx, stdio, r, true)
+	return cmd.ResourceSetCmd.Run(ctx, stdio, r, cmd.Target, true)
 }
 
 type ResourceDetachCmd[R resource.DetachableResource] struct {
 	ResourceSetCmd[R]
+
+	Target string `arg:"" name:"target" completion-predictor:"resource-key-${name}" help:"Target ${name} to detach."`
 }
 
 func (cmd ResourceDetachCmd[R]) Examples() []kingkong.Example {
@@ -898,7 +905,7 @@ func (cmd *ResourceDetachCmd[R]) Run(ctx context.Context, stdio config.Stdio, sa
 	var empty R
 	r := sandbox.WrapDetachable(empty)
 
-	return cmd.ResourceSetCmd.Run(ctx, stdio, r, true)
+	return cmd.ResourceSetCmd.Run(ctx, stdio, r, cmd.Target, true)
 }
 
 type ResourceCreateCmd[R resource.CreatableResource] struct {

--- a/internal/resource/cmd/cmd_test.go
+++ b/internal/resource/cmd/cmd_test.go
@@ -1400,14 +1400,16 @@ func TestEditOutput(t *testing.T) {
 		t.Helper()
 		var out bytes.Buffer
 		cmd := &ResourceEditCmd[resourcet.TestResource]{
-			Target: "test-edit",
-			SetArgs: SetArgs{
-				Set: []map[string]string{
-					{"settings.foo": "999"},
+			ResourceSetCmd[resourcet.TestResource]{
+				Target: "test-edit",
+				SetArgs: SetArgs{
+					Set: []map[string]string{
+						{"settings.foo": "999"},
+					},
 				},
-			},
-			FormatOpts: FormatOpts{
-				Output: printer,
+				FormatOpts: FormatOpts{
+					Output: printer,
+				},
 			},
 		}
 		err := cmd.Run(ctx, testStdio(&out), sandbox)
@@ -1439,12 +1441,14 @@ func TestEditDryRun(t *testing.T) {
 
 	var out bytes.Buffer
 	cmd := &ResourceEditCmd[resourcet.TestResource]{
-		Target: "test-edit",
-		DryRun: true,
-		SetArgs: SetArgs{
-			Set: []map[string]string{
-				{"settings.foo": "999"},
-				{"settings.bar": "modified"},
+		ResourceSetCmd[resourcet.TestResource]{
+			Target: "test-edit",
+			DryRun: true,
+			SetArgs: SetArgs{
+				Set: []map[string]string{
+					{"settings.foo": "999"},
+					{"settings.bar": "modified"},
+				},
 			},
 		},
 	}
@@ -1483,9 +1487,11 @@ func TestEditCmdNoChangesDryRun(t *testing.T) {
 
 	var out bytes.Buffer
 	cmd := &ResourceEditCmd[resourcet.TestResource]{
-		Target: "test-edit",
-		Cmd:    "cat", // pass through unchanged
-		DryRun: true,
+		ResourceSetCmd[resourcet.TestResource]{
+			Target: "test-edit",
+			Cmd:    "cat", // pass through unchanged
+			DryRun: true,
+		},
 	}
 	err := cmd.Run(ctx, testStdio(&out), sandbox)
 	require.NoError(t, err)
@@ -1515,9 +1521,11 @@ func TestEditCmdWithChangesDryRun(t *testing.T) {
 
 	var out bytes.Buffer
 	cmd := &ResourceEditCmd[resourcet.TestResource]{
-		Target: "test-edit",
-		Cmd:    `sed 's/old-value/new-value/'`, // change settings.bar
-		DryRun: true,
+		ResourceSetCmd[resourcet.TestResource]{
+			Target: "test-edit",
+			Cmd:    `sed 's/old-value/new-value/'`, // change settings.bar
+			DryRun: true,
+		},
 	}
 	err := cmd.Run(ctx, testStdio(&out), sandbox)
 	require.NoError(t, err)
@@ -1539,21 +1547,23 @@ func TestEditPatchSpecFileArgs(t *testing.T) {
 	delFile := tempFile(t, " old-entry\n")
 
 	cmd := &ResourceEditCmd[resourcet.TestResource]{
-		SetArgs: SetArgs{
-			Set:     []map[string]string{{"settings.bar": "inline"}},
-			SetFile: []map[string]string{{"settings.foo": setFile}},
-		},
-		AddArgs: AddArgs{
-			Add:     []map[string]string{{"authors": "inline-entry"}},
-			AddFile: []map[string]string{{"authors": addFile}},
-		},
-		DelArgs: DelArgs{
-			Del:     []map[string]string{{"url": "inline-entry"}},
-			DelFile: []map[string]string{{"url": delFile}},
+		ResourceSetCmd[resourcet.TestResource]{
+			SetArgs: SetArgs{
+				Set:     []map[string]string{{"settings.bar": "inline"}},
+				SetFile: []map[string]string{{"settings.foo": setFile}},
+			},
+			AddArgs: AddArgs{
+				Add:     []map[string]string{{"authors": "inline-entry"}},
+				AddFile: []map[string]string{{"authors": addFile}},
+			},
+			DelArgs: DelArgs{
+				Del:     []map[string]string{{"url": "inline-entry"}},
+				DelFile: []map[string]string{{"url": delFile}},
+			},
 		},
 	}
 
-	spec, err := cmd.toPatchSpec()
+	spec, err := cmd.toPatchSpec(false)
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"inline"}, spec.Set["settings.bar"])

--- a/internal/resource/cmd/cmd_test.go
+++ b/internal/resource/cmd/cmd_test.go
@@ -650,8 +650,10 @@ func TestPartialResultsPrintedBeforeError(t *testing.T) {
 
 		var out bytes.Buffer
 		cmd := &ResourceCreateCmd[resourcet.TestResource]{
-			SetArgs:    SetArgs{Set: []map[string]string{{"name": "created"}}},
-			FormatOpts: FormatOpts{Output: Printer{Type: PrinterTypeQuiet}},
+			ResourceMutateCmd[resourcet.TestResource]{
+				FormatOpts: FormatOpts{Output: Printer{Type: PrinterTypeQuiet}},
+			},
+			SetArgs{Set: []map[string]string{{"name": "created"}}},
 		}
 		err := cmd.Run(ctx, testStdio(&out), nil)
 		require.Error(t, err)
@@ -769,8 +771,10 @@ func TestPartialResultsOrderWhenCallerPrintsError(t *testing.T) {
 
 		var out bytes.Buffer
 		cmd := &ResourceCreateCmd[resourcet.TestResource]{
-			SetArgs:    SetArgs{Set: []map[string]string{{"name": "created"}}},
-			FormatOpts: FormatOpts{Output: Printer{Type: PrinterTypeKeyValue}},
+			ResourceMutateCmd[resourcet.TestResource]{
+				FormatOpts: FormatOpts{Output: Printer{Type: PrinterTypeKeyValue}},
+			},
+			SetArgs{Set: []map[string]string{{"name": "created"}}},
 		}
 		err := cmd.Run(ctx, testStdio(&out), nil)
 		require.Error(t, err)
@@ -1113,15 +1117,17 @@ func TestCreateOutput(t *testing.T) {
 		t.Helper()
 		var out bytes.Buffer
 		cmd := &ResourceCreateCmd[resourcet.TestResource]{
-			SetArgs: SetArgs{
+			ResourceMutateCmd[resourcet.TestResource]{
+				FormatOpts: FormatOpts{
+					Output: printer,
+				},
+			},
+			SetArgs{
 				Set: []map[string]string{
 					{"name": "test-output"},
 					{"settings.foo": "100"},
 					{"settings.bar": "created"},
 				},
-			},
-			FormatOpts: FormatOpts{
-				Output: printer,
 			},
 		}
 		err := cmd.Run(ctx, testStdio(&out), sandbox)
@@ -1144,8 +1150,10 @@ func TestCreateDryRun(t *testing.T) {
 
 	var out bytes.Buffer
 	cmd := &ResourceCreateCmd[resourcet.TestResource]{
-		DryRun: true,
-		SetArgs: SetArgs{
+		ResourceMutateCmd[resourcet.TestResource]{
+			DryRun: true,
+		},
+		SetArgs{
 			Set: []map[string]string{
 				{"name": "test-dry"},
 				{"settings.foo": "100"},
@@ -1208,8 +1216,10 @@ func TestCreateDryRunWithShortcutZeroValues(t *testing.T) {
 
 		var out bytes.Buffer
 		cmd := &ResourceCreateCmd[resourcet.TestResource]{
-			DryRun:  true,
-			SetArgs: setArgs,
+			ResourceMutateCmd[resourcet.TestResource]{
+				DryRun: true,
+			},
+			setArgs,
 		}
 		err := cmd.Run(ctx, testStdio(&out), sandbox)
 		require.NoError(t, err)
@@ -1235,8 +1245,10 @@ func TestCreateDryRunWithShortcutZeroValues(t *testing.T) {
 
 		var out bytes.Buffer
 		cmd := &ResourceCreateCmd[resourcet.TestResource]{
-			DryRun:  true,
-			SetArgs: setArgs,
+			ResourceMutateCmd[resourcet.TestResource]{
+				DryRun: true,
+			},
+			setArgs,
 		}
 		err := cmd.Run(ctx, testStdio(&out), sandbox)
 		require.NoError(t, err)
@@ -1261,8 +1273,10 @@ func TestCreateDryRunWithShortcutZeroValues(t *testing.T) {
 
 		var out bytes.Buffer
 		cmd := &ResourceCreateCmd[resourcet.TestResource]{
-			DryRun:  true,
-			SetArgs: setArgs,
+			ResourceMutateCmd[resourcet.TestResource]{
+				DryRun: true,
+			},
+			setArgs,
 		}
 		err := cmd.Run(ctx, testStdio(&out), sandbox)
 		require.NoError(t, err)
@@ -1283,7 +1297,8 @@ func TestCreatePatchSpecFileArgs(t *testing.T) {
 	setTextFile := tempFile(t, " created\n")
 
 	cmd := &ResourceCreateCmd[resourcet.TestResource]{
-		SetArgs: SetArgs{
+		ResourceMutateCmd[resourcet.TestResource]{},
+		SetArgs{
 			Set: []map[string]string{{"name": "test-inline"}},
 			SetFile: []map[string]string{
 				{"name": nameFile},
@@ -1312,7 +1327,8 @@ func TestCreateSetFile(t *testing.T) {
 
 	var out bytes.Buffer
 	cmd := &ResourceCreateCmd[resourcet.TestResource]{
-		SetArgs: SetArgs{
+		ResourceMutateCmd[resourcet.TestResource]{},
+		SetArgs{
 			SetFile: []map[string]string{
 				{"name": nameFile},
 				{"settings.foo": setFile},
@@ -1400,14 +1416,14 @@ func TestEditOutput(t *testing.T) {
 		t.Helper()
 		var out bytes.Buffer
 		cmd := &ResourceEditCmd[resourcet.TestResource]{
-			ResourceSetCmd: ResourceSetCmd[resourcet.TestResource]{
-				SetArgs: SetArgs{
-					Set: []map[string]string{
-						{"settings.foo": "999"},
-					},
-				},
+			ResourceMutateCmd: ResourceMutateCmd[resourcet.TestResource]{
 				FormatOpts: FormatOpts{
 					Output: printer,
+				},
+			},
+			SetArgs: SetArgs{
+				Set: []map[string]string{
+					{"settings.foo": "999"},
 				},
 			},
 			Target: "test-edit",
@@ -1441,13 +1457,13 @@ func TestEditDryRun(t *testing.T) {
 
 	var out bytes.Buffer
 	cmd := &ResourceEditCmd[resourcet.TestResource]{
-		ResourceSetCmd: ResourceSetCmd[resourcet.TestResource]{
+		ResourceMutateCmd: ResourceMutateCmd[resourcet.TestResource]{
 			DryRun: true,
-			SetArgs: SetArgs{
-				Set: []map[string]string{
-					{"settings.foo": "999"},
-					{"settings.bar": "modified"},
-				},
+		},
+		SetArgs: SetArgs{
+			Set: []map[string]string{
+				{"settings.foo": "999"},
+				{"settings.bar": "modified"},
 			},
 		},
 		Target: "test-edit",
@@ -1487,7 +1503,7 @@ func TestEditCmdNoChangesDryRun(t *testing.T) {
 
 	var out bytes.Buffer
 	cmd := &ResourceEditCmd[resourcet.TestResource]{
-		ResourceSetCmd: ResourceSetCmd[resourcet.TestResource]{
+		ResourceMutateCmd: ResourceMutateCmd[resourcet.TestResource]{
 			Cmd:    "cat", // pass through unchanged
 			DryRun: true,
 		},
@@ -1521,7 +1537,7 @@ func TestEditCmdWithChangesDryRun(t *testing.T) {
 
 	var out bytes.Buffer
 	cmd := &ResourceEditCmd[resourcet.TestResource]{
-		ResourceSetCmd: ResourceSetCmd[resourcet.TestResource]{
+		ResourceMutateCmd: ResourceMutateCmd[resourcet.TestResource]{
 			Cmd:    `sed 's/old-value/new-value/'`, // change settings.bar
 			DryRun: true,
 		},
@@ -1547,23 +1563,22 @@ func TestEditPatchSpecFileArgs(t *testing.T) {
 	delFile := tempFile(t, " old-entry\n")
 
 	cmd := &ResourceEditCmd[resourcet.TestResource]{
-		ResourceSetCmd: ResourceSetCmd[resourcet.TestResource]{
-			SetArgs: SetArgs{
-				Set:     []map[string]string{{"settings.bar": "inline"}},
-				SetFile: []map[string]string{{"settings.foo": setFile}},
-			},
-			AddArgs: AddArgs{
-				Add:     []map[string]string{{"authors": "inline-entry"}},
-				AddFile: []map[string]string{{"authors": addFile}},
-			},
-			DelArgs: DelArgs{
-				Del:     []map[string]string{{"url": "inline-entry"}},
-				DelFile: []map[string]string{{"url": delFile}},
-			},
+		ResourceMutateCmd: ResourceMutateCmd[resourcet.TestResource]{},
+		SetArgs: SetArgs{
+			Set:     []map[string]string{{"settings.bar": "inline"}},
+			SetFile: []map[string]string{{"settings.foo": setFile}},
+		},
+		AddArgs: AddArgs{
+			Add:     []map[string]string{{"authors": "inline-entry"}},
+			AddFile: []map[string]string{{"authors": addFile}},
+		},
+		DelArgs: DelArgs{
+			Del:     []map[string]string{{"url": "inline-entry"}},
+			DelFile: []map[string]string{{"url": delFile}},
 		},
 	}
 
-	spec, err := cmd.toPatchSpec(false)
+	spec, err := cmd.toPatchSpec()
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"inline"}, spec.Set["settings.bar"])

--- a/internal/resource/cmd/cmd_test.go
+++ b/internal/resource/cmd/cmd_test.go
@@ -1400,8 +1400,7 @@ func TestEditOutput(t *testing.T) {
 		t.Helper()
 		var out bytes.Buffer
 		cmd := &ResourceEditCmd[resourcet.TestResource]{
-			ResourceSetCmd[resourcet.TestResource]{
-				Target: "test-edit",
+			ResourceSetCmd: ResourceSetCmd[resourcet.TestResource]{
 				SetArgs: SetArgs{
 					Set: []map[string]string{
 						{"settings.foo": "999"},
@@ -1411,6 +1410,7 @@ func TestEditOutput(t *testing.T) {
 					Output: printer,
 				},
 			},
+			Target: "test-edit",
 		}
 		err := cmd.Run(ctx, testStdio(&out), sandbox)
 		require.NoError(t, err)
@@ -1441,8 +1441,7 @@ func TestEditDryRun(t *testing.T) {
 
 	var out bytes.Buffer
 	cmd := &ResourceEditCmd[resourcet.TestResource]{
-		ResourceSetCmd[resourcet.TestResource]{
-			Target: "test-edit",
+		ResourceSetCmd: ResourceSetCmd[resourcet.TestResource]{
 			DryRun: true,
 			SetArgs: SetArgs{
 				Set: []map[string]string{
@@ -1451,6 +1450,7 @@ func TestEditDryRun(t *testing.T) {
 				},
 			},
 		},
+		Target: "test-edit",
 	}
 	err := cmd.Run(ctx, testStdio(&out), sandbox)
 	require.NoError(t, err)
@@ -1487,11 +1487,11 @@ func TestEditCmdNoChangesDryRun(t *testing.T) {
 
 	var out bytes.Buffer
 	cmd := &ResourceEditCmd[resourcet.TestResource]{
-		ResourceSetCmd[resourcet.TestResource]{
-			Target: "test-edit",
+		ResourceSetCmd: ResourceSetCmd[resourcet.TestResource]{
 			Cmd:    "cat", // pass through unchanged
 			DryRun: true,
 		},
+		Target: "test-edit",
 	}
 	err := cmd.Run(ctx, testStdio(&out), sandbox)
 	require.NoError(t, err)
@@ -1521,11 +1521,11 @@ func TestEditCmdWithChangesDryRun(t *testing.T) {
 
 	var out bytes.Buffer
 	cmd := &ResourceEditCmd[resourcet.TestResource]{
-		ResourceSetCmd[resourcet.TestResource]{
-			Target: "test-edit",
+		ResourceSetCmd: ResourceSetCmd[resourcet.TestResource]{
 			Cmd:    `sed 's/old-value/new-value/'`, // change settings.bar
 			DryRun: true,
 		},
+		Target: "test-edit",
 	}
 	err := cmd.Run(ctx, testStdio(&out), sandbox)
 	require.NoError(t, err)
@@ -1547,7 +1547,7 @@ func TestEditPatchSpecFileArgs(t *testing.T) {
 	delFile := tempFile(t, " old-entry\n")
 
 	cmd := &ResourceEditCmd[resourcet.TestResource]{
-		ResourceSetCmd[resourcet.TestResource]{
+		ResourceSetCmd: ResourceSetCmd[resourcet.TestResource]{
 			SetArgs: SetArgs{
 				Set:     []map[string]string{{"settings.bar": "inline"}},
 				SetFile: []map[string]string{{"settings.foo": setFile}},

--- a/internal/resource/cmd/examples.go
+++ b/internal/resource/cmd/examples.go
@@ -17,6 +17,8 @@ const (
 	CmdTypeCreate CmdType = "create"
 	CmdTypeEdit   CmdType = "edit"
 	CmdTypeDelete CmdType = "delete"
+	CmdTypeAttach CmdType = "attach"
+	CmdTypeDetach CmdType = "detach"
 )
 
 type ExampledResource interface {

--- a/internal/resource/patch/patch.go
+++ b/internal/resource/patch/patch.go
@@ -46,7 +46,7 @@ func (spec *PatchSpec) Keys() iter.Seq[string] {
 // PatchedFields applies the given PatchSpec to the provided fields, returning
 // only the modified fields or an error if the patching process encounters
 // issues.
-func PatchedFields(fields []resource.Field, spec PatchSpec) ([]resource.Field, error) {
+func PatchedFields(fields []resource.Field, spec *PatchSpec) ([]resource.Field, error) {
 	foundFields := make(map[string]struct{})
 	setForbiddenFields := make(map[string]struct{})
 	addForbiddenFields := make(map[string]struct{})

--- a/internal/resource/patch/visual_test.go
+++ b/internal/resource/patch/visual_test.go
@@ -989,7 +989,7 @@ func TestEdit_SimulateActualCommand(t *testing.T) {
 	}
 
 	// Step 3: Apply patches (like patch.PatchedFields)
-	patched, err := PatchedFields(fields, spec)
+	patched, err := PatchedFields(fields, &spec)
 	require.NoError(t, err)
 
 	t.Log("Patched fields (from --set):")

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -52,9 +52,24 @@ type EditableResource interface {
 	Edit(ctx context.Context, key string, fields []Field) error
 }
 
+type SettableResource interface {
+	GettableResource
+	Set(ctx context.Context, key string, fields []Field) error
+}
+
 type CreatableResource interface {
 	GettableResource
 	Create(ctx context.Context, fields []Field) ([]Resource, error)
+}
+
+type AttachableResource interface {
+	GettableResource
+	Attach(ctx context.Context, key string, fields []Field) error
+}
+
+type DetachableResource interface {
+	GettableResource
+	Detach(ctx context.Context, key string, fields []Field) error
 }
 
 type DeletableResource interface {

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -52,7 +52,7 @@ type EditableResource interface {
 	Edit(ctx context.Context, key string, fields []Field) error
 }
 
-type SettableResource interface {
+type MutableResource interface {
 	GettableResource
 	Set(ctx context.Context, key string, fields []Field) error
 }

--- a/internal/resource/sandbox.go
+++ b/internal/resource/sandbox.go
@@ -266,24 +266,24 @@ func (s *Sandbox) WrapListable(r ListableResource) ListableResource {
 	}
 }
 
-func (s *Sandbox) WrapEditable(r EditableResource) SettableResource {
-	return sandboxedSettableResource{
+func (s *Sandbox) WrapEditable(r EditableResource) MutableResource {
+	return sandboxedMutableResource{
 		GettableResource: r,
 		setFn:            r.Edit,
 		sandbox:          s,
 	}
 }
 
-func (s *Sandbox) WrapAttachable(r AttachableResource) SettableResource {
-	return sandboxedSettableResource{
+func (s *Sandbox) WrapAttachable(r AttachableResource) MutableResource {
+	return sandboxedMutableResource{
 		GettableResource: r,
 		setFn:            r.Attach,
 		sandbox:          s,
 	}
 }
 
-func (s *Sandbox) WrapDetachable(r DetachableResource) SettableResource {
-	return sandboxedSettableResource{
+func (s *Sandbox) WrapDetachable(r DetachableResource) MutableResource {
+	return sandboxedMutableResource{
 		GettableResource: r,
 		setFn:            r.Detach,
 		sandbox:          s,
@@ -349,20 +349,20 @@ func (r sanboxedListableResource) List(ctx context.Context) ([]Resource, error) 
 	return resources, opErr
 }
 
-type sandboxedSettableResource struct {
+type sandboxedMutableResource struct {
 	GettableResource
 	setFn   func(ctx context.Context, key string, fields []Field) error
 	sandbox *Sandbox
 }
 
-func (r sandboxedSettableResource) Get(ctx context.Context, keys []string) ([]Resource, error) {
+func (r sandboxedMutableResource) Get(ctx context.Context, keys []string) ([]Resource, error) {
 	return sandboxedGettableResource{
 		GettableResource: r.GettableResource,
 		sandbox:          r.sandbox,
 	}.Get(ctx, keys)
 }
 
-func (r sandboxedSettableResource) Set(ctx context.Context, key string, fields []Field) error {
+func (r sandboxedMutableResource) Set(ctx context.Context, key string, fields []Field) error {
 	if err := r.setFn(ctx, key, fields); err != nil {
 		return err
 	}

--- a/internal/resource/sandbox.go
+++ b/internal/resource/sandbox.go
@@ -266,12 +266,26 @@ func (s *Sandbox) WrapListable(r ListableResource) ListableResource {
 	}
 }
 
-func (s *Sandbox) WrapEditable(r EditableResource) EditableResource {
-	if s == nil {
-		return r
+func (s *Sandbox) WrapEditable(r EditableResource) SettableResource {
+	return sandboxedSettableResource{
+		GettableResource: r,
+		setFn:            r.Edit,
+		sandbox:          s,
 	}
-	return sandboxedEditableResource{
-		EditableResource: r,
+}
+
+func (s *Sandbox) WrapAttachable(r AttachableResource) SettableResource {
+	return sandboxedSettableResource{
+		GettableResource: r,
+		setFn:            r.Attach,
+		sandbox:          s,
+	}
+}
+
+func (s *Sandbox) WrapDetachable(r DetachableResource) SettableResource {
+	return sandboxedSettableResource{
+		GettableResource: r,
+		setFn:            r.Detach,
 		sandbox:          s,
 	}
 }
@@ -306,6 +320,11 @@ func (r sandboxedGettableResource) Get(ctx context.Context, keys []string) ([]Re
 	if opErr != nil && len(resources) == 0 {
 		return nil, opErr
 	}
+
+	if r.sandbox == nil {
+		return resources, nil
+	}
+
 	resources = slices.DeleteFunc(resources, r.sandbox.Missing)
 	if len(resources) == 0 {
 		if opErr != nil {
@@ -330,25 +349,31 @@ func (r sanboxedListableResource) List(ctx context.Context) ([]Resource, error) 
 	return resources, opErr
 }
 
-type sandboxedEditableResource struct {
-	EditableResource
+type sandboxedSettableResource struct {
+	GettableResource
+	setFn   func(ctx context.Context, key string, fields []Field) error
 	sandbox *Sandbox
 }
 
-func (r sandboxedEditableResource) Get(ctx context.Context, keys []string) ([]Resource, error) {
+func (r sandboxedSettableResource) Get(ctx context.Context, keys []string) ([]Resource, error) {
 	return sandboxedGettableResource{
-		GettableResource: r.EditableResource,
+		GettableResource: r.GettableResource,
 		sandbox:          r.sandbox,
 	}.Get(ctx, keys)
 }
 
-func (r sandboxedEditableResource) Edit(ctx context.Context, key string, fields []Field) error {
-	if err := r.EditableResource.Edit(ctx, key, fields); err != nil {
+func (r sandboxedSettableResource) Set(ctx context.Context, key string, fields []Field) error {
+	if err := r.setFn(ctx, key, fields); err != nil {
 		return err
 	}
+
+	if r.sandbox == nil {
+		return nil
+	}
+
 	// re-fetch, since we may have found new strongly linked dependencies (e.g.
 	// by creating a certificate)
-	resources, err := r.EditableResource.Get(ctx, []string{key})
+	resources, err := r.GettableResource.Get(ctx, []string{key})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

  - Adds `unikraft volume attach` and `unikraft volume detach` subcommands for attaching/detaching volumes to/from instances
  - Introduces `ResourceAttachCmd` and `ResourceDetachCmd` as generic command types, sharing logic via the new `ResourceMutateCmd` base (extracted from `ResourceEditCmd`)
  - Adds `AttachableResource` and `DetachableResource` interfaces alongside a unified `MutableResource` interface, replacing the previous `EditableResource`-specific sandbox wrapping

  ## Usage

  ```sh
  # Attach a volume to an instance
  unikraft volume attach demo-volume \
    --to instance-name \
    --at /mnt \
    --readonly

  # Detach a volume from an instance
  unikraft volume detach demo-volume \
    --from instance-name
```

<img height="500" alt="demo" src="https://github.com/user-attachments/assets/4620d976-cc33-48ff-bd47-e74eabe51353" />