### PR TITLE
fix(config): Strip urls only if fully qualified

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -71,6 +71,18 @@ func TestLegacyProfileParsing(t *testing.T) {
 			expectedEndpoint: "https://api.fra.unikraft.cloud",
 		},
 		{
+			name:             "full URL with trailing slash",
+			metroEnv:         "https://api.fra.unikraft.cloud/v1/",
+			expectedName:     "fra",
+			expectedEndpoint: "https://api.fra.unikraft.cloud",
+		},
+		{
+			name:             "local proxy URL",
+			metroEnv:         "http://localhost:8080/v1",
+			expectedName:     "localhost:8080",
+			expectedEndpoint: "http://localhost:8080",
+		},
+		{
 			name:             "short name",
 			metroEnv:         "fra",
 			expectedName:     "fra",
@@ -244,6 +256,13 @@ func TestEnvProfile(t *testing.T) {
 			metroEnv:         "https://api.fra.unikraft.cloud/v1",
 			expectedName:     "fra",
 			expectedEndpoint: "https://api.fra.unikraft.cloud",
+		},
+		{
+			name:             "truthy with local proxy URL",
+			profileEnv:       "true",
+			metroEnv:         "http://localhost:8080/v1",
+			expectedName:     "localhost:8080",
+			expectedEndpoint: "http://localhost:8080",
 		},
 		{
 			name:             "truthy with short name",

--- a/internal/config/profile.go
+++ b/internal/config/profile.go
@@ -117,16 +117,14 @@ func profileFromEnv(name string) Profile {
 
 // metroFromEnv parses the UKC_METRO environment variable into a Metro.
 func metroFromEnv(raw string) Metro {
-	endpoint := raw
-	var name string
-	if strings.Contains(endpoint, "://") {
-		_, host, _ := strings.Cut(endpoint, "://")
-		host = strings.TrimPrefix(host, "api.")
-		name, _, _ = strings.Cut(host, ".")
-		endpoint = strings.TrimSuffix(strings.TrimSuffix(endpoint, "/"), "/v1")
+	var name, endpoint string
+	if u, err := url.Parse(raw); err == nil && u.IsAbs() && u.Host != "" {
+		u.Path = strings.TrimSuffix(strings.TrimSuffix(u.Path, "/"), "/v1")
+		name, _, _ = strings.Cut(strings.TrimPrefix(u.Host, "api."), ".")
+		endpoint = u.String()
 	} else {
-		name = endpoint
-		endpoint = fmt.Sprintf("https://api.%s.unikraft.cloud", endpoint)
+		name = raw
+		endpoint = fmt.Sprintf("https://api.%s.unikraft.cloud", raw)
 	}
 
 	var insecure *bool


### PR DESCRIPTION
So if you look at the parse it used string parsing. This means that the `/v1` suffix stayed in the host variable aka the name of the node.

Or maybe you like the AI explanation better:
```
URL parser derived name before removing /v1 → client registered as localhost:8080/v1; resource requests select localhost:8080 → missing client.
```

Closes: TOOL-1140