### PR TITLE
fix(integration): Stop using deprecated --data flag in api test

### DIFF
--- a/cmd/unikraft/integration/api_test.go
+++ b/cmd/unikraft/integration/api_test.go
@@ -69,14 +69,14 @@ func TestAPI(t *testing.T) {
 			"--metro=" + r.Config.MetroName,
 			"/v1/volumes",
 			"--method", "DELETE",
-			"--data", string(deletePayload),
+			string(deletePayload),
 		}
 
 		out := r.Run(t, []string{
 			"unikraft", "api",
 			"--metro=" + r.Config.MetroName,
 			"/v1/volumes",
-			"--data", "@" + payloadPath,
+			"@" + payloadPath,
 		})
 		t.Cleanup(func() {
 			out, err := r.RunRaw(t, deleteArgs, integ.WithoutCancel())


### PR DESCRIPTION
## Summary
- PR #389 deprecated `-d`/`--data` on the `api` command in favor of positional arguments, and logs a warning via `log.Warn()` (stderr) whenever the deprecated flag is used.
- The integration test harness (`internal/integration/env.go`) merges a command's stdout and stderr into a single buffer, so that warning corrupts the JSON payload the `volume from data file` subtest asserts is valid, since it still invokes `api` with `--data`.
- This breaks `TestAPI/volume_from_data_file` on staging CI (self-inflicted by #389, reproducible on `prod-staging` HEAD independent of any other PR — see run https://github.com/unikraft-cloud/cli/actions/runs/31517275398/job/93865785980).
- Switches both invocations in that subtest to the new positional-argument body syntax, avoiding the deprecation warning entirely.

## Test plan
- [x] `go vet ./cmd/unikraft/integration/...` passes
- [x] CI integration (STAGING) job passes for `TestAPI/volume_from_data_file`