### PR TITLE
fix: Update missing timeout golden output

### DIFF
--- a/cmd/unikraft/testdata/TestHelp/images
+++ b/cmd/unikraft/testdata/TestHelp/images
@@ -100,6 +100,8 @@ Global flags:
       --[no-]telemetry ($UNIKRAFT_TELEMETRY)
           Toggle anonymous usage analytics.
           [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft image get --help
 


### PR DESCRIPTION
This was missed in a quick series of merges.