### PR TITLE
feat: Add volume attach and detach

### DIFF
--- a/cmd/unikraft/help_test.go
+++ b/cmd/unikraft/help_test.go
@@ -124,6 +124,8 @@ func volumesHelpTests(t *testing.T, unikraftPath string) {
 		[]string{"unikraft", "volume", "wait", "--help"},
 		[]string{"unikraft", "volume", "create", "--help"},
 		[]string{"unikraft", "volume", "clone", "--help"},
+		[]string{"unikraft", "volume", "attach", "--help"},
+		[]string{"unikraft", "volume", "detach", "--help"},
 		[]string{"unikraft", "volume", "import", "--help"},
 		[]string{"unikraft", "volume", "edit", "--help"},
 		[]string{"unikraft", "volume", "delete", "--help"},

--- a/cmd/unikraft/integration/instance_test.go
+++ b/cmd/unikraft/integration/instance_test.go
@@ -513,6 +513,84 @@ cmd: ["cat", "/rom/hello.txt"]
 		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName})
 	})
 
+	t.Run("volume-add", func(t *testing.T) {
+		r := runner(t, true)
+		instName := uniq()
+		volName := uniq()
+
+		r.Run(t, []string{
+			"unikraft", "volume", "create",
+			"--output", "quiet",
+			"--set", "name=test-" + volName,
+			"--set", "size=10",
+			"--set", "metro=" + r.Config.MetroName,
+		})
+
+		r.Run(t, []string{
+			"unikraft", "instance", "create",
+			"--output", "quiet",
+			"--set", "name=test-" + instName,
+			"--set", "metro=" + r.Config.MetroName,
+			"--set", "image=nginx:latest",
+			"--set", "autostart=false",
+			"--set", "resources.memory=128",
+			"--set", "resources.vcpus=1",
+		})
+
+		r.Run(t, []string{
+			"unikraft", "instance", "edit", "test-" + instName,
+			"--output", "quiet",
+			"--add", "volumes=test-" + volName + ":/data",
+		})
+
+		out := r.Run(t, []string{"unikraft", "instance", "inspect", "test-" + instName})
+		assert.Regexp(t, `at:\s+/data`, out)
+
+		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName})
+		r.Run(t, []string{"unikraft", "volume", "delete", "test-" + volName})
+	})
+
+	t.Run("volume-del", func(t *testing.T) {
+		r := runner(t, true)
+		instName := uniq()
+		volName := uniq()
+
+		r.Run(t, []string{
+			"unikraft", "volume", "create",
+			"--output", "quiet",
+			"--set", "name=test-" + volName,
+			"--set", "size=10",
+			"--set", "metro=" + r.Config.MetroName,
+		})
+
+		r.Run(t, []string{
+			"unikraft", "instance", "create",
+			"--output", "quiet",
+			"--set", "name=test-" + instName,
+			"--set", "metro=" + r.Config.MetroName,
+			"--set", "image=nginx:latest",
+			"--set", "autostart=false",
+			"--set", "resources.memory=128",
+			"--set", "resources.vcpus=1",
+			"--set", "volumes=test-" + volName + ":/data",
+		})
+
+		out := r.Run(t, []string{"unikraft", "instance", "inspect", "test-" + instName})
+		assert.Regexp(t, `at:\s+/data`, out)
+
+		r.Run(t, []string{
+			"unikraft", "instance", "edit", "test-" + instName,
+			"--output", "quiet",
+			"--del", "volumes=test-" + volName,
+		})
+
+		out = r.Run(t, []string{"unikraft", "instance", "inspect", "test-" + instName})
+		assert.NotRegexp(t, `at:\s+/data`, out)
+
+		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName})
+		r.Run(t, []string{"unikraft", "volume", "delete", "test-" + volName})
+	})
+
 	t.Run("autostart", func(t *testing.T) {
 		r := runner(t, true)
 		instName := uniq()

--- a/cmd/unikraft/integration/volume_test.go
+++ b/cmd/unikraft/integration/volume_test.go
@@ -136,6 +136,57 @@ func TestVolumes(t *testing.T) {
 		r.Run(t, []string{"unikraft", "volume", "delete", "test-" + volName})
 	})
 
+	t.Run("attach-detach", func(t *testing.T) {
+		r := runner(t, true)
+		volName := uniq()
+		instName := uniq()
+
+		r.Run(t, []string{
+			"unikraft", "volume", "create",
+			"--output", "quiet",
+			"--set", "name=test-" + volName,
+			"--set", "size=10",
+			"--set", "metro=" + r.Config.MetroName,
+		})
+
+		r.Run(t, []string{
+			"unikraft", "instance", "create",
+			"--output", "quiet",
+			"--set", "name=test-" + instName,
+			"--set", "metro=" + r.Config.MetroName,
+			"--set", "image=nginx:latest",
+			"--set", "resources.memory=128",
+			"--set", "resources.vcpus=1",
+		})
+
+		// attach shows instance diff
+		out := r.Run(t, []string{
+			"unikraft", "volume", "attach",
+			"test-" + volName,
+			"--to", "test-" + instName,
+			"--at", "/data",
+		})
+		assert.Regexp(t, `test-`+volName, out)
+
+		// verify via volume inspect
+		out = r.Run(t, []string{"unikraft", "volume", "inspect", "test-" + volName})
+		assert.Regexp(t, `test-`+instName, out)
+
+		// detach shows instance diff
+		out = r.Run(t, []string{
+			"unikraft", "volume", "detach",
+			"test-" + volName,
+			"--from", "test-" + instName,
+		})
+		assert.Regexp(t, `test-`+instName, out)
+
+		out = r.Run(t, []string{"unikraft", "volume", "inspect", "test-" + volName})
+		assert.NotRegexp(t, `test-`+instName, out)
+
+		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName})
+		r.Run(t, []string{"unikraft", "volume", "delete", "test-" + volName})
+	})
+
 	t.Run("import", func(t *testing.T) {
 		t.Run("missing-source", func(t *testing.T) {
 			r := runner(t, false)

--- a/cmd/unikraft/testdata/TestHelp/instances
+++ b/cmd/unikraft/testdata/TestHelp/instances
@@ -482,6 +482,12 @@ Examples:
   # Remove a ROM from an instance by name
   unikraft instance edit demo-instance --del roms=name=my-rom
 
+  # Attach a volume to an instance
+  unikraft instance edit demo-instance --add volumes=my-vol:/data
+
+  # Detach a volume from an instance
+  unikraft instance edit demo-instance --del volumes=my-vol
+
 Fields:
   metro
   name

--- a/cmd/unikraft/testdata/TestHelp/volumes
+++ b/cmd/unikraft/testdata/TestHelp/volumes
@@ -20,6 +20,10 @@ Resources:
           Edit a volume.
   clone
           Clone a volume.
+  attach
+          Attach a volume to an instance.
+  detach
+          Detach a volume from an instance.
   import
           Import data into a volume.
 
@@ -381,6 +385,98 @@ flag-clone
       --tags=<tag>
           Volume tags.
           [examples: env=prod, team=platform]
+
+$ unikraft volume attach --help
+
+Attach a volume to an instance.
+
+Usage:
+  unikraft volumes attach --to=instance --at=path <volume> [flags]
+
+Arguments:
+  <volume>
+          Name or UUID of the volume to attach.
+
+Examples:
+  # Attach a volume to a stopped instance
+  unikraft volume attach my-volume --to my-instance --at /data
+
+  # Attach a volume read-only
+  unikraft volume attach my-volume --to my-instance --at /data --readonly
+
+Flags:
+      --to=<instance>
+          Name or UUID of the instance to attach to.
+      --at=<path>
+          Absolute mount path inside the instance.
+          [examples: /data, /mnt]
+      --readonly
+          Mount volume as read-only.
+  -f, --field
+          Specify which fields to include in the output.
+  -o, --output
+          Output format. One of: kv, table, json, yaml, raw, quiet, template.
+
+Global flags:
+  -h, --help
+          Show context-sensitive help.
+      --config=<file> ($UNIKRAFT_CONFIG)
+          Path to the configuration file.
+      --log-level=<level> ($UNIKRAFT_LOG_LEVEL)
+          Set the logging level.
+          [default: info, choices: trace, debug, info, warn, error, fatal]
+      --log-type=<type> ($UNIKRAFT_LOG_TYPE)
+          Set the log type.
+          [default: text, choices: text, json]
+      --profile=<name> ($UNIKRAFT_PROFILE)
+          Set the current profile.
+      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+          Toggle anonymous usage analytics.
+          [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
+
+$ unikraft volume detach --help
+
+Detach a volume from an instance.
+
+Usage:
+  unikraft volumes detach --from=instance <volume> [flags]
+
+Arguments:
+  <volume>
+          Name or UUID of the volume to detach.
+
+Examples:
+  # Detach a volume from an instance
+  unikraft volume detach my-volume --from my-instance
+
+Flags:
+      --from=<instance>
+          Name or UUID of the instance to detach from.
+  -f, --field
+          Specify which fields to include in the output.
+  -o, --output
+          Output format. One of: kv, table, json, yaml, raw, quiet, template.
+
+Global flags:
+  -h, --help
+          Show context-sensitive help.
+      --config=<file> ($UNIKRAFT_CONFIG)
+          Path to the configuration file.
+      --log-level=<level> ($UNIKRAFT_LOG_LEVEL)
+          Set the logging level.
+          [default: info, choices: trace, debug, info, warn, error, fatal]
+      --log-type=<type> ($UNIKRAFT_LOG_TYPE)
+          Set the log type.
+          [default: text, choices: text, json]
+      --profile=<name> ($UNIKRAFT_PROFILE)
+          Set the current profile.
+      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+          Toggle anonymous usage analytics.
+          [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft volume import --help
 

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -159,7 +159,7 @@ type Instance struct {
 	}
 
 	Service *InstanceService  `mirror:"instance.service_group" field:",embed" create:"set"`
-	Volumes []*InstanceVolume `mirror:"instance.volumes" field:",embed" create:"set"`
+	Volumes []*InstanceVolume `mirror:"instance.volumes" field:",embed" create:"set" edit:"add,del=strings"`
 	Roms    []*InstanceRom    `mirror:"instance.roms" field:",embed" create:"set" edit:"set,add,del"`
 
 	Networks []InstanceNetwork `mirror:"instance.network_interfaces" field:",embed"`
@@ -258,9 +258,13 @@ type InstanceVolume struct {
 }
 
 func (v *InstanceVolume) MarshalText() ([]byte, error) {
-	parts := []string{
-		cmp.Or(v.Name, v.UUID),
-		v.At,
+	volKey, err := v.Link.MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	parts := []string{string(volKey)}
+	if v.At != "" || v.Readonly || v.Size > 0 {
+		parts = append(parts, v.At)
 	}
 	if v.Readonly {
 		parts = append(parts, "ro")
@@ -299,10 +303,10 @@ func (v *InstanceVolume) UnmarshalJSON(data []byte) error {
 func (v *InstanceVolume) UnmarshalText(data []byte) error {
 	str := string(data)
 	parts := strings.Split(str, ":")
+
 	if len(parts) < 2 {
 		return fmt.Errorf("invalid volume format, expected NAME:AT, got %q", str)
 	}
-
 	name, at, parts := parts[0], parts[1], parts[2:]
 	readonly := false
 	size := types.SizeMebibytes(0)
@@ -718,7 +722,6 @@ func (Instance) Edit(ctx context.Context, key string, fields []resource.Field) e
 			hasStateChange = true
 		}
 	}
-
 	var currentState types.InstanceState
 	if hasStateChange {
 		resources, err := Instance{}.Get(ctx, []string{key})
@@ -728,21 +731,40 @@ func (Instance) Edit(ctx context.Context, key string, fields []resource.Field) e
 		currentState = resources[0].(Instance).State
 	}
 
+	// Extract volume add/del ops before the standard patch pipeline.
+	var volumeAddOps []*InstanceVolume
+	var volumeDelOps []string
+	for path, field := range resource.IterFields(fields) {
+		if path.String() != "volumes" || field.Edit == nil {
+			continue
+		}
+		if add, ok := field.Edit.Add.([]*InstanceVolume); ok {
+			volumeAddOps = add
+			field.Edit.Add = nil
+		}
+		if del, ok := field.Edit.Del.([]string); ok {
+			volumeDelOps = del
+			field.Edit.Del = nil
+		}
+		break
+	}
+
 	patches, err := patchRequests(fields, instancePatchSpec)
 	if err != nil {
 		return err
 	}
-
 	g, err := multimetro.NewClient(ctx)
 	if err != nil {
 		return err
 	}
+
 	if hasStateChange && currentState.IsRunning() && !targetState.IsRunning() {
 		_, err := stopInstances(ctx, g, parsedKeys, StopOpts{DrainTimeout: -1})
 		if err != nil {
 			return err
 		}
 	}
+
 	if len(patches) > 0 {
 		err = group.DoRefs(ctx, g, parsedKeys.Refs(), func(ctx context.Context, c multimetro.MetroClient, refs group.Refs) (group.Refs, error) {
 			reqs := make([]platform.UpdateInstancesRequestItem, 0, len(refs)*len(patches))
@@ -775,12 +797,83 @@ func (Instance) Edit(ctx context.Context, key string, fields []resource.Field) e
 			return err
 		}
 	}
+
+	// Handle volume attach/detach ops using the dedicated volume APIs.
+	if len(volumeAddOps) > 0 || len(volumeDelOps) > 0 {
+		err = group.DoRefs(ctx, g, parsedKeys.Refs(), func(ctx context.Context, c multimetro.MetroClient, refs group.Refs) (group.Refs, error) {
+			var attachReqs []platform.AttachVolumesRequestItem
+			var detachReqs []platform.DetachVolumesRequestItem
+			for _, ref := range refs {
+				instRef := platform.NameOrUUID{
+					Uuid: ptr.NilIfZero(ref.UUID),
+					Name: ptr.NilIfZero(ref.Name),
+				}
+				for _, vol := range volumeAddOps {
+					if vol.Metro != "" && vol.Metro != c.Metro.Name {
+						return nil, fmt.Errorf("volume %q is in metro %q but instance is in metro %q: cross-metro volume attachment is not supported",
+							cmp.Or(vol.Name, vol.UUID), vol.Metro, c.Metro.Name)
+					}
+					if vol.At == "" {
+						return nil, fmt.Errorf("volume %q: mount path is required for attach (format: NAME:PATH[:<options>])",
+							cmp.Or(vol.Name, vol.UUID))
+					}
+					req := platform.AttachVolumesRequestItem{
+						AttachTo: instRef,
+						At:       vol.At,
+					}
+					if vol.UUID != "" {
+						req.Uuid = ptr.NilIfZero(vol.UUID)
+					} else {
+						req.Name = ptr.NilIfZero(vol.Name)
+					}
+					if vol.Readonly {
+						req.Readonly = new(true)
+					}
+					attachReqs = append(attachReqs, req)
+				}
+				for _, volKey := range volumeDelOps {
+					ref := multimetro.ParseKey(volKey)
+					if ref.Metro != "" && ref.Metro != c.Metro.Name {
+						return nil, fmt.Errorf("volume %q is in metro %q but instance is in metro %q: cross-metro volume attachment is not supported",
+							cmp.Or(ref.Name, ref.UUID), ref.Metro, c.Metro.Name)
+					}
+					req := platform.DetachVolumesRequestItem{
+						From: &instRef,
+					}
+					if ref.UUID != "" {
+						req.Uuid = ptr.NilIfZero(ref.UUID)
+					} else {
+						req.Name = ptr.NilIfZero(ref.Name)
+					}
+					detachReqs = append(detachReqs, req)
+				}
+			}
+			if len(attachReqs) > 0 {
+				log.G(ctx).Trace().Msg("attaching volumes to instance")
+				if _, err := c.AttachVolumes(ctx, attachReqs); err != nil {
+					return nil, err
+				}
+			}
+			if len(detachReqs) > 0 {
+				log.G(ctx).Trace().Msg("detaching volumes from instance")
+				if _, err := c.DetachVolumes(ctx, detachReqs); err != nil {
+					return nil, err
+				}
+			}
+			return refs, nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
 	if hasStateChange && !currentState.IsRunning() && targetState.IsRunning() {
 		_, err := startInstances(ctx, g, parsedKeys)
 		if err != nil {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -1179,6 +1272,18 @@ func (Instance) Examples() map[cmd.CmdType][]kingkong.Example {
 				Description: "Remove a ROM from an instance by name",
 				Commands: []string{
 					"unikraft instance edit demo-instance --del roms=name=my-rom",
+				},
+			},
+			{
+				Description: "Attach a volume to an instance",
+				Commands: []string{
+					"unikraft instance edit demo-instance --add volumes=my-vol:/data",
+				},
+			},
+			{
+				Description: "Detach a volume from an instance",
+				Commands: []string{
+					"unikraft instance edit demo-instance --del volumes=my-vol",
 				},
 			},
 		},

--- a/internal/cmd/testdata/TestOutput/instances
+++ b/internal/cmd/testdata/TestOutput/instances
@@ -446,6 +446,10 @@ fra    my-instance  running  nginx  ["arg1", "arg2"]  256MiB  2      example.uni
       "set": [
         "my-volume"
       ]
+    },
+    "edit": {
+      "add": null,
+      "del": null
     }
   },
   {

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -52,6 +52,8 @@ type VolumesCmd struct {
 	Template VolumeTemplatesCmd `cmd:"" group:"cmd-templates" help:"Manage volume templates." aliases:"templates" set:"name=volume-template" set:"names=volume-templates"`
 
 	Clone  VolumesCloneCmd `cmd:"" help:"Clone a volume."`
+	Attach VolumeAttachCmd `cmd:"" help:"Attach a volume to an instance."`
+	Detach VolumeDetachCmd `cmd:"" help:"Detach a volume from an instance."`
 	Import VolumeImportCmd `cmd:"" help:"Import data into a volume."`
 }
 
@@ -572,6 +574,72 @@ func volumePatchSpec(path string, _ patchOp, value any) (platform.MutableVolumeP
 	default:
 		return zero, nil, nil
 	}
+}
+
+// VolumeAttachCmd attaches an existing volume to an instance.
+type VolumeAttachCmd struct {
+	Volume   string `arg:"" completion-predictor:"resource-key-volume" help:"Name or UUID of the volume to attach."`
+	To       string `required:"" completion-predictor:"resource-key-instance" help:"Name or UUID of the instance to attach to." placeholder:"instance"`
+	At       string `required:"" help:"Absolute mount path inside the instance." placeholder:"path" example:"/data,/mnt"`
+	Readonly bool   `help:"Mount volume as read-only."`
+
+	cmd.FormatOpts
+}
+
+func (VolumeAttachCmd) Examples() []kingkong.Example {
+	return []kingkong.Example{
+		{
+			Description: "Attach a volume to a stopped instance",
+			Commands:    []string{"unikraft volume attach my-volume --to my-instance --at /data"},
+		},
+		{
+			Description: "Attach a volume read-only",
+			Commands:    []string{"unikraft volume attach my-volume --to my-instance --at /data --readonly"},
+		},
+	}
+}
+
+func (c *VolumeAttachCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox) error {
+	vol := &InstanceVolume{At: c.At, Readonly: c.Readonly}
+	if err := vol.Link.UnmarshalText([]byte(c.Volume)); err != nil {
+		return err
+	}
+	volStr, err := vol.MarshalText()
+	if err != nil {
+		return err
+	}
+	editCmd := &cmd.ResourceEditCmd[Instance]{
+		Target:     c.To,
+		AddArgs:    cmd.AddArgs{Add: []map[string]string{{"volumes": string(volStr)}}},
+		FormatOpts: c.FormatOpts,
+	}
+	return editCmd.Run(ctx, stdio, sandbox)
+}
+
+// VolumeDetachCmd detaches a volume from an instance.
+type VolumeDetachCmd struct {
+	Volume string `arg:"" completion-predictor:"resource-key-volume" help:"Name or UUID of the volume to detach."`
+	From   string `required:"" completion-predictor:"resource-key-instance" help:"Name or UUID of the instance to detach from." placeholder:"instance"`
+
+	cmd.FormatOpts
+}
+
+func (VolumeDetachCmd) Examples() []kingkong.Example {
+	return []kingkong.Example{
+		{
+			Description: "Detach a volume from an instance",
+			Commands:    []string{"unikraft volume detach my-volume --from my-instance"},
+		},
+	}
+}
+
+func (c *VolumeDetachCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox) error {
+	editCmd := &cmd.ResourceEditCmd[Instance]{
+		Target:     c.From,
+		DelArgs:    cmd.DelArgs{Del: []map[string]string{{"volumes": c.Volume}}},
+		FormatOpts: c.FormatOpts,
+	}
+	return editCmd.Run(ctx, stdio, sandbox)
 }
 
 // VolumeImportCmd imports data from a local source into a volume by

--- a/internal/resource/patch/filter.go
+++ b/internal/resource/patch/filter.go
@@ -44,7 +44,8 @@ func FilterDisplayableEditFields(fields []resource.Field) []resource.Field {
 		if field.Edit == nil {
 			return resource.FilterPrune
 		}
-		if reflect.ValueOf(field.Edit.Set).IsZero() {
+		rv := reflect.ValueOf(field.Edit.Set)
+		if !rv.IsValid() || rv.IsZero() {
 			return resource.FilterPrune
 		}
 		return resource.FilterInclude

--- a/internal/resource/patch/visual.go
+++ b/internal/resource/patch/visual.go
@@ -211,13 +211,16 @@ func loadFieldPatches(fields []resource.Field, data []byte, create bool) ([]reso
 		} else {
 			patch = field.Edit
 		}
-		if patch == nil || patch.Set == nil {
+		if patch == nil {
 			continue
 		}
 
 		// Visual editing only supports Set operations - always clear Add/Del
 		patch.Add = nil
 		patch.Del = nil
+		if patch.Set == nil {
+			continue
+		}
 
 		// Get the value from the edited YAML
 		newValue, found := getNestedValue(obj, key)

--- a/internal/resource/struct.go
+++ b/internal/resource/struct.go
@@ -399,6 +399,11 @@ func parsePatchEmpty(tp reflect.Type, tag string) (any, error) {
 	switch tag {
 	case "":
 		return reflect.Zero(tp).Interface(), nil
+	case "strings":
+		if tp.Kind() != reflect.Slice {
+			return nil, fmt.Errorf("strings patch value only valid for slice types")
+		}
+		return []string(nil), nil
 	case "keys":
 		if tp.Kind() != reflect.Map {
 			return nil, fmt.Errorf("keys patch value only valid for map types")


### PR DESCRIPTION
Implement these via instance edits. This way, you can also do `unikraft instance edit --add` to modify the volumes, since conceptually this is modifying the volume. This isn't super visible today - but at some point, it would be great to have visual edits use this.