### PR TITLE
feat(cmd): Add command to unpack rootfses

### DIFF
--- a/cmd/unikraft/integration/image_test.go
+++ b/cmd/unikraft/integration/image_test.go
@@ -7,9 +7,15 @@ package integration
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/containerd/continuity/fs/fstest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	integ "unikraft.com/cli/internal/integration"
 )
 
 func TestImages(t *testing.T) {
@@ -37,5 +43,67 @@ func TestImages(t *testing.T) {
 		assert.Regexp(t, `kernel:`, out)
 		assert.Regexp(t, `kernel.dbg:`, out)
 		r.Run(t, []string{"unikraft", "image", "delete", imageFull})
+	})
+
+	// unpack exercises image unpack across both supported rootfs formats
+	// (CPIO and EROFS). A known image is built with deterministic rootfs
+	// content, then unpacked to a directory whose tree is asserted on disk.
+	t.Run("unpack", func(t *testing.T) {
+		for _, format := range []string{"cpio", "erofs"} {
+			t.Run(format, func(t *testing.T) {
+				r := runner(t, true, []string{staging, stable})
+
+				imageTag := uniq()
+				imagePrefix := r.Config.Profile.Organization + "/unpack-" + format + "-e2e"
+				image := imagePrefix + ":" + imageTag
+
+				// Build an image whose rootfs carries a known directory tree,
+				// a regular file, and a symlink.
+				dir := t.TempDir()
+				require.NoError(t, fstest.Apply(
+					fstest.CreateFile("Dockerfile", []byte(`FROM busybox:latest
+RUN mkdir -p /app/sub && echo "unpack-e2e" > /app/hello.txt \
+	&& echo "nested" > /app/sub/nested.txt \
+	&& ln -s hello.txt /app/link.txt
+`), 0o644),
+					fstest.CreateFile("Kraftfile", []byte(fmt.Sprintf(`
+spec: v0.7
+name: unpack-%s-e2e
+runtime: base-compat:latest
+rootfs:
+  format: %s
+  source: ./Dockerfile
+cmd: ["sh"]
+`, format, format)), 0o644),
+				).Apply(dir))
+
+				r.Run(t, []string{"unikraft", "build", ".", "--output", image}, integ.WithWorkDir(dir))
+
+				// Unpack the freshly built image into a temp directory.
+				outDir := t.TempDir()
+				r.Run(t, []string{"unikraft", "image", "unpack", image, outDir})
+
+				// Regular file content round-trips intact.
+				got, err := os.ReadFile(filepath.Join(outDir, "app/hello.txt"))
+				require.NoError(t, err)
+				assert.Equal(t, "unpack-e2e\n", string(got))
+
+				gotNested, err := os.ReadFile(filepath.Join(outDir, "app/sub/nested.txt"))
+				require.NoError(t, err)
+				assert.Equal(t, "nested\n", string(gotNested))
+
+				// Nested directory exists.
+				fi, err := os.Stat(filepath.Join(outDir, "app/sub"))
+				require.NoError(t, err)
+				assert.True(t, fi.IsDir())
+
+				// Symlink target preserved.
+				gotLink, err := os.Readlink(filepath.Join(outDir, "app/link.txt"))
+				require.NoError(t, err)
+				assert.Equal(t, "hello.txt", gotLink)
+
+				r.Run(t, []string{"unikraft", "image", "delete", image})
+			})
+		}
 	})
 }

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -43,6 +43,7 @@ type ImagesCmd struct {
 	Get    ImagesGetCmd    `cmd:"" help:"Inspect an image." aliases:"inspect,show"`
 	Delete ImagesDeleteCmd `cmd:"" help:"Remove an image." aliases:"rm,remove"`
 	Copy   ImagesCopyCmd   `cmd:"" help:"Copy images."`
+	Unpack ImagesUnpackCmd `cmd:"" help:"Download an image and unpack its rootfs to a directory." hidden:""`
 }
 
 type Image struct {

--- a/internal/cmd/images_unpack.go
+++ b/internal/cmd/images_unpack.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/containerd/platforms"
+	goerofs "github.com/unikraft/go-archivefs/erofs"
+	gocpio "github.com/unikraft/go-cpio"
+	imagespec "unikraft.com/x/image-spec"
+	"unikraft.com/x/log"
+
+	"unikraft.com/cli/internal/images"
+)
+
+// ImagesUnpackCmd downloads an image from a source reference and unpacks its
+// rootfs (initrd) into a directory. It is intentionally hidden from the help
+// output while the feature is still experimental.
+type ImagesUnpackCmd struct {
+	Source   string   `arg:"" help:"Source image reference (registry, OCI archive, or OCI layout directory)."`
+	Dest     string   `arg:"" help:"Destination directory to extract the rootfs into."`
+	Insecure []string `help:"Allow insecure (HTTP/unverified TLS) connections to registries. Specify hostnames to restrict, or omit to apply to all." type:"optional"`
+}
+
+func (cmd ImagesUnpackCmd) Run(ctx context.Context) error {
+	var opts []images.AccessorOpt
+	if cmd.Insecure != nil {
+		if len(cmd.Insecure) > 0 {
+			opts = append(opts, images.WithInsecureRegistry(cmd.Insecure...))
+		} else {
+			opts = append(opts, images.WithInsecureRegistries())
+		}
+	}
+
+	access, err := images.Accessor(ctx, opts...)
+	if err != nil {
+		return err
+	}
+
+	src, err := imagespec.GuessURI(cmd.Source)
+	if err != nil {
+		return fmt.Errorf("parsing source image reference: %w", err)
+	}
+
+	imgs, err := access.LoadAll(ctx, src, platforms.All)
+	if err != nil {
+		return fmt.Errorf("loading image from source: %w", err)
+	}
+	defer func() {
+		for _, img := range imgs {
+			img.Close()
+		}
+	}()
+
+	if len(imgs) == 0 {
+		return fmt.Errorf("no images found at %q", cmd.Source)
+	}
+	img := imgs[0]
+	if img.Initrd == nil {
+		return fmt.Errorf("image %q has no rootfs (initrd)", cmd.Source)
+	}
+
+	if err := os.MkdirAll(cmd.Dest, 0o755); err != nil {
+		return fmt.Errorf("creating destination directory: %w", err)
+	}
+
+	rc, _, err := img.Initrd.Open(ctx)
+	if err != nil {
+		return fmt.Errorf("opening rootfs: %w", err)
+	}
+	defer rc.Close()
+
+	br := bufio.NewReader(rc)
+	need := goerofs.SuperBlockOffset + 4
+	peeked, err := br.Peek(need)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, bufio.ErrBufferFull) {
+		return fmt.Errorf("reading rootfs: %w", err)
+	}
+
+	switch {
+	case len(peeked) >= 6 && gocpio.IsValid(bytes.NewReader(peeked)):
+		// CPIO can be unpacked straight from the stream.
+		if err := gocpio.Unpack(br, cmd.Dest); err != nil {
+			return fmt.Errorf("unpacking rootfs (CPIO): %w", err)
+		}
+	case len(peeked) >= need &&
+		goerofs.IsValid(bytes.NewReader(peeked[goerofs.SuperBlockOffset:])):
+		// EROFS needs random access, so spill the stream to a temp file first.
+		if err := unpackEROFSStream(br, cmd.Dest); err != nil {
+			return fmt.Errorf("unpacking rootfs (EROFS): %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported rootfs format (expected CPIO or EROFS)")
+	}
+
+	log.G(ctx).Info().
+		Str("source", cmd.Source).
+		Str("dest", cmd.Dest).
+		Msg("unpacked rootfs")
+	return nil
+}
+
+// unpackEROFSStream spills r into a temporary file (EROFS needs io.ReaderAt),
+// then unpacks it via goerofs.Unpack and removes the temp file.
+func unpackEROFSStream(r io.Reader, dest string) (rerr error) {
+	tmp, err := os.CreateTemp("", "unikraft-unpack-erofs-*.img")
+	if err != nil {
+		return fmt.Errorf("creating temporary file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { rerr = errors.Join(rerr, os.Remove(tmpPath)) }()
+
+	if _, err := io.Copy(tmp, r); err != nil {
+		tmp.Close()
+		return fmt.Errorf("reading rootfs: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("writing rootfs: %w", err)
+	}
+
+	f, err := os.Open(tmpPath)
+	if err != nil {
+		return fmt.Errorf("reopening rootfs: %w", err)
+	}
+	defer f.Close()
+
+	return goerofs.Unpack(f, dest)
+}


### PR DESCRIPTION
Currently blocked on these, so in draft:
https://github.com/unikraft/go-archivefs/pull/10
https://github.com/unikraft/go-cpio/pull/2

erofs one worth discussing if it can be done cleaner

Closes: TOOL-1029