### PR TITLE
refactor(integration): Build shared images only once

### DIFF
--- a/cmd/unikraft/integration/build_test.go
+++ b/cmd/unikraft/integration/build_test.go
@@ -7,7 +7,6 @@ package integration
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/containerd/continuity/fs/fstest"
@@ -25,39 +24,27 @@ func TestBuild(t *testing.T) {
 	for _, romFormat := range []string{"erofs", "cpio"} {
 		t.Run("rom-"+romFormat, func(t *testing.T) {
 			r := runner(t, true, []string{staging, stable})
+			image := integ.Busybox.Build(t, r)
 			romImagePrefix := r.Config.Profile.Organization + "/rom-" + romFormat + "-e2e"
-			baseImagePrefix := r.Config.Profile.Organization + "/busybox-rom-" + romFormat + "-e2e"
-
-			// Only erofs ROMs support kernel automounting via at=.
-			// For CPIO, we extract manually from the block device.
-			entryCmd := []string{"sh", "-c", "cd /tmp && cpio -id < /dev/ukp_rom_myrom && cat hello.txt"}
-			if romFormat == "erofs" {
-				entryCmd = []string{"cat", "/rom/hello.txt"}
-			}
 
 			imageTag := uniq()
 			instName := uniq()
 			romImage := romImagePrefix + ":" + imageTag
-			baseImage := baseImagePrefix + ":" + imageTag
+
+			// Only erofs ROMs support kernel automounting via at=.
+			// For CPIO, we extract manually from the block device.
 			romFlag := "image=" + romImage + ",name=myrom"
+			var args string
 			if romFormat == "erofs" {
 				romFlag += ",at=/rom"
+				args = "cat /rom/hello.txt"
+			} else {
+				args = "sh -c 'cd /tmp && cpio -id < /dev/ukp_rom_myrom && cat hello.txt'"
 			}
 
+			// ROM-only image context: just a directory with a text file.
 			dir := t.TempDir()
 			require.NoError(t, fstest.Apply(
-				fstest.CreateDir("base", 0o755),
-				fstest.CreateFile("base/Dockerfile", []byte(`FROM busybox:latest`), 0o644),
-				fstest.CreateFile("base/Kraftfile", fmt.Appendf(nil, `
-spec: v0.7
-name: busybox-rom-%s-e2e
-runtime: base-compat:latest
-rootfs:
-  format: erofs
-  source: ./Dockerfile
-cmd: ["%s"]
-`, romFormat, strings.Join(entryCmd, `", "`)), 0o644),
-				// ROM-only image context: just a directory with a text file.
 				fstest.CreateDir("rom", 0o755),
 				fstest.CreateDir("rom/myrom", 0o755),
 				fstest.CreateFile("rom/myrom/hello.txt", []byte("Hello from ROM!\n"), 0o644),
@@ -70,9 +57,8 @@ roms:
 `, romFormat, romFormat), 0o644),
 			).Apply(dir))
 
-			r.Run(t, []string{"unikraft", "build", "base", "--output", baseImage}, integ.WithWorkDir(dir))
 			r.Run(t, []string{"unikraft", "build", "rom", "--arch", "x86_64", "--output", romImage}, integ.WithWorkDir(dir))
-			r.Run(t, []string{"unikraft", "run", "--name", "test-" + instName, "--metro", r.Config.MetroName, "--output", "quiet", "--image", baseImage, "--rom", romFlag})
+			r.Run(t, []string{"unikraft", "run", "--name", "test-" + instName, "--metro", r.Config.MetroName, "--output", "quiet", "--image", image, "--rom", romFlag, "--args", args})
 			r.Run(t, []string{"unikraft", "--timeout", "10s", "instance", "wait", "--until", "state==stopped", "test-" + instName})
 
 			out := r.Run(t, []string{"unikraft", "instance", "logs", "test-" + instName})
@@ -84,31 +70,17 @@ roms:
 
 	t.Run("rom-dir", func(t *testing.T) {
 		r := runner(t, true, []string{staging, stable})
-		baseImagePrefix := r.Config.Profile.Organization + "/busybox-romdir-e2e"
+		image := integ.Busybox.Build(t, r)
 
-		imageTag := uniq()
 		instName := uniq()
-		baseImage := baseImagePrefix + ":" + imageTag
 
 		dir := t.TempDir()
 		require.NoError(t, fstest.Apply(
-			fstest.CreateDir("base", 0o755),
-			fstest.CreateFile("base/Dockerfile", []byte(`FROM busybox:latest`), 0o644),
-			fstest.CreateFile("base/Kraftfile", []byte(`
-spec: v0.7
-name: busybox-romdir-e2e
-runtime: base-compat:latest
-rootfs:
-  format: erofs
-  source: ./Dockerfile
-cmd: ["cat", "/rom/hello.txt"]
-`), 0o644),
 			fstest.CreateDir("romdata", 0o755),
 			fstest.CreateFile("romdata/hello.txt", []byte("Hello from ROM!\n"), 0o644),
 		).Apply(dir))
 
-		r.Run(t, []string{"unikraft", "build", "base", "--output", baseImage}, integ.WithWorkDir(dir))
-		r.Run(t, []string{"unikraft", "run", "--name", "test-" + instName, "--metro", r.Config.MetroName, "--output", "quiet", "--image", baseImage, "--rom", "dir=romdata,at=/rom"}, integ.WithWorkDir(dir))
+		r.Run(t, []string{"unikraft", "run", "--name", "test-" + instName, "--metro", r.Config.MetroName, "--output", "quiet", "--image", image, "--rom", "dir=romdata,at=/rom", "--args", "cat /rom/hello.txt"}, integ.WithWorkDir(dir))
 		r.Run(t, []string{"unikraft", "--timeout", "10s", "instance", "wait", "--until", "state==stopped", "test-" + instName})
 
 		out := r.Run(t, []string{"unikraft", "instance", "logs", "test-" + instName})
@@ -194,44 +166,18 @@ cmd: ["sh", "/entrypoint.sh"]
 		}
 	})
 
-	t.Run("busybox-custom-dockerfile", func(t *testing.T) {
+	t.Run("shared-run", func(t *testing.T) {
 		r := runner(t, true, []string{staging, stable})
-		imagePrefix := r.Config.Profile.Organization + "/busybox-custom-df-e2e"
-		imageTag := uniq()
+		image := integ.Busybox.Build(t, r)
+
 		instName := uniq()
-		image := imagePrefix + ":" + imageTag
 
-		dir := t.TempDir()
-		require.NoError(t, fstest.Apply(
-			fstest.CreateFile("App.dockerfile", []byte(`
-FROM busybox:latest
-COPY <<EOF /entrypoint.sh
-#!/bin/sh
-echo UNIKRAFT_E2E_OK
-EOF
-RUN chmod +x /entrypoint.sh
-`), 0o644),
-			fstest.CreateFile("Kraftfile", []byte(`
-spec: v0.7
-name: busybox-custom-df-e2e
-runtime: base-compat:latest
-rootfs:
-  format: erofs
-  source:
-    path: .
-    dockerfile: App.dockerfile
-cmd: ["sh", "/entrypoint.sh"]
-`), 0o644),
-		).Apply(dir))
-
-		r.Run(t, []string{"unikraft", "build", ".", "--output", image}, integ.WithWorkDir(dir))
-		r.Run(t, []string{"unikraft", "run", "--name", "test-" + instName, "--metro", r.Config.MetroName, "--output", "quiet", "--image", image})
-		r.Run(t, []string{"unikraft", "instance", "wait", "--until", "state==stopped", "--timeout", "10s", "test-" + instName})
+		r.Run(t, []string{"unikraft", "run", "--name", "test-" + instName, "--metro", r.Config.MetroName, "--output", "quiet", "--image", image, "--args", "echo UNIKRAFT_E2E_OK"})
+		r.Run(t, []string{"unikraft", "--timeout", "10s", "instance", "wait", "--until", "state==stopped", "test-" + instName})
 
 		out := r.Run(t, []string{"unikraft", "instance", "logs", "test-" + instName})
 		assert.Regexp(t, `UNIKRAFT_E2E_OK`, out)
 
 		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName})
-		r.Run(t, []string{"unikraft", "image", "delete", image})
 	})
 }

--- a/cmd/unikraft/integration/helpers_test.go
+++ b/cmd/unikraft/integration/helpers_test.go
@@ -26,6 +26,12 @@ import (
 	"unikraft.com/cli/internal/resource"
 )
 
+func TestMain(m *testing.M) {
+	code := m.Run()
+	integ.CleanupSharedImages()
+	os.Exit(code)
+}
+
 var (
 	uniqSeed    string
 	uniqCounter atomic.Uint64

--- a/cmd/unikraft/integration/instance_checkpoint_test.go
+++ b/cmd/unikraft/integration/instance_checkpoint_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	integ "unikraft.com/cli/internal/integration"
 )
@@ -343,13 +342,7 @@ func TestInstanceCheckpoints(t *testing.T) {
 		restoredName := uniq()
 		domainName := uniq()
 		domainRestored := uniq()
-		imageTag := uniq()
-		image := r.Config.Profile.Organization + "/counter-e2e:" + imageTag
-
-		dir := t.TempDir()
-		require.NoError(t, applyCounterContext(dir))
-
-		r.Run(t, []string{"unikraft", "build", ".", "--output", image}, integ.WithWorkDir(dir))
+		image := sharedCounter.Build(t, r)
 
 		r.Run(t, []string{
 			"unikraft", "instance", "create",
@@ -425,6 +418,5 @@ func TestInstanceCheckpoints(t *testing.T) {
 
 		r.Run(t, []string{"unikraft", "instance", "checkpoint", "delete", checkpointName})
 		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName, "test-restored-" + restoredName})
-		r.Run(t, []string{"unikraft", "image", "delete", image})
 	})
 }

--- a/cmd/unikraft/integration/instance_test.go
+++ b/cmd/unikraft/integration/instance_test.go
@@ -27,7 +27,27 @@ import (
 )
 
 //go:embed testdata/counter_server.py
-var counterServerPy []byte
+var counterServerPy string
+
+// sharedCounter serves a counter over HTTP. GET /count reads the count and
+// POST /increment changes it; COUNTER_FILE selects the file that holds it.
+var sharedCounter = &integ.SharedImage{
+	Image: integ.Image{
+		Name: "counter-e2e",
+		Files: map[string]string{
+			"Dockerfile": "FROM python:3.12-slim\nCOPY server.py /app/server.py\n",
+			"server.py":  counterServerPy,
+			"Kraftfile": `spec: v0.7
+name: counter-e2e
+runtime: base-compat:latest
+rootfs:
+  format: erofs
+  source: ./Dockerfile
+cmd: ["python3", "/app/server.py"]
+`,
+		},
+	},
+}
 
 // followArgs counts the boots in /data/n, prints the count, then waits. The
 // instance stays running while the test reads the output of the boot.
@@ -1336,13 +1356,7 @@ cmd: ["cat", "/marker.txt"]
 		branchName := uniq()
 		domainName := uniq()
 		domainBranch := uniq()
-		imageTag := uniq()
-		image := r.Config.Profile.Organization + "/counter-e2e:" + imageTag
-
-		dir := t.TempDir()
-		require.NoError(t, applyCounterContext(dir))
-
-		r.Run(t, []string{"unikraft", "build", ".", "--output", image}, integ.WithWorkDir(dir))
+		image := sharedCounter.Build(t, r)
 
 		r.Run(t, []string{
 			"unikraft", "instance", "create",
@@ -1382,7 +1396,6 @@ cmd: ["cat", "/marker.txt"]
 		assert.Contains(t, integ.HTTPGet(t, "https://"+fqdnBranch+"/count"), `"count": 0`)
 
 		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName, "test-branch-" + branchName})
-		r.Run(t, []string{"unikraft", "image", "delete", image})
 	})
 
 	// branch-state verifies that --branch preserves current in-memory state and
@@ -1395,13 +1408,7 @@ cmd: ["cat", "/marker.txt"]
 		branchName := uniq()
 		domainName := uniq()
 		domainBranch := uniq()
-		imageTag := uniq()
-		image := r.Config.Profile.Organization + "/counter-e2e:" + imageTag
-
-		dir := t.TempDir()
-		require.NoError(t, applyCounterContext(dir))
-
-		r.Run(t, []string{"unikraft", "build", ".", "--output", image}, integ.WithWorkDir(dir))
+		image := sharedCounter.Build(t, r)
 
 		r.Run(t, []string{
 			"unikraft", "instance", "create",
@@ -1462,7 +1469,6 @@ cmd: ["cat", "/marker.txt"]
 		assert.Contains(t, integ.HTTPGet(t, "https://"+fqdnBranch+"/count"), `"count": 15`)
 
 		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName, "test-branch-" + branchName})
-		r.Run(t, []string{"unikraft", "image", "delete", image})
 	})
 
 	// stop-disk-reset verifies a plain stop/start also resets the root disk (by design, not just a --branch gap).
@@ -1470,13 +1476,7 @@ cmd: ["cat", "/marker.txt"]
 		r := runner(t, true, []string{staging, stable})
 		instName := uniq()
 		domainName := uniq()
-		imageTag := uniq()
-		image := r.Config.Profile.Organization + "/counter-e2e:" + imageTag
-
-		dir := t.TempDir()
-		require.NoError(t, applyCounterContext(dir))
-
-		r.Run(t, []string{"unikraft", "build", ".", "--output", image}, integ.WithWorkDir(dir))
+		image := sharedCounter.Build(t, r)
 
 		r.Run(t, []string{
 			"unikraft", "instance", "create",
@@ -1511,7 +1511,6 @@ cmd: ["cat", "/marker.txt"]
 		assert.Contains(t, integ.HTTPGet(t, "https://"+fqdn+"/count"), `"count": 0`)
 
 		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName})
-		r.Run(t, []string{"unikraft", "image", "delete", image})
 	})
 
 	// branch-stopped verifies --branch works when the source is stopped. The
@@ -1525,13 +1524,7 @@ cmd: ["cat", "/marker.txt"]
 		volName := uniq()
 		domainName := uniq()
 		domainBranch := uniq()
-		imageTag := uniq()
-		image := r.Config.Profile.Organization + "/counter-e2e:" + imageTag
-
-		dir := t.TempDir()
-		require.NoError(t, applyCounterContext(dir))
-
-		r.Run(t, []string{"unikraft", "build", ".", "--output", image}, integ.WithWorkDir(dir))
+		image := sharedCounter.Build(t, r)
 
 		r.Run(t, []string{
 			"unikraft", "volume", "create",
@@ -1607,7 +1600,6 @@ cmd: ["cat", "/marker.txt"]
 		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName, "test-branch-" + branchName})
 		r.Run(t, []string{"unikraft", "--timeout", "30s", "volume", "wait", "--until", "state==available", "test-" + volName})
 		r.Run(t, []string{"unikraft", "volume", "delete", "test-" + volName})
-		r.Run(t, []string{"unikraft", "image", "delete", image})
 	})
 
 	// branch-template verifies --branch works when the source is a template.
@@ -1619,13 +1611,7 @@ cmd: ["cat", "/marker.txt"]
 		branchName := uniq()
 		domainName := uniq()
 		domainBranch := uniq()
-		imageTag := uniq()
-		image := r.Config.Profile.Organization + "/counter-e2e:" + imageTag
-
-		dir := t.TempDir()
-		require.NoError(t, applyCounterContext(dir))
-
-		r.Run(t, []string{"unikraft", "build", ".", "--output", image}, integ.WithWorkDir(dir))
+		image := sharedCounter.Build(t, r)
 
 		r.Run(t, []string{
 			"unikraft", "instance", "create",
@@ -1682,28 +1668,5 @@ cmd: ["cat", "/marker.txt"]
 
 		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName, "test-branch-" + branchName})
 		r.Run(t, []string{"unikraft", "instance", "template", "delete", templateName})
-		r.Run(t, []string{"unikraft", "image", "delete", image})
 	})
-}
-
-// applyCounterContext writes the build context for a minimal Python HTTP counter
-// server into dir. The server maintains an in-memory counter that can be read
-// via GET /count and incremented via POST /increment with a JSON body.
-func applyCounterContext(dir string) error {
-	return fstest.Apply(
-		fstest.CreateFile("Dockerfile", []byte(`
-FROM python:3.12-slim
-COPY server.py /app/server.py
-`), 0o644),
-		fstest.CreateFile("server.py", counterServerPy, 0o644),
-		fstest.CreateFile("Kraftfile", []byte(`
-spec: v0.7
-name: counter-e2e
-runtime: base-compat:latest
-rootfs:
-  format: erofs
-  source: ./Dockerfile
-cmd: ["python3", "/app/server.py"]
-`), 0o644),
-	).Apply(dir)
 }

--- a/cmd/unikraft/integration/instance_test.go
+++ b/cmd/unikraft/integration/instance_test.go
@@ -29,6 +29,10 @@ import (
 //go:embed testdata/counter_server.py
 var counterServerPy []byte
 
+// followArgs counts the boots in /data/n, prints the count, then waits. The
+// instance stays running while the test reads the output of the boot.
+const followArgs = `runtime.args=["sh","-c","n=$(cat /data/n 2>/dev/null || echo 0); n=$((n+1)); echo $n > /data/n; echo starting $n; sleep 30s"]`
+
 // tunnelProxyUUIDs queries the platform directly (bypassing the CLI's
 // resource sandbox, which never tracks the tunnel command's internal proxy
 // instance since it's created via the raw platform client rather than
@@ -191,33 +195,18 @@ func TestInstances(t *testing.T) {
 	t.Run("annotations-guest", func(t *testing.T) {
 		r := runner(t, true, []string{staging, stable})
 		instName := uniq()
-		image := r.Config.Profile.Organization + "/startdata-e2e:" + uniq()
+		image := integ.Busybox.Build(t, r)
 
-		dir := t.TempDir()
-		require.NoError(t, fstest.Apply(
-			fstest.CreateDir("base", 0o755),
-			fstest.CreateFile("base/Dockerfile", []byte(`FROM busybox:latest`), 0o644),
-			fstest.CreateFile("base/Kraftfile", []byte(`
-spec: v0.7
-name: startdata-e2e
-runtime: base-compat:latest
-rootfs:
-  format: erofs
-  source: ./Dockerfile
-cmd: ["cat", "/sys/class/uio/uio0/device/startdata"]
-`), 0o644),
-		).Apply(dir))
-
-		r.Run(t, []string{"unikraft", "build", "base", "--output", image}, integ.WithWorkDir(dir))
 		r.Run(t, []string{
 			"unikraft", "run",
 			"--name", "test-" + instName,
 			"--metro", r.Config.MetroName,
 			"--output", "quiet",
 			"--image", image,
+			"--args", "cat /sys/class/uio/uio0/device/startdata",
 			"--annotation", "my-key=value1",
 			"--annotation", "example.com/annotation2=value2",
-		}, integ.WithWorkDir(dir))
+		})
 		r.Run(t, []string{"unikraft", "--timeout", "30s", "instance", "wait", "--until", "state==stopped", "test-" + instName})
 
 		out := r.Run(t, []string{"unikraft", "instance", "logs", "test-" + instName})
@@ -365,31 +354,7 @@ cmd: ["cat", "/sys/class/uio/uio0/device/startdata"]
 		r := runner(t, true, []string{staging, stable})
 		instName := uniq()
 		volName := uniq()
-		imageTag := uniq()
-
-		baseImagePrefix := r.Config.Profile.Organization + "/busybox-start-follow-e2e"
-		baseImage := baseImagePrefix + ":" + imageTag
-
-		dir := t.TempDir()
-		require.NoError(t, fstest.Apply(
-			fstest.CreateDir("base", 0o755),
-			fstest.CreateFile("base/Dockerfile", []byte(`
-FROM busybox:latest
-
-RUN echo 'n=$(cat /data/n 2>/dev/null || echo 0); n=$((n+1)); echo $n > /data/n; echo starting $n; sleep 30s' > /start.sh
-RUN chmod +x /start.sh
-`), 0o644),
-			fstest.CreateFile("base/Kraftfile", []byte(`
-spec: v0.7
-name: busybox-start-follow-e2e
-runtime: base-compat:latest
-rootfs:
-  format: erofs
-  source: ./Dockerfile
-`), 0o644),
-		).Apply(dir))
-
-		r.Run(t, []string{"unikraft", "build", "base", "--output", baseImage}, integ.WithWorkDir(dir))
+		baseImage := integ.Busybox.Build(t, r)
 
 		// Volume provides persistent counter across boots.
 		r.Run(t, []string{
@@ -411,7 +376,7 @@ rootfs:
 			"--set", "resources.memory=128",
 			"--set", "resources.vcpus=1",
 			"--set", "volumes=test-" + volName + ":/data",
-			"--set", `runtime.args=["sh","-c","/start.sh"]`,
+			"--set", followArgs,
 		})
 
 		// First boot ("starting 1"): start, wait running, then stop.
@@ -439,31 +404,7 @@ rootfs:
 		r := runner(t, true, []string{staging, stable})
 		instName := uniq()
 		volName := uniq()
-		imageTag := uniq()
-
-		baseImagePrefix := r.Config.Profile.Organization + "/busybox-restart-follow-e2e"
-		baseImage := baseImagePrefix + ":" + imageTag
-
-		dir := t.TempDir()
-		require.NoError(t, fstest.Apply(
-			fstest.CreateDir("base", 0o755),
-			fstest.CreateFile("base/Dockerfile", []byte(`
-FROM busybox:latest
-
-RUN echo 'n=$(cat /data/n 2>/dev/null || echo 0); n=$((n+1)); echo $n > /data/n; echo starting $n; sleep 30s' > /start.sh
-RUN chmod +x /start.sh
-`), 0o644),
-			fstest.CreateFile("base/Kraftfile", []byte(`
-spec: v0.7
-name: busybox-restart-follow-e2e
-runtime: base-compat:latest
-rootfs:
-  format: erofs
-  source: ./Dockerfile
-`), 0o644),
-		).Apply(dir))
-
-		r.Run(t, []string{"unikraft", "build", "base", "--output", baseImage}, integ.WithWorkDir(dir))
+		baseImage := integ.Busybox.Build(t, r)
 
 		// Volume provides persistent counter across boots.
 		r.Run(t, []string{
@@ -485,7 +426,7 @@ rootfs:
 			"--set", "resources.memory=128",
 			"--set", "resources.vcpus=1",
 			"--set", "volumes=test-" + volName + ":/data",
-			"--set", `runtime.args=["sh","-c","/start.sh"]`,
+			"--set", followArgs,
 		})
 		r.Run(t, []string{"unikraft", "instance", "wait", "--until", "state==running", "--timeout", "30s", "test-" + instName})
 

--- a/internal/integration/env.go
+++ b/internal/integration/env.go
@@ -61,6 +61,7 @@ type cmdConfig struct {
 	workDir       string
 	expectFail    bool
 	allowFail     bool
+	noSandbox     bool
 	timeout       time.Duration
 	withoutCancel bool
 }
@@ -86,6 +87,12 @@ func WithoutCancel() CmdOption {
 // Use for commands that run indefinitely (e.g. --follow).
 func WithTimeout(d time.Duration) CmdOption {
 	return func(c *cmdConfig) { c.timeout = d }
+}
+
+// WithNoSandbox disables sandbox tracking for the command. The resource is not
+// registered in a test sandbox and stays after individual test cleanup.
+func WithNoSandbox() CmdOption {
+	return func(c *cmdConfig) { c.noSandbox = true }
 }
 
 func (env *TestEnv) RunRaw(t *testing.T, args []string, opts ...CmdOption) (string, error) {
@@ -125,7 +132,9 @@ func (env *TestEnv) RunRaw(t *testing.T, args []string, opts ...CmdOption) (stri
 	c.Env = append(c.Env, "NO_COLOR=1")
 	c.Env = append(c.Env, "UNIKRAFT_CONFIG="+env.configPath)
 	c.Env = append(c.Env, "BUILDKIT_PROGRESS=quiet")
-	c.Env = append(c.Env, resource.UnikraftSandboxEnv+"="+env.sandboxPath)
+	if !cfg.noSandbox {
+		c.Env = append(c.Env, resource.UnikraftSandboxEnv+"="+env.sandboxPath)
+	}
 
 	err := c.Run()
 	return ansi.Strip(output.String()), err

--- a/internal/integration/image.go
+++ b/internal/integration/image.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package integration
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	imagespec "unikraft.com/x/image-spec"
+
+	"unikraft.com/cli/internal/config"
+	"unikraft.com/cli/internal/images"
+)
+
+// Busybox is a busybox rootfs with no application. Tests give their own
+// command with --args or runtime.args, which replaces the cmd of the image.
+var Busybox = &SharedImage{
+	Image: Image{
+		Name: "busybox-e2e",
+		Files: map[string]string{
+			"Dockerfile": "FROM busybox:latest",
+			"Kraftfile": `spec: v0.7
+name: busybox-e2e
+runtime: base-compat:latest
+rootfs:
+  format: erofs
+  source: ./Dockerfile
+cmd: ["sh", "-c"]
+`,
+		},
+	},
+}
+
+// Image is a build context that a test builds into the registry.
+type Image struct {
+	// Name is the image name, without the organization and the tag.
+	Name string
+	// Each key is a file name in the context root.
+	Files map[string]string
+}
+
+// Ref gives the full reference of the image for tag.
+func (i *Image) Ref(env *TestEnv, tag string) string {
+	return env.Config.Profile.Organization + "/" + i.Name + ":" + tag
+}
+
+// Build writes the files to a temporary context and builds the image at ref.
+// The sandbox of the test deletes the image, unless opts give WithNoSandbox.
+func (i *Image) Build(t *testing.T, env *TestEnv, ref string, opts ...CmdOption) error {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "unikraft-test-image-*")
+	if err != nil {
+		return fmt.Errorf("creating build context of %s: %w", ref, err)
+	}
+	defer os.RemoveAll(dir)
+
+	for name, content := range i.Files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return fmt.Errorf("populating build context of %s: %w", ref, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			return fmt.Errorf("populating build context of %s: %w", ref, err)
+		}
+	}
+
+	opts = append([]CmdOption{WithWorkDir(dir)}, opts...)
+	if out, err := env.RunRaw(t, []string{"unikraft", "build", ".", "--output", ref}, opts...); err != nil {
+		return fmt.Errorf("building image %s: %w\n%s", ref, err, out)
+	}
+
+	return nil
+}
+
+// SharedImage is an image that tests use. Build makes the image one time,
+// and CleanupSharedImages deletes it when the test binary ends.
+type SharedImage struct {
+	Image
+
+	once sync.Once
+	ref  string
+	err  error
+}
+
+var (
+	sharedImageTag    = randomImageTag()
+	sharedImageMu     sync.Mutex
+	sharedImageRefs   []string
+	sharedImageConfig *config.Config
+)
+
+func randomImageTag() string {
+	var b [6]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		panic(err)
+	}
+	return "shared-" + hex.EncodeToString(b[:])
+}
+
+// Build makes the image one time and gives the full reference. Later calls
+// give the reference of the first build.
+func (s *SharedImage) Build(t *testing.T, env *TestEnv) string {
+	t.Helper()
+	require.NotNil(t, env.Config, "shared image build requires a config")
+	s.once.Do(func() {
+		s.ref, s.err = s.build(t, env)
+	})
+	require.NoError(t, s.err)
+	return s.ref
+}
+
+// build makes the image out of the sandbox of the test, so that the cleanup of
+// one test does not delete an image that other tests still use.
+func (s *SharedImage) build(t *testing.T, env *TestEnv) (string, error) {
+	t.Helper()
+	ref := s.Ref(env, sharedImageTag)
+	if err := s.Image.Build(t, env, ref, WithNoSandbox(), WithoutCancel()); err != nil {
+		return "", err
+	}
+	registerSharedImage(env, ref)
+	return ref, nil
+}
+
+// registerSharedImage records ref for deletion after the tests end.
+func registerSharedImage(env *TestEnv, ref string) {
+	sharedImageMu.Lock()
+	defer sharedImageMu.Unlock()
+
+	if sharedImageConfig == nil {
+		sharedImageConfig = env.Config.Config
+	}
+	sharedImageRefs = append(sharedImageRefs, ref)
+}
+
+// CleanupSharedImages deletes every shared image from the registry.
+func CleanupSharedImages() {
+	sharedImageMu.Lock()
+	cfg := sharedImageConfig
+	refs := slices.Clone(sharedImageRefs)
+	sharedImageRefs = nil
+	sharedImageMu.Unlock()
+
+	if cfg == nil || len(refs) == 0 {
+		return
+	}
+
+	ctx := config.WithConfig(context.Background(), cfg)
+	access, err := images.Accessor(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to cleanup shared images: %v\n", err)
+		return
+	}
+
+	for _, ref := range refs {
+		uri, err := imagespec.GuessURI(ref)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to parse shared image %s: %v\n", ref, err)
+			continue
+		}
+		if err := access.Delete(ctx, uri); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to delete shared image %s: %v\n", ref, err)
+		}
+	}
+}


### PR DESCRIPTION
Like this we build the instance only once instead of multiple times cutting down significantly on builds.

Three commits:
1. Add the shared mechanism and use it for busybox images
2. Use the shared image also for images that change only the command
3. Use another shared image for some python tests