### PR TITLE
ci: Fix mirroring permissions

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -19,6 +19,7 @@ jobs:
       uses: actions/checkout@v7
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Fetch all tags
       shell: bash


### PR DESCRIPTION
Follow-up to https://github.com/unikraft-cloud/cli/pull/404.