### PR TITLE
chore: Add delete-lock flag

### DIFF
--- a/cmd/unikraft/integration/instance_test.go
+++ b/cmd/unikraft/integration/instance_test.go
@@ -804,6 +804,48 @@ cmd: ["cat", "/rom/hello.txt"]
 		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName})
 	})
 
+	t.Run("delete-lock", func(t *testing.T) {
+		r := runner(t, true)
+		instName := uniq()
+
+		r.Run(t, []string{
+			"unikraft", "instance", "create",
+			"--output", "quiet",
+			"--set", "name=test-" + instName,
+			"--set", "metro=" + r.Config.MetroName,
+			"--set", "image=nginx:latest",
+			"--set", "autostart=false",
+			"--set", "resources.memory=128",
+			"--set", "resources.vcpus=1",
+		})
+
+		r.Run(t, []string{
+			"unikraft", "instance", "edit", "test-" + instName,
+			"--output", "quiet",
+			"--set", "delete-lock=true",
+		})
+
+		out := r.Run(t, []string{"unikraft", "instance", "inspect", "test-" + instName, "-f", "+delete-lock"})
+		assert.Regexp(t, `delete-lock:\s+true`, out)
+
+		out = r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName}, integ.ExpectFail())
+		assert.Regexp(t, `(?i)deletion protection`, out)
+
+		out = r.Run(t, []string{"unikraft", "instance", "inspect", "test-" + instName})
+		assert.Regexp(t, `name:\s+test-`+instName, out)
+
+		r.Run(t, []string{
+			"unikraft", "instance", "edit", "test-" + instName,
+			"--output", "quiet",
+			"--set", "delete-lock=false",
+		})
+
+		r.Run(t, []string{"unikraft", "instance", "delete", "test-" + instName})
+
+		out = r.Run(t, []string{"unikraft", "instance", "inspect", "test-" + instName}, integ.ExpectFail())
+		assert.Regexp(t, `not found`, out)
+	})
+
 	t.Run("watch-timeout", func(t *testing.T) {
 		r := runner(t, true)
 		r.Run(t, []string{"unikraft", "--timeout=1s", "instance", "ls", "-w"}, integ.AllowFail())

--- a/cmd/unikraft/testdata/TestHelp/instances
+++ b/cmd/unikraft/testdata/TestHelp/instances
@@ -63,6 +63,7 @@ Fields:
   vsock
   template
   stop, stop.reason, stop.origin, stop.errno, stop.exit-code
+  delete-lock
 
 Global flags:
   -h, --help
@@ -128,6 +129,7 @@ Fields:
   vsock
   template
   stop, stop.reason, stop.origin, stop.errno, stop.exit-code
+  delete-lock
 
 Flags:
   -w, --watch=<duration>
@@ -201,6 +203,7 @@ Fields:
   vsock
   template
   stop, stop.reason, stop.origin, stop.errno, stop.exit-code
+  delete-lock
 
 Flags:
       --filter
@@ -276,6 +279,7 @@ Fields:
   vsock
   template
   stop, stop.reason, stop.origin, stop.errno, stop.exit-code
+  delete-lock
 
 Flags:
       --until, --filter
@@ -361,6 +365,7 @@ Fields:
   vsock
   template
   stop, stop.reason, stop.origin, stop.errno, stop.exit-code
+  delete-lock
 
 Flags:
       --set=<name>=<value>, --set-file=<name>=<filename>
@@ -512,6 +517,7 @@ Fields:
   vsock
   template
   stop, stop.reason, stop.origin, stop.errno, stop.exit-code
+  delete-lock
 
 Flags:
       --set=<name>=<value>, --set-file=<name>=<filename>
@@ -672,6 +678,7 @@ Fields:
   vsock
   template
   stop, stop.reason, stop.origin, stop.errno, stop.exit-code
+  delete-lock
 
 Flags:
       --set=<name>=<value>, --set-file=<name>=<filename>
@@ -743,6 +750,8 @@ Edit flags:
             notify-time: notification time in ms before scaling to zero
             stateful: true | false.
           [examples: on, policy=on,cooldown-time=300, policy=on,stateful=true,cooldown-time=500,notify-time=100]
+      --delete-lock
+          Prevent instance deletion until the lock is removed.
 
 $ unikraft instance delete --help
 
@@ -789,6 +798,7 @@ Fields:
   vsock
   template
   stop, stop.reason, stop.origin, stop.errno, stop.exit-code
+  delete-lock
 
 Flags:
       --all

--- a/cmd/unikraft/testdata/TestHelp/volumes
+++ b/cmd/unikraft/testdata/TestHelp/volumes
@@ -49,6 +49,7 @@ Fields:
   attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
   mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
   by.*.read-only
+  delete-lock
 
 Global flags:
   -h, --help
@@ -102,6 +103,7 @@ Fields:
   attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
   mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
   by.*.read-only
+  delete-lock
 
 Flags:
   -w, --watch=<duration>
@@ -163,6 +165,7 @@ Fields:
   attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
   mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
   by.*.read-only
+  delete-lock
 
 Flags:
       --filter
@@ -226,6 +229,7 @@ Fields:
   attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
   mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
   by.*.read-only
+  delete-lock
 
 Flags:
       --until, --filter
@@ -290,6 +294,7 @@ Fields:
   attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
   mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
   by.*.read-only
+  delete-lock
 
 Flags:
       --set=<name>=<value>, --set-file=<name>=<filename>
@@ -573,6 +578,7 @@ Fields:
   attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
   mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
   by.*.read-only
+  delete-lock
 
 Flags:
       --set=<name>=<value>, --set-file=<name>=<filename>
@@ -623,6 +629,8 @@ Edit flags:
       --quota-policy=<quota-policy>
           Volume quota policy.
           [examples: static, dynamic]
+      --delete-lock
+          Prevent volume deletion until the lock is removed.
 
 $ unikraft volume delete --help
 
@@ -657,6 +665,7 @@ Fields:
   attached-to, attached-to.*, attached-to.*.name, attached-to.*.uuid
   mounted-by, mounted-by.*, mounted-by.*.name, mounted-by.*.uuid, mounted-
   by.*.read-only
+  delete-lock
 
 Flags:
       --all

--- a/internal/cmd/instance_templates.go
+++ b/internal/cmd/instance_templates.go
@@ -79,7 +79,7 @@ type InstanceTemplate struct {
 	UUID  string          `mirror:"instance.uuid" field:",long"`
 
 	Tags       []string `mirror:"instance.tags" field:",long" edit:"set,add,del"`
-	DeleteLock bool     `mirror:"instance.delete_lock" field:"delete-lock,hidden" edit:"set"`
+	DeleteLock bool     `mirror:"instance.delete_lock" field:"delete-lock,long" edit:"set"`
 
 	State types.InstanceState             `mirror:"instance.state" field:",short"`
 	Image types.ImageRef[reference.Named] `mirror:"instance.image" field:",short"`

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -140,6 +140,8 @@ type InstanceEditCmd struct {
 	Tags []string `group:"flag-edit" shortcut:"tags" help:"Instance tags." placeholder:"tag" example:"env-prod,team-platform"`
 
 	ScaleToZero InstanceScaleToZero `group:"flag-edit" shortcut:"scale-to-zero" help:"Scale-to-zero options.\n  policy: on | idle | off\n  cooldown-time: cooldown in ms before scaling to zero\n  notify-time: notification time in ms before scaling to zero\n  stateful: true | false" placeholder:"<key>=<value>" example:"on,policy=on\\,cooldown-time=300,policy=on\\,stateful=true\\,cooldown-time=500\\,notify-time=100"`
+
+	DeleteLock *bool `group:"flag-edit" shortcut:"delete-lock" help:"Prevent instance deletion until the lock is removed."`
 }
 
 func (c *InstanceEditCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox, kctx *kong.Context) error {
@@ -216,6 +218,8 @@ type Instance struct {
 	Profile  *config.Profile   `field:"-" json:"profile"`
 
 	key multimetro.Key
+
+	DeleteLock bool `mirror:"instance.delete_lock" field:"delete-lock,long" edit:"set"`
 }
 
 type InstanceNetwork struct {
@@ -969,6 +973,8 @@ func instancePatchSpec(path string, op patchOp, value any) (platform.MutableInst
 			reqRoms = append(reqRoms, reqRom)
 		}
 		return platform.MutableInstancePropertyRoms, reqRoms, nil
+	case "delete-lock":
+		return platform.MutableInstancePropertyDeleteLock, value.(bool), nil
 	default:
 		return zero, nil, nil
 	}

--- a/internal/cmd/testdata/TestOutput/instance-templates
+++ b/internal/cmd/testdata/TestOutput/instance-templates
@@ -79,7 +79,7 @@ fra    my-template  stopped  nginx        128MiB  1
   {
     "name": "delete-lock",
     "value": false,
-    "verbosity": "hidden",
+    "verbosity": "long",
     "edit": {
       "set": false
     }

--- a/internal/cmd/testdata/TestOutput/instances
+++ b/internal/cmd/testdata/TestOutput/instances
@@ -102,6 +102,7 @@ stop:
   origin:        kernel
   errno:
   exit-code:     1
+delete-lock:     false
 
 ==================================== table =====================================
 METRO  NAME         STATE    IMAGE  ARGS              MEMORY  VCPUS  FQDN                  CREATED
@@ -789,5 +790,13 @@ fra    my-instance  running  nginx  ["arg1", "arg2"]  256MiB  2      example.uni
       }
     ],
     "verbosity": "long"
+  },
+  {
+    "name": "delete-lock",
+    "value": false,
+    "verbosity": "long",
+    "edit": {
+      "set": false
+    }
   }
 ]

--- a/internal/cmd/testdata/TestOutput/volume-templates
+++ b/internal/cmd/testdata/TestOutput/volume-templates
@@ -65,7 +65,7 @@ fra    my-vol-template  available  20MiB
   {
     "name": "delete-lock",
     "value": false,
-    "verbosity": "hidden",
+    "verbosity": "long",
     "edit": {
       "set": false
     }

--- a/internal/cmd/testdata/TestOutput/volumes
+++ b/internal/cmd/testdata/TestOutput/volumes
@@ -28,6 +28,7 @@ timestamps:
   created:    never
 attached-to:
 mounted-by:
+delete-lock:  false
 
 ==================================== table =====================================
 METRO  NAME       STATE      SIZE   CREATED
@@ -202,5 +203,13 @@ fra    my-volume  available  50MiB
       "verbosity": "long"
     },
     "verbosity": "long"
+  },
+  {
+    "name": "delete-lock",
+    "value": false,
+    "verbosity": "long",
+    "edit": {
+      "set": false
+    }
   }
 ]

--- a/internal/cmd/volume_templates.go
+++ b/internal/cmd/volume_templates.go
@@ -78,7 +78,7 @@ type VolumeTemplate struct {
 	UUID  string          `mirror:"volume.uuid" field:",long"`
 
 	Tags       []string `mirror:"volume.tags" field:",long" edit:"set,add,del"`
-	DeleteLock bool     `mirror:"volume.delete_lock" field:"delete-lock,hidden" edit:"set"`
+	DeleteLock bool     `mirror:"volume.delete_lock" field:"delete-lock,long" edit:"set"`
 
 	State      types.VolumeState   `mirror:"volume.state" field:",short"`
 	Size       types.SizeMebibytes `mirror:"volume.size_mb" field:",short"`

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -91,6 +91,7 @@ type VolumeEditCmd struct {
 	Size        types.SizeMebibytes `group:"flag-edit" shortcut:"size" help:"Volume size." placeholder:"size" example:"20GiB,100MiB"`
 	Tags        []string            `group:"flag-edit" shortcut:"tags" help:"Volume tags." placeholder:"tag" example:"env-prod,team-platform"`
 	QuotaPolicy string              `group:"flag-edit" shortcut:"quota-policy" help:"Volume quota policy." placeholder:"quota-policy" example:"static,dynamic"`
+	DeleteLock  *bool               `group:"flag-edit" shortcut:"delete-lock" help:"Prevent volume deletion until the lock is removed."`
 }
 
 func (c *VolumeEditCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *resource.Sandbox, kctx *kong.Context) error {
@@ -272,6 +273,8 @@ type Volume struct {
 	Volume platform.Volume `field:"-" json:"volume"`
 
 	key multimetro.Key
+
+	DeleteLock bool `mirror:"volume.delete_lock" field:"delete-lock,long" edit:"set"`
 }
 
 func (Volume) Type() resource.Type {
@@ -588,6 +591,8 @@ func volumePatchSpec(path string, _ patchOp, value any) (platform.MutableVolumeP
 		return platform.MutableVolumePropertySizeMb, int64(value.(types.SizeMebibytes)), nil
 	case "quota-policy":
 		return platform.MutableVolumePropertyQuotaPolicy, value.(string), nil
+	case "delete-lock":
+		return platform.MutableVolumePropertyDeleteLock, value.(bool), nil
 	default:
 		return zero, nil, nil
 	}


### PR DESCRIPTION
This PR exposes delete locks as flags in the CLI
Linear ticket: TOOL-670

The SDK and proto definitions are all up to date, but the flag was missing in the CLI

Delete locks have been added for instances and volumes

enable delete lock by editing a stopped instance
unikraft instances edit --delete-lock=true nginx-29ws0

<img width="935" height="200" alt="image" src="https://github.com/user-attachments/assets/897a0cf1-86dd-4c6b-9e1b-3d9a2fb10049" />
