### PR TITLE
ci: Set `CGO_ENABLED=0` for releases

### DIFF
--- a/.goreleaser.ytt
+++ b/.goreleaser.ytt
@@ -187,13 +187,19 @@ builds:
   - #@ os
   goarch:
   - #@ arch
+  #@ if os == "linux":
+  env:
+  - CGO_ENABLED=0
+  #@ end
   flags:
   - -buildmode=pie
   ldflags:
   - -s
   - -w
+  #@ if os != "linux":
   - -extldflags
   - -static-pie
+  #@ end
   - -X unikraft.com/cli/internal/version.Version={{ .Version }}
   - -X unikraft.com/cli/internal/version.Commit={{ .Commit }}
   - -X unikraft.com/cli/internal/version.BuildTime={{ .Date }}


### PR DESCRIPTION
So that we can run regardless of libc version.

We can also disable the extldflags, since those don't have an effect for CGO_ENABLED=0.

Fixes https://linear.app/unikraft/issue/TOOL-1028/unikraft-cli-doesnt-work-on-debian-11.