### PR TITLE
feat: Add autokill

### DIFF
--- a/cmd/unikraft/integration/instance_test.go
+++ b/cmd/unikraft/integration/instance_test.go
@@ -1842,4 +1842,38 @@ cmd: ["cat", "/marker.txt"]
 		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName, "test-branch-" + branchName})
 		r.Run(t, []string{"unikraft", "instance", "template", "delete", templateName})
 	})
+
+	t.Run("autokill", func(t *testing.T) {
+		r := runner(t, true, []string{staging, stable})
+		instName := uniq()
+
+		r.Run(t, []string{
+			"unikraft", "instance", "create",
+			"--output", "quiet",
+			"--set", "name=test-" + instName,
+			"--set", "metro=" + r.Config.MetroName,
+			"--set", "image=nginx:latest",
+			"--set", "autostart=false",
+			"--set", "resources.memory=128",
+			"--set", "resources.vcpus=1",
+			"--autokill", "time=5s",
+		})
+
+		out := r.Run(t, []string{"unikraft", "instance", "inspect", "test-" + instName})
+		assert.Regexp(t, `autokill:`, out)
+		assert.Regexp(t, `time:\s+5s`, out)
+
+		r.Run(t, []string{
+			"unikraft", "instance", "edit", "test-" + instName,
+			"--output", "quiet",
+			"--autokill", `time=10s,num-requests=100`,
+		})
+
+		out = r.Run(t, []string{"unikraft", "instance", "inspect", "test-" + instName})
+		assert.Regexp(t, `autokill:`, out)
+		assert.Regexp(t, `time:\s+10s`, out)
+		assert.Regexp(t, `num-requests:\s+100`, out)
+
+		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName})
+	})
 }

--- a/cmd/unikraft/testdata/TestHelp/instances
+++ b/cmd/unikraft/testdata/TestHelp/instances
@@ -76,6 +76,7 @@ Fields:
   timestamps, timestamps.created, timestamps.started, timestamps.stopped
   scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
   zero.stateful, scale-to-zero.cooldown-time, scale-to-zero.notify-time
+  autokill, autokill.time, autokill.num-requests
   timing, timing.uptime, timing.boot-time, timing.net-time
   restart, restart.policy, restart.start-count, restart.restart-count
   sched-priority
@@ -148,6 +149,7 @@ Fields:
   timestamps, timestamps.created, timestamps.started, timestamps.stopped
   scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
   zero.stateful, scale-to-zero.cooldown-time, scale-to-zero.notify-time
+  autokill, autokill.time, autokill.num-requests
   timing, timing.uptime, timing.boot-time, timing.net-time
   restart, restart.policy, restart.start-count, restart.restart-count
   sched-priority
@@ -228,6 +230,7 @@ Fields:
   timestamps, timestamps.created, timestamps.started, timestamps.stopped
   scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
   zero.stateful, scale-to-zero.cooldown-time, scale-to-zero.notify-time
+  autokill, autokill.time, autokill.num-requests
   timing, timing.uptime, timing.boot-time, timing.net-time
   restart, restart.policy, restart.start-count, restart.restart-count
   sched-priority
@@ -310,6 +313,7 @@ Fields:
   timestamps, timestamps.created, timestamps.started, timestamps.stopped
   scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
   zero.stateful, scale-to-zero.cooldown-time, scale-to-zero.notify-time
+  autokill, autokill.time, autokill.num-requests
   timing, timing.uptime, timing.boot-time, timing.net-time
   restart, restart.policy, restart.start-count, restart.restart-count
   sched-priority
@@ -416,6 +420,7 @@ Fields:
   timestamps, timestamps.created, timestamps.started, timestamps.stopped
   scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
   zero.stateful, scale-to-zero.cooldown-time, scale-to-zero.notify-time
+  autokill, autokill.time, autokill.num-requests
   timing, timing.uptime, timing.boot-time, timing.net-time
   restart, restart.policy, restart.start-count, restart.restart-count
   sched-priority
@@ -523,6 +528,11 @@ Create flags:
             notify-time: notification time in ms before scaling to zero
             stateful: true | false.
           [examples: on, policy=on,cooldown-time=300, policy=on,stateful=true,cooldown-time=500,notify-time=100]
+      --autokill=<key>=<value>
+          Autokill options.
+            time: time after the instance stops before it is deleted
+            num-requests: max requests before the instance is deleted.
+          [examples: time=5s, num-requests=100, time=5s,num-requests=100]
       --restart=<policy>
           Restart policy.
           [examples: always, on-failure, never]
@@ -607,6 +617,7 @@ Fields:
   timestamps, timestamps.created, timestamps.started, timestamps.stopped
   scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
   zero.stateful, scale-to-zero.cooldown-time, scale-to-zero.notify-time
+  autokill, autokill.time, autokill.num-requests
   timing, timing.uptime, timing.boot-time, timing.net-time
   restart, restart.policy, restart.start-count, restart.restart-count
   sched-priority
@@ -714,6 +725,11 @@ Create flags:
             notify-time: notification time in ms before scaling to zero
             stateful: true | false.
           [examples: on, policy=on,cooldown-time=300, policy=on,stateful=true,cooldown-time=500,notify-time=100]
+      --autokill=<key>=<value>
+          Autokill options.
+            time: time after the instance stops before it is deleted
+            num-requests: max requests before the instance is deleted.
+          [examples: time=5s, num-requests=100, time=5s,num-requests=100]
       --restart=<policy>
           Restart policy.
           [examples: always, on-failure, never]
@@ -807,6 +823,7 @@ Fields:
   timestamps, timestamps.created, timestamps.started, timestamps.stopped
   scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
   zero.stateful, scale-to-zero.cooldown-time, scale-to-zero.notify-time
+  autokill, autokill.time, autokill.num-requests
   timing, timing.uptime, timing.boot-time, timing.net-time
   restart, restart.policy, restart.start-count, restart.restart-count
   sched-priority
@@ -916,6 +933,11 @@ Create flags:
             notify-time: notification time in ms before scaling to zero
             stateful: true | false.
           [examples: on, policy=on,cooldown-time=300, policy=on,stateful=true,cooldown-time=500,notify-time=100]
+      --autokill=<key>=<value>
+          Autokill options.
+            time: time after the instance stops before it is deleted
+            num-requests: max requests before the instance is deleted.
+          [examples: time=5s, num-requests=100, time=5s,num-requests=100]
       --restart=<policy>
           Restart policy.
           [examples: always, on-failure, never]
@@ -995,6 +1017,7 @@ Fields:
   timestamps, timestamps.created, timestamps.started, timestamps.stopped
   scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
   zero.stateful, scale-to-zero.cooldown-time, scale-to-zero.notify-time
+  autokill, autokill.time, autokill.num-requests
   timing, timing.uptime, timing.boot-time, timing.net-time
   restart, restart.policy, restart.start-count, restart.restart-count
   sched-priority
@@ -1081,6 +1104,11 @@ Edit flags:
             notify-time: notification time in ms before scaling to zero
             stateful: true | false.
           [examples: on, policy=on,cooldown-time=300, policy=on,stateful=true,cooldown-time=500,notify-time=100]
+      --autokill=<key>=<value>
+          Autokill options.
+            time: time after the instance stops before it is deleted
+            num-requests: max requests before the instance is deleted.
+          [examples: time=5s, num-requests=100, time=5s,num-requests=100]
       --sched-priority=<priority>
           Scheduling priority for the instance.
           [examples: normal, medium, high, admin]
@@ -1127,6 +1155,7 @@ Fields:
   timestamps, timestamps.created, timestamps.started, timestamps.stopped
   scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
   zero.stateful, scale-to-zero.cooldown-time, scale-to-zero.notify-time
+  autokill, autokill.time, autokill.num-requests
   timing, timing.uptime, timing.boot-time, timing.net-time
   restart, restart.policy, restart.start-count, restart.restart-count
   sched-priority

--- a/cmd/unikraft/testdata/TestHelp/instances
+++ b/cmd/unikraft/testdata/TestHelp/instances
@@ -1227,6 +1227,7 @@ Fields:
   tags
   annotations
   delete-lock
+  autokill, autokill.time
   state
   image
   type
@@ -1283,6 +1284,7 @@ Fields:
   tags
   annotations
   delete-lock
+  autokill, autokill.time
   state
   image
   type
@@ -1347,6 +1349,7 @@ Fields:
   tags
   annotations
   delete-lock
+  autokill, autokill.time
   state
   image
   type
@@ -1417,6 +1420,7 @@ Fields:
   tags
   annotations
   delete-lock
+  autokill, autokill.time
   state
   image
   type
@@ -1467,6 +1471,12 @@ Global flags:
       --timeout=<duration> ($UNIKRAFT_TIMEOUT)
           Set a deadline for the command (e.g. 30s, 5m, 1h).
 
+Create flags:
+      --autokill=<key>=<value>
+          Autokill options.
+            time: time without a clone before the template is deleted.
+          [example: time=24h]
+
 $ unikraft instance template edit --help
 
 Edit an instance template.
@@ -1489,6 +1499,7 @@ Fields:
   tags
   annotations
   delete-lock
+  autokill, autokill.time
   state
   image
   type
@@ -1549,6 +1560,10 @@ Edit flags:
           [example: env-dev]
       --delete-lock
           Prevent deletion of the template.
+      --autokill=<key>=<value>
+          Autokill options.
+            time: time without a clone before the template is deleted.
+          [example: time=24h]
 
 $ unikraft instance template delete --help
 
@@ -1572,6 +1587,7 @@ Fields:
   tags
   annotations
   delete-lock
+  autokill, autokill.time
   state
   image
   type

--- a/cmd/unikraft/testdata/TestHelp/instances
+++ b/cmd/unikraft/testdata/TestHelp/instances
@@ -1665,6 +1665,7 @@ Fields:
   tags
   annotations
   delete-lock
+  autokill, autokill.time
   state
   image
   type
@@ -1720,6 +1721,7 @@ Fields:
   tags
   annotations
   delete-lock
+  autokill, autokill.time
   state
   image
   type
@@ -1783,6 +1785,7 @@ Fields:
   tags
   annotations
   delete-lock
+  autokill, autokill.time
   state
   image
   type
@@ -1848,6 +1851,7 @@ Fields:
   tags
   annotations
   delete-lock
+  autokill, autokill.time
   state
   image
   type
@@ -1915,6 +1919,7 @@ Fields:
   tags
   annotations
   delete-lock
+  autokill, autokill.time
   state
   image
   type
@@ -1964,6 +1969,12 @@ Global flags:
       --timeout=<duration> ($UNIKRAFT_TIMEOUT)
           Set a deadline for the command (e.g. 30s, 5m, 1h).
 
+Create flags:
+      --autokill=<key>=<value>
+          Autokill options.
+            time: time without a restore before the checkpoint is deleted.
+          [example: time=24h]
+
 $ unikraft instance checkpoint edit --help
 
 Edit an instance checkpoint.
@@ -1986,6 +1997,7 @@ Fields:
   tags
   annotations
   delete-lock
+  autokill, autokill.time
   state
   image
   type
@@ -2045,6 +2057,10 @@ Edit flags:
           [example: env-dev]
       --delete-lock
           Prevent deletion of the checkpoint.
+      --autokill=<key>=<value>
+          Autokill options.
+            time: time without a restore before the checkpoint is deleted.
+          [example: time=24h]
 
 $ unikraft instance checkpoint delete --help
 
@@ -2068,6 +2084,7 @@ Fields:
   tags
   annotations
   delete-lock
+  autokill, autokill.time
   state
   image
   type

--- a/cmd/unikraft/testdata/TestHelp/run
+++ b/cmd/unikraft/testdata/TestHelp/run
@@ -68,6 +68,7 @@ Fields:
   timestamps, timestamps.created, timestamps.started, timestamps.stopped
   scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
   zero.stateful, scale-to-zero.cooldown-time, scale-to-zero.notify-time
+  autokill, autokill.time, autokill.num-requests
   timing, timing.uptime, timing.boot-time, timing.net-time
   restart, restart.policy, restart.start-count, restart.restart-count
   sched-priority
@@ -177,6 +178,11 @@ Create flags:
             notify-time: notification time in ms before scaling to zero
             stateful: true | false.
           [examples: on, policy=on,cooldown-time=300, policy=on,stateful=true,cooldown-time=500,notify-time=100]
+      --autokill=<key>=<value>
+          Autokill options.
+            time: time after the instance stops before it is deleted
+            num-requests: max requests before the instance is deleted.
+          [examples: time=5s, num-requests=100, time=5s,num-requests=100]
       --restart=<policy>
           Restart policy.
           [examples: always, on-failure, never]

--- a/cmd/unikraft/testdata/TestHelp/services
+++ b/cmd/unikraft/testdata/TestHelp/services
@@ -26,6 +26,7 @@ Fields:
   persistent
   autoscale
   limits, limits.soft, limits.hard
+  autokill, autokill.time
   timestamps, timestamps.created
   domains, domains.*, domains.*.fqdn, domains.*.certificate,
   domains.*.certificate.name, domains.*.certificate.uuid
@@ -74,6 +75,7 @@ Fields:
   persistent
   autoscale
   limits, limits.soft, limits.hard
+  autokill, autokill.time
   timestamps, timestamps.created
   domains, domains.*, domains.*.fqdn, domains.*.certificate,
   domains.*.certificate.name, domains.*.certificate.uuid
@@ -130,6 +132,7 @@ Fields:
   persistent
   autoscale
   limits, limits.soft, limits.hard
+  autokill, autokill.time
   timestamps, timestamps.created
   domains, domains.*, domains.*.fqdn, domains.*.certificate,
   domains.*.certificate.name, domains.*.certificate.uuid
@@ -188,6 +191,7 @@ Fields:
   persistent
   autoscale
   limits, limits.soft, limits.hard
+  autokill, autokill.time
   timestamps, timestamps.created
   domains, domains.*, domains.*.fqdn, domains.*.certificate,
   domains.*.certificate.name, domains.*.certificate.uuid
@@ -248,6 +252,7 @@ Fields:
   persistent
   autoscale
   limits, limits.soft, limits.hard
+  autokill, autokill.time
   timestamps, timestamps.created
   domains, domains.*, domains.*.fqdn, domains.*.certificate,
   domains.*.certificate.name, domains.*.certificate.uuid
@@ -302,6 +307,10 @@ Create flags:
       --hard-limit=<n>
           Hard limit.
           [examples: 10, 100]
+      --autokill=<key>=<value>
+          Autokill options.
+            time: time the group must stay empty before it is deleted.
+          [example: time=5m]
       --domain=<fqdn> ...
           Service domain.
           [example: example.com]
@@ -331,6 +340,7 @@ Fields:
   persistent
   autoscale
   limits, limits.soft, limits.hard
+  autokill, autokill.time
   timestamps, timestamps.created
   domains, domains.*, domains.*.fqdn, domains.*.certificate,
   domains.*.certificate.name, domains.*.certificate.uuid
@@ -384,6 +394,10 @@ Edit flags:
       --hard-limit=<n>
           Hard limit.
           [examples: 10, 100]
+      --autokill=<key>=<value>
+          Autokill options.
+            time: time the group must stay empty before it is deleted.
+          [example: time=5m]
       --domain=<fqdn> ...
           Service domain.
           [example: example.com]
@@ -413,6 +427,7 @@ Fields:
   persistent
   autoscale
   limits, limits.soft, limits.hard
+  autokill, autokill.time
   timestamps, timestamps.created
   domains, domains.*, domains.*.fqdn, domains.*.certificate,
   domains.*.certificate.name, domains.*.certificate.uuid

--- a/internal/cmd/instance_checkpoints.go
+++ b/internal/cmd/instance_checkpoints.go
@@ -50,6 +50,8 @@ type InstanceCheckpoint struct {
 	Annotations map[string]string `mirror:"instance.annotations" field:",long"`
 	DeleteLock  bool              `mirror:"instance.delete_lock" field:"delete-lock,long" edit:"set" flag:"delete-lock" help:"Prevent deletion of the checkpoint."`
 
+	Autokill Autokill `field:",embed" mirror:"instance.checkpoint_autokill" create:"set" edit:"set" flag:"autokill" help:"Autokill options.\n  time: time without a restore before the checkpoint is deleted" placeholder:"<key>=<value>" example:"time=24h"`
+
 	State types.InstanceState             `mirror:"instance.state" field:",short"`
 	Image types.ImageRef[reference.Named] `mirror:"instance.image" field:",short"`
 	Type_ *platform.InstanceType          `mirror:"instance.type" field:"type,long"`
@@ -282,6 +284,13 @@ func instanceCheckpointPatchSpec(path string, op patchOp, value any) (platform.M
 	switch path {
 	case "tags":
 		return platform.MutableCheckpointInstancePropertyTags, value.([]string), nil
+	case "autokill":
+		autokill := value.(Autokill)
+		req := map[string]any{}
+		if autokill.TimeMs > 0 {
+			req["time_ms"] = uint64(autokill.TimeMs)
+		}
+		return platform.MutableCheckpointInstancePropertyAutokill, req, nil
 	case "delete-lock":
 		if value == nil {
 			return zero, nil, nil
@@ -300,12 +309,16 @@ func instanceCheckpointPatchSpec(path string, op patchOp, value any) (platform.M
 
 func (InstanceCheckpoint) Create(ctx context.Context, fields []resource.Field) ([]resource.Resource, error) {
 	var instance string
+	var autokill Autokill
 	for key, field := range resource.IterFields(fields) {
 		if field.Create == nil || field.Create.Set == nil {
 			continue
 		}
-		if key.String() == "instance" {
+		switch key.String() {
+		case "instance":
 			instance = field.Create.Set.(string)
+		case "autokill":
+			autokill = field.Create.Set.(Autokill)
 		}
 	}
 	if instance == "" {
@@ -340,6 +353,10 @@ func (InstanceCheckpoint) Create(ctx context.Context, fields []resource.Field) (
 		req := platform.CreateCheckpointInstancesRequestItem{
 			From:     ref.NameOrUUID(),
 			TimeoutS: new(int64(-1)),
+		}
+		if autokill.TimeMs > 0 {
+			t := uint64(autokill.TimeMs)
+			req.Autokill = &platform.ItemCheckpointAutokill{TimeMs: &t}
 		}
 		resp, err := timeouts.TryWithFallback(
 			ctx,

--- a/internal/cmd/instance_templates.go
+++ b/internal/cmd/instance_templates.go
@@ -47,6 +47,8 @@ type InstanceTemplate struct {
 	Annotations map[string]string `mirror:"instance.annotations" field:",long"`
 	DeleteLock  bool              `mirror:"instance.delete_lock" field:"delete-lock,long" edit:"set" flag:"delete-lock" help:"Prevent deletion of the template."`
 
+	Autokill Autokill `field:",embed" mirror:"instance.template_autokill" create:"set" edit:"set" flag:"autokill" help:"Autokill options.\n  time: time without a clone before the template is deleted" placeholder:"<key>=<value>" example:"time=24h"`
+
 	State types.InstanceState             `mirror:"instance.state" field:",short"`
 	Image types.ImageRef[reference.Named] `mirror:"instance.image" field:",short"`
 	Type_ *platform.InstanceType          `mirror:"instance.type" field:"type,long"`
@@ -283,6 +285,13 @@ func instanceTemplatePatchSpec(path string, op patchOp, value any) (platform.Mut
 	switch path {
 	case "tags":
 		return platform.MutableTemplateInstancePropertyTags, value.([]string), nil
+	case "autokill":
+		autokill := value.(Autokill)
+		req := map[string]any{}
+		if autokill.TimeMs > 0 {
+			req["time_ms"] = uint64(autokill.TimeMs)
+		}
+		return platform.MutableTemplateInstancePropertyAutokill, req, nil
 	case "delete-lock":
 		if value == nil {
 			return zero, nil, nil
@@ -301,12 +310,16 @@ func instanceTemplatePatchSpec(path string, op patchOp, value any) (platform.Mut
 
 func (InstanceTemplate) Create(ctx context.Context, fields []resource.Field) ([]resource.Resource, error) {
 	var instance string
+	var autokill Autokill
 	for key, field := range resource.IterFields(fields) {
 		if field.Create == nil || field.Create.Set == nil {
 			continue
 		}
-		if key.String() == "instance" {
+		switch key.String() {
+		case "instance":
 			instance = field.Create.Set.(string)
+		case "autokill":
+			autokill = field.Create.Set.(Autokill)
 		}
 	}
 	if instance == "" {
@@ -341,6 +354,10 @@ func (InstanceTemplate) Create(ctx context.Context, fields []resource.Field) ([]
 			reqItem.Name = new(ref.Name)
 		} else {
 			reqItem.Uuid = new(ref.UUID)
+		}
+		if autokill.TimeMs > 0 {
+			t := uint64(autokill.TimeMs)
+			reqItem.Autokill = &platform.ItemAutokill{TimeMs: &t}
 		}
 		log.G(ctx).Trace().Str("ref", refStr).Msg("creating instance template")
 		reqItem.TimeoutS = new(int64(-1))

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -137,6 +137,7 @@ type Instance struct {
 	}
 
 	ScaleToZero InstanceScaleToZero `field:",embed" mirror:"instance.scale_to_zero" create:"set" edit:"set" flag:"scale-to-zero" help:"Scale-to-zero options.\n  policy: on | idle | off\n  cooldown-time: cooldown in ms before scaling to zero\n  notify-time: notification time in ms before scaling to zero\n  stateful: true | false" placeholder:"<key>=<value>" example:"on,policy=on\\,cooldown-time=300,policy=on\\,stateful=true\\,cooldown-time=500\\,notify-time=100"`
+	Autokill    InstanceAutokill    `field:",embed" mirror:"instance.autokill" create:"set" edit:"set" flag:"autokill" help:"Autokill options.\n  time: time after the instance stops before it is deleted\n  num-requests: max requests before the instance is deleted" placeholder:"<key>=<value>" example:"time=5s,num-requests=100,time=5s\\,num-requests=100"`
 
 	Timing struct {
 		Uptime   types.DurationMS `mirror:"instance.uptime_ms"`
@@ -568,6 +569,89 @@ func (s InstanceScaleToZero) MarshalText() ([]byte, error) {
 func (s InstanceScaleToZero) MarshalJSON() ([]byte, error) {
 	type scaleToZeroJSON InstanceScaleToZero
 	return json.Marshal(scaleToZeroJSON(s))
+}
+
+type InstanceAutokill struct {
+	TimeMs      types.DurationMS `name:"time" json:"time,omitempty" mirror:"time_ms" field:"time,long"`
+	NumRequests uint32           `name:"num-requests" json:"num-requests,omitempty" mirror:"num_requests" field:"num-requests,long"`
+}
+
+func (a *InstanceAutokill) UnmarshalText(data []byte) error {
+	type autokillAlias InstanceAutokill
+	parsed, err := value.Parse[autokillAlias]([]string{string(data)})
+	if err != nil {
+		return err
+	}
+	*a = InstanceAutokill(parsed)
+	return nil
+}
+
+func (a *InstanceAutokill) UnmarshalJSON(data []byte) error {
+	if len(data) != 0 && data[0] == '"' {
+		var text string
+		if err := json.Unmarshal(data, &text); err != nil {
+			return err
+		}
+		return a.UnmarshalText([]byte(text))
+	}
+	type autokillJSON InstanceAutokill
+	return json.Unmarshal(data, (*autokillJSON)(a))
+}
+
+func (a InstanceAutokill) MarshalText() ([]byte, error) {
+	var parts []string
+	if a.TimeMs > 0 {
+		parts = append(parts, fmt.Sprintf("time=%s", a.TimeMs))
+	}
+	if a.NumRequests > 0 {
+		parts = append(parts, fmt.Sprintf("num-requests=%d", a.NumRequests))
+	}
+	return []byte(strings.Join(parts, ",")), nil
+}
+
+func (a InstanceAutokill) MarshalJSON() ([]byte, error) {
+	type autokillJSON InstanceAutokill
+	return json.Marshal(autokillJSON(a))
+}
+
+// Autokill is the time-only form of autokill used by service groups and
+// instance templates, whose endpoints have no request-count trigger.
+type Autokill struct {
+	TimeMs types.DurationMS `name:"time" json:"time,omitempty" mirror:"time_ms" field:"time,long"`
+}
+
+func (a *Autokill) UnmarshalText(data []byte) error {
+	type autokillAlias Autokill
+	parsed, err := value.Parse[autokillAlias]([]string{string(data)})
+	if err != nil {
+		return err
+	}
+	*a = Autokill(parsed)
+	return nil
+}
+
+func (a *Autokill) UnmarshalJSON(data []byte) error {
+	if len(data) != 0 && data[0] == '"' {
+		var text string
+		if err := json.Unmarshal(data, &text); err != nil {
+			return err
+		}
+		return a.UnmarshalText([]byte(text))
+	}
+	type autokillJSON Autokill
+	return json.Unmarshal(data, (*autokillJSON)(a))
+}
+
+func (a Autokill) MarshalText() ([]byte, error) {
+	if a.TimeMs <= 0 {
+		return nil, nil
+	}
+	return fmt.Appendf(nil, "time=%s", a.TimeMs), nil
+}
+
+func (a Autokill) MarshalJSON() ([]byte, error) {
+	type autokillJSON Autokill
+	return json.Marshal(autokillJSON(a))
 }
 
 // InstanceArgs is a []string type that uses shell-style word splitting when
@@ -1025,6 +1109,16 @@ func instancePatchSpec(path string, op patchOp, value any) (platform.MutableInst
 			req["notify_time_ms"] = int32(value.NotifyTime)
 		}
 		return platform.MutableInstancePropertyScaleToZero, req, nil
+	case "autokill":
+		value := value.(InstanceAutokill)
+		req := map[string]any{}
+		if value.TimeMs > 0 {
+			req["time_ms"] = uint64(value.TimeMs)
+		}
+		if value.NumRequests > 0 {
+			req["num_requests"] = value.NumRequests
+		}
+		return platform.MutableInstancePropertyAutokill, req, nil
 	case "vsock":
 		return "vsock", value.(bool), nil
 	case "roms":
@@ -1148,6 +1242,19 @@ func (Instance) Create(ctx context.Context, fields []resource.Field) ([]resource
 			if scale.NotifyTime > 0 {
 				notify := int32(scale.NotifyTime)
 				req.ScaleToZero.NotifyTimeMs = &notify
+			}
+		case "autokill":
+			autokill := field.Create.Set.(InstanceAutokill)
+			if autokill.TimeMs > 0 || autokill.NumRequests > 0 {
+				req.Autokill = &platform.CreateInstanceRequestAutokill{}
+				if autokill.TimeMs > 0 {
+					t := uint64(autokill.TimeMs)
+					req.Autokill.TimeMs = &t
+				}
+				if autokill.NumRequests > 0 {
+					n := autokill.NumRequests
+					req.Autokill.NumRequests = &n
+				}
 			}
 		case "volumes":
 			for _, vol := range field.Create.Set.([]*InstanceVolume) {

--- a/internal/cmd/services.go
+++ b/internal/cmd/services.go
@@ -52,6 +52,8 @@ type ServiceGroup struct {
 		Hard uint64 `mirror:"service_group.hard_limit" field:",long" create:"set" edit:"set" flag:"hard-limit" help:"Hard limit." placeholder:"n" example:"10,100"`
 	}
 
+	Autokill Autokill `field:",embed" mirror:"service_group.autokill" create:"set" edit:"set" flag:"autokill" help:"Autokill options.\n  time: time the group must stay empty before it is deleted" placeholder:"<key>=<value>" example:"time=5m"`
+
 	Timestamps struct {
 		Created types.RelativeTime `mirror:"service_group.created_at" field:",short"`
 	}
@@ -333,6 +335,12 @@ func (ServiceGroup) Create(ctx context.Context, fields []resource.Field) ([]reso
 			case "limits.hard":
 				limit := field.Create.Set.(uint64)
 				req.HardLimit = &limit
+			case "autokill":
+				autokill := field.Create.Set.(Autokill)
+				if autokill.TimeMs > 0 {
+					t := uint64(autokill.TimeMs)
+					req.Autokill = &platform.CreateServiceGroupRequestAutokill{TimeMs: &t}
+				}
 			case "domains":
 				for _, domain := range field.Create.Set.([]Domain) {
 					name := domain.Name
@@ -489,6 +497,13 @@ func serviceGroupPatchSpec(path string, _ patchOp, value any) (platform.MutableS
 		return platform.MutableServiceGroupPropertySoftLimit, value.(uint64), nil
 	case "limits.hard":
 		return platform.MutableServiceGroupPropertyHardLimit, value.(uint64), nil
+	case "autokill":
+		autokill := value.(Autokill)
+		req := map[string]any{}
+		if autokill.TimeMs > 0 {
+			req["time_ms"] = uint64(autokill.TimeMs)
+		}
+		return platform.MutableServiceGroupPropertyAutokill, req, nil
 	case "domains":
 		nvalue := []platform.CreateServiceGroupRequestDomain{}
 		for _, domain := range value.([]Domain) {

--- a/internal/cmd/testdata/TestOutput/instance-checkpoints
+++ b/internal/cmd/testdata/TestOutput/instance-checkpoints
@@ -34,6 +34,8 @@ annotations:
   env:              production
   example.com/team: platform
 delete-lock:        true
+autokill:
+  time:             0s
 state:              checkpoint
 image:              nginx
 type:               micro
@@ -120,6 +122,23 @@ fra    my-checkpoint  checkpoint  nginx  ["arg1", "arg2"]  256MiB  2      never
     "verbosity": "long",
     "edit": {
       "set": true
+    }
+  },
+  {
+    "name": "autokill",
+    "subfields": [
+      {
+        "name": "time",
+        "value": "0s",
+        "verbosity": "long"
+      }
+    ],
+    "verbosity": "long",
+    "create": {
+      "set": {}
+    },
+    "edit": {
+      "set": {}
     }
   },
   {

--- a/internal/cmd/testdata/TestOutput/instance-templates
+++ b/internal/cmd/testdata/TestOutput/instance-templates
@@ -24,6 +24,8 @@ tags:            ["env-staging"]
 annotations:
   env:           staging
 delete-lock:     false
+autokill:
+  time:          0s
 state:           template
 image:           nginx
 type:            micro
@@ -104,6 +106,23 @@ fra    my-template  template  nginx        128MiB  1      never
     "verbosity": "long",
     "edit": {
       "set": false
+    }
+  },
+  {
+    "name": "autokill",
+    "subfields": [
+      {
+        "name": "time",
+        "value": "0s",
+        "verbosity": "long"
+      }
+    ],
+    "verbosity": "long",
+    "create": {
+      "set": {}
+    },
+    "edit": {
+      "set": {}
     }
   },
   {

--- a/internal/cmd/testdata/TestOutput/instances
+++ b/internal/cmd/testdata/TestOutput/instances
@@ -112,6 +112,9 @@ scale-to-zero:
   stateful:         true
   cooldown-time:    500ms
   notify-time:      100ms
+autokill:
+  time:             0s
+  num-requests:     0
 timing:
   uptime:           1.5s
   boot-time:        250ms
@@ -865,6 +868,28 @@ fra    my-instance  running  nginx  ["arg1", "arg2"]  256MiB  2      example.uni
         "cooldown-time": "500ms",
         "notify-time": "100ms"
       }
+    }
+  },
+  {
+    "name": "autokill",
+    "subfields": [
+      {
+        "name": "time",
+        "value": "0s",
+        "verbosity": "long"
+      },
+      {
+        "name": "num-requests",
+        "value": 0,
+        "verbosity": "long"
+      }
+    ],
+    "verbosity": "long",
+    "create": {
+      "set": {}
+    },
+    "edit": {
+      "set": {}
     }
   },
   {

--- a/internal/cmd/testdata/TestOutput/services
+++ b/internal/cmd/testdata/TestOutput/services
@@ -26,6 +26,8 @@ autoscale:     true
 limits:
   soft:        5
   hard:        50
+autokill:
+  time:        0s
 timestamps:
   created:     never
 domains:
@@ -113,6 +115,23 @@ fra    my-service  true       never    example.unikraft.app  443     8080       
       }
     ],
     "verbosity": "long"
+  },
+  {
+    "name": "autokill",
+    "subfields": [
+      {
+        "name": "time",
+        "value": "0s",
+        "verbosity": "long"
+      }
+    ],
+    "verbosity": "long",
+    "create": {
+      "set": {}
+    },
+    "edit": {
+      "set": {}
+    }
   },
   {
     "name": "timestamps",


### PR DESCRIPTION
Adds `--autokill` everywhere the platform accepts it: instances (`time` + `num-requests`), and service groups, instance templates and checkpoints (`time` only — those endpoints have no request-count rigger). Create and edit both, on all four.

Templates read back from `instance.template_autokill` and checkpoints from `instance.checkpoint_autokill` — the platform stores one timer but emits it under different names depending on the kind of instance.

Checkpoint create needed [https://github.com/unikraft-cloud/proto/pull/343](<https://github.com/unikraft-cloud/proto/pull/343>) first, since the spec never described `autokill` on that endpoint; the SDK bump here picks it up.

The one remaining autokill surface is image pin, which the CLI has no command for at all (`PinImages`/`UnpinImages` are unused) — that is its own feature, not an autokill gap. The same proto change also added `tags` to checkpoint create, which is still unwired here; happy to fold that in if you would rather not have a second PR.