### PR TITLE
feat: Add 'new' alias to instance create subcommand

### DIFF
--- a/cmd/unikraft/help_test.go
+++ b/cmd/unikraft/help_test.go
@@ -99,6 +99,7 @@ func instancesHelpTests(t *testing.T, unikraftPath string) {
 		[]string{"unikraft", "instance", "list", "--help"},
 		[]string{"unikraft", "instance", "wait", "--help"},
 		[]string{"unikraft", "instance", "create", "--help"},
+		[]string{"unikraft", "instance", "new", "--help"},
 		[]string{"unikraft", "instance", "edit", "--help"},
 		[]string{"unikraft", "instance", "delete", "--help"},
 		[]string{"unikraft", "instance", "template", "--help"},

--- a/cmd/unikraft/testdata/TestHelp/instances
+++ b/cmd/unikraft/testdata/TestHelp/instances
@@ -14,7 +14,7 @@ Resources:
           List instances.
   delete, rm, remove
           Remove a instance.
-  create
+  create, new
           Create an instance.
   edit
           Edit an instance.
@@ -309,6 +309,154 @@ Global flags:
           Set a deadline for the command (e.g. 30s, 5m, 1h).
 
 $ unikraft instance create --help
+
+Create an instance.
+
+Usage:
+  unikraft instances create [flags]
+
+Examples:
+  # Create a new instance
+  unikraft instance create \
+  	  --name demo-instance \
+  	  --metro fra \
+  	  --image nginx:latest \
+  	  --autostart \
+  	  --memory 128 \
+  	  --vcpus 1
+
+  # Create an instance from a template
+  unikraft instance create \
+  	  --name new-instance \
+  	  --metro fra \
+  	  --template my-template
+
+Fields:
+  metro
+  name
+  uuid
+  tags
+  state
+  image
+  runtime, runtime.args, runtime.env
+  resources, resources.memory, resources.vcpus
+  service, service.name, service.uuid, service.services, service.domains,
+  service.domains.*, service.domains.*.fqdn, service.domains.*.certificate,
+  service.domains.*.certificate.name, service.domains.*.certificate.uuid,
+  service.soft-limit, service.hard-limit
+  volumes, volumes.*, volumes.*.name, volumes.*.uuid, volumes.*.at,
+  volumes.*.readonly, volumes.*.size
+  roms, roms.*, roms.*.name, roms.*.image, roms.*.dir, roms.*.at
+  networks, networks.*, networks.*.uuid, networks.*.private-ip, networks.*.mac
+  timestamps, timestamps.created, timestamps.started, timestamps.stopped
+  scale-to-zero, scale-to-zero.enabled, scale-to-zero.policy, scale-to-
+  zero.stateful, scale-to-zero.cooldown-time, scale-to-zero.notify-time
+  timing, timing.uptime, timing.boot-time, timing.net-time
+  restart, restart.policy, restart.start-count, restart.restart-count
+  sched-priority
+  autostart
+  replicas
+  wait-timeout
+  features
+  vsock
+  template
+  stop, stop.reason, stop.origin, stop.errno, stop.exit-code
+
+Flags:
+      --set=<name>=<value>, --set-file=<name>=<filename>
+          Key-value pairs to set on the instance.
+      --visual
+          Open an editor to modify fields visually.
+      --cmd
+          Run a command to edit fields (receives YAML on stdin, outputs edited YAML on stdout).
+      --load, --save=<FILE>
+          Load fields from a YAML file.
+      --dry-run
+          Print patches without applying them.
+  -f, --field
+          Specify which fields to include in the output.
+  -o, --output
+          Output format. One of: kv, table, json, yaml, raw, quiet, template.
+
+Global flags:
+  -h, --help
+          Show context-sensitive help.
+      --config=<file> ($UNIKRAFT_CONFIG)
+          Path to the configuration file.
+      --log-level=<level> ($UNIKRAFT_LOG_LEVEL)
+          Set the logging level.
+          [default: info, choices: trace, debug, info, warn, error, fatal]
+      --log-type=<type> ($UNIKRAFT_LOG_TYPE)
+          Set the log type.
+          [default: text, choices: text, json]
+      --profile=<name> ($UNIKRAFT_PROFILE)
+          Set the current profile.
+      --[no-]telemetry ($UNIKRAFT_TELEMETRY)
+          Toggle anonymous usage analytics.
+          [default: true]
+      --timeout=<duration> ($UNIKRAFT_TIMEOUT)
+          Set a deadline for the command (e.g. 30s, 5m, 1h).
+
+Create flags:
+      --metro=<metro>
+          Metro to deploy in.
+          [examples: fra, sfo, nyc]
+  -n, --name=<name>
+          Instance name.
+      --image=<name>:<tag>
+          Image to deploy.
+          [examples: nginx:latest, my-app:v1.2.3]
+      --args=<arg>
+          Arguments to pass to the instance.
+  -e, --env=<key>=<value>
+          Environment variables.
+          [examples: DEBUG=true, PORT=8080]
+  -m, --memory=<size>
+          Memory allocation.
+          [examples: 128MiB, 1GiB]
+      --vcpus=<n>
+          Number of vCPUs.
+          [examples: 1, 2, 4]
+      --sched-priority=<priority>
+          Scheduling priority for the instance.
+          [examples: normal, medium, high, admin]
+  -v, --volume=<name>:<path>[:<options>]
+          Attach volume.
+          [examples: my-vol:/data, cache:/tmp:ro, data:/mnt:size=10GiB]
+      --rom=image=<ref>,at=<path>
+          Attach ROM.
+          [examples: image=myuser/my-rom:latest,at=/rom0,name=my-rom, dir=./mydata,at=/rom]
+      --service=<name>
+          Service group name or key.
+  -p, --publish=<src>:<dest>[/<handlers>]
+          Publish port.
+          [examples: 443:8080/http+tls, 80:8080/http]
+      --domain=<fqdn>
+          Service domain.
+          [examples: example.com, api.example.com]
+      --scale-to-zero=<key>=<value>
+          Scale-to-zero options.
+            policy: on | idle | off
+            cooldown-time: cooldown in ms before scaling to zero
+            notify-time: notification time in ms before scaling to zero
+            stateful: true | false.
+          [examples: on, policy=on,cooldown-time=300, policy=on,stateful=true,cooldown-time=500,notify-time=100]
+      --restart=<policy>
+          Restart policy.
+          [examples: always, on-failure, never]
+      --autostart
+          Start instance automatically.
+      --replicas=<n>
+          Number of replicas.
+          [examples: 1, 3]
+      --features=<feature>
+          Instance features.
+      --template=<name>
+          Create from instance template.
+      --rm
+          Automatically delete the instance when it stops.
+
+$ unikraft instance new --help
 
 Create an instance.
 

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -49,7 +49,7 @@ type InstancesCmd struct {
 	cmd.ListableResourceCmd[Instance]
 	cmd.BulkDeletableResourceCmd[Instance]
 
-	Create   InstanceCreateCmd    `cmd:"" help:"Create an instance."`
+	Create   InstanceCreateCmd    `cmd:"" aliases:"new" help:"Create an instance."`
 	Edit     InstanceEditCmd      `cmd:"" help:"Edit an instance."`
 	Template InstanceTemplatesCmd `cmd:"" group:"cmd-templates" help:"Manage instance templates." aliases:"templates" set:"name=instance-template" set:"names=instance-templates"`
 


### PR DESCRIPTION
- add alias `new` for `create` in the `instance` subcommand

closes #370 