### PR TITLE
feat(config): Add option to use profile from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,15 +171,10 @@ profiles:
         insecure: false # skip tls verification (avoid for production use)
 ```
 
-You can also easily migrate your old `UKC_METRO`/`UKC_TOKEN` environment variable setup to a profile:
+You can also use your old, already set, `UKC_METRO`/`UKC_TOKEN` by setting also this variable:
 
-```yaml
-# Linux: ~/.config/unikraft/config.yaml
-# MacOS: ~/Library/Application\ Support/unikraft/config.yaml
-profile: default
-profiles:
-  default:
-    type: legacy
+```sh
+export UNIKRAFT_PROFILE_ENV="true"
 ```
 
 ### 2. Deploy Your First Instance
@@ -279,13 +274,17 @@ The CLI stores configuration in `~/.config/unikraft/config.yaml` (or the path sp
 
 ### Environment Variables
 
-| Variable             | Description                                                        |
-| -------------------- | ------------------------------------------------------------------ |
-| `UNIKRAFT_CONFIG`    | Path to the configuration file                                     |
-| `UNIKRAFT_PROFILE`   | Override the current profile                                       |
-| `UNIKRAFT_LOG_LEVEL` | Set log level (`trace`, `debug`, `info`, `warn`, `error`, `fatal`) |
-| `UNIKRAFT_LOG_TYPE`  | Set output format (`text`, `json`)                                 |
-| `UNIKRAFT_TELEMETRY` | Enable/disable anonymous telemetry (`true`, `false`)               |
+| Variable                | Description                                                                                          |
+| ----------------------- | ---------------------------------------------------------------------------------------------------- |
+| `UNIKRAFT_CONFIG`       | Path to the configuration file                                                                       |
+| `UNIKRAFT_PROFILE`      | Override the current profile                                                                         |
+| `UNIKRAFT_PROFILE_ENV`  | Use a virtual profile from `UKC_*` env vars instead of config (`true`, `false`)                      |
+| `UNIKRAFT_LOG_LEVEL`    | Set log level (`trace`, `debug`, `info`, `warn`, `error`, `fatal`)                                   |
+| `UNIKRAFT_LOG_TYPE`     | Set output format (`text`, `json`)                                                                   |
+| `UNIKRAFT_TELEMETRY`    | Enable/disable anonymous telemetry (`true`, `false`)                                                 |
+| `UKC_TOKEN`             | API token for legacy profiles / `UNIKRAFT_PROFILE_ENV`                                               |
+| `UKC_METRO`             | Metro name (e.g. `fra`) or full endpoint URL for legacy profiles / `UNIKRAFT_PROFILE_ENV`            |
+| `UKC_ALLOW_INSECURE`    | Skip TLS verification for the metro from `UKC_METRO` (`true`, `false`)                               |
 
 ### Profiles
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -230,6 +230,100 @@ profiles:
 	assert.Contains(t, content, "type: legacy")
 }
 
+func TestEnvProfile(t *testing.T) {
+	tests := []struct {
+		name             string
+		profileEnv       string
+		metroEnv         string
+		expectedName     string
+		expectedEndpoint string
+	}{
+		{
+			name:             "truthy with full URL",
+			profileEnv:       "true",
+			metroEnv:         "https://api.fra.unikraft.cloud/v1",
+			expectedName:     "fra",
+			expectedEndpoint: "https://api.fra.unikraft.cloud",
+		},
+		{
+			name:             "truthy with short name",
+			profileEnv:       "1",
+			metroEnv:         "fra",
+			expectedName:     "fra",
+			expectedEndpoint: "https://api.fra.unikraft.cloud",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("UNIKRAFT_PROFILE_ENV", tt.profileEnv)
+			t.Setenv("UKC_METRO", tt.metroEnv)
+			t.Setenv("UKC_TOKEN", "env-token")
+
+			// No config file is needed; the virtual profile bypasses it.
+			config := &Config{}
+			profile, err := config.CurrentProfile()
+			require.NoError(t, err)
+
+			assert.Equal(t, EnvProfile, profile.Name)
+			assert.Equal(t, ProfileTypeLegacy, profile.Type)
+			assert.Equal(t, "env-token", profile.Token)
+			require.Len(t, profile.Metros, 1)
+			assert.Equal(t, tt.expectedName, profile.Metros[0].Name)
+			assert.Equal(t, tt.expectedEndpoint, profile.Metros[0].Endpoint)
+		})
+	}
+}
+
+func TestEnvProfileDisabled(t *testing.T) {
+	// Unset / falsy values must not synthesize a virtual profile.
+	for _, val := range []string{"", "false", "0", "no", "not-a-bool"} {
+		name := val
+		if name == "" {
+			name = "unset"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			if val != "" {
+				t.Setenv("UNIKRAFT_PROFILE_ENV", val)
+			}
+			t.Setenv("UKC_TOKEN", "env-token")
+
+			config := &Config{}
+			_, err := config.CurrentProfile()
+			assert.ErrorIs(t, err, ErrNotSetup)
+		})
+	}
+}
+
+func TestEnvProfileBypassesConfigFile(t *testing.T) {
+	// When enabled, the env-derived profile takes precedence over on-disk profiles.
+	t.Setenv("UNIKRAFT_PROFILE_ENV", "true")
+	t.Setenv("UKC_METRO", "fra")
+	t.Setenv("UKC_TOKEN", "env-token")
+
+	root := t.TempDir()
+	path := filepath.Join(root, "config.yaml")
+	input := strings.TrimSpace(`
+profile: default
+profiles:
+  default:
+    type: cloud
+    token: on-disk-token
+`) + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(input), 0o600))
+
+	config, err := Load(path)
+	require.NoError(t, err)
+
+	profile, err := config.CurrentProfile()
+	require.NoError(t, err)
+	assert.Equal(t, EnvProfile, profile.Name)
+	assert.Equal(t, EnvProfile, config.CurrentProfileName())
+	assert.Equal(t, "env-token", profile.Token)
+	assert.Equal(t, ProfileTypeLegacy, profile.Type)
+}
+
 func TestProfile_GetDefaultMetro(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -23,6 +23,11 @@ import (
 // any profiles yet.
 const DefaultProfile = "default"
 
+// EnvProfile is the name of the virtual profile created from the environment
+// variables UKC_TOKEN and UKC_METRO. It is used when the UNIKRAFT_PROFILE_ENV
+// environment variable is set to true.
+const EnvProfile = "env"
+
 // ErrNotSetup is returned when there are no profiles available in the
 // configuration.
 var ErrNotSetup = jujuerrors.New(heredoc.Docf(`
@@ -90,38 +95,50 @@ func (p Profile) GetDefaultMetro() string {
 
 func (p *Profile) populate() {
 	if p.Type == ProfileTypeLegacy {
-		np := Profile{
-			Name:  p.Name,
-			Type:  ProfileTypeLegacy,
-			Token: os.Getenv("UKC_TOKEN"),
-		}
+		*p = profileFromEnv(p.Name)
+	}
+}
 
-		endpoint := os.Getenv("UKC_METRO")
-		if endpoint != "" {
-			var name string
-			if strings.Contains(endpoint, "://") {
-				_, host, _ := strings.Cut(endpoint, "://")
-				host = strings.TrimPrefix(host, "api.")
-				name, _, _ = strings.Cut(host, ".")
-				endpoint = strings.TrimSuffix(strings.TrimSuffix(endpoint, "/"), "/v1")
-			} else {
-				name = endpoint
-				endpoint = fmt.Sprintf("https://api.%s.unikraft.cloud", endpoint)
-			}
+// profileFromEnv constructs a Profile from the UKC_TOKEN and UKC_METRO
+// environment variables. It is used both to hydrate legacy profiles from the
+// environment and to create a virtual profile when UNIKRAFT_PROFILE_ENV is set.
+func profileFromEnv(name string) Profile {
+	p := Profile{
+		Name:  name,
+		Type:  ProfileTypeLegacy,
+		Token: os.Getenv("UKC_TOKEN"),
+	}
 
-			var insecure *bool
-			if v := os.Getenv("UKC_ALLOW_INSECURE"); v != "" {
-				b, _ := strconv.ParseBool(v)
-				insecure = &b
-			}
-			metro := Metro{
-				Name:     name,
-				Endpoint: endpoint,
-				Insecure: insecure,
-			}
-			np.Metros = []Metro{metro}
+	if raw := os.Getenv("UKC_METRO"); raw != "" {
+		p.Metros = []Metro{metroFromEnv(raw)}
+	}
+	return p
+}
+
+// metroFromEnv parses the UKC_METRO environment variable into a Metro.
+func metroFromEnv(raw string) Metro {
+	endpoint := raw
+	var name string
+	if strings.Contains(endpoint, "://") {
+		_, host, _ := strings.Cut(endpoint, "://")
+		host = strings.TrimPrefix(host, "api.")
+		name, _, _ = strings.Cut(host, ".")
+		endpoint = strings.TrimSuffix(strings.TrimSuffix(endpoint, "/"), "/v1")
+	} else {
+		name = endpoint
+		endpoint = fmt.Sprintf("https://api.%s.unikraft.cloud", endpoint)
+	}
+
+	var insecure *bool
+	if v := os.Getenv("UKC_ALLOW_INSECURE"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			insecure = &b
 		}
-		*p = np
+	}
+	return Metro{
+		Name:     name,
+		Endpoint: endpoint,
+		Insecure: insecure,
 	}
 }
 
@@ -202,6 +219,11 @@ func (config *Config) ProfileList() []Profile {
 // CurrentProfile returns the currently selected profile from the configuration.
 // If the profile does not exist, it returns an error.
 func (config *Config) CurrentProfile() (*Profile, error) {
+	if b, _ := strconv.ParseBool(os.Getenv("UNIKRAFT_PROFILE_ENV")); b {
+		p := profileFromEnv(EnvProfile)
+		return &p, nil
+	}
+
 	if config == nil {
 		return nil, ErrNotSetup
 	}
@@ -218,6 +240,9 @@ func (config *Config) CurrentProfile() (*Profile, error) {
 }
 
 func (config *Config) CurrentProfileName() string {
+	if b, _ := strconv.ParseBool(os.Getenv("UNIKRAFT_PROFILE_ENV")); b {
+		return EnvProfile
+	}
 	if config == nil {
 		return DefaultProfile
 	}


### PR DESCRIPTION
Reads four new environmental variables:
- UNIKRAFT_PROFILE_ENV=true/false
- UKC_TOKEN=\<string>
- UKC_METRO=\<string>
- UKC_ALLOW_INSECURE=true/false

Closes: TOOL-1163