### PR TITLE
fix(tools/gendocs): Correctly escape mdx

### DIFF
--- a/tools/gendocs/mdx.go
+++ b/tools/gendocs/mdx.go
@@ -85,12 +85,12 @@ func generateMarkdown(ctx context.Context, node *kong.Node, dir string) error {
 
 	if node.Parent == nil {
 		if help != "" {
-			buf.WriteString(help + "\n\n")
+			buf.WriteString(escapeMdx(help) + "\n\n")
 		}
 	} else if node.Detail != "" {
-		buf.WriteString(node.Detail + "\n\n")
+		buf.WriteString(escapeMdx(node.Detail) + "\n\n")
 	} else if help != "" {
-		buf.WriteString(help + "\n\n")
+		buf.WriteString(escapeMdx(help) + "\n\n")
 	}
 
 	if IsRunnable(node) {
@@ -125,7 +125,7 @@ func generateMarkdown(ctx context.Context, node *kong.Node, dir string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(buf, "* [`%s`](%s): %s\n", relatedName, link, related.Help)
+		fmt.Fprintf(buf, "* [`%s`](%s): %s\n", relatedName, link, escapeMdx(related.Help))
 	}
 	if hasSeeAlso {
 		buf.WriteString("\n")
@@ -169,7 +169,7 @@ func printDocsExamples(buf *bytes.Buffer, node *kong.Node) {
 	buf.WriteString("## Examples\n\n")
 	for _, example := range examples {
 		if example.Description != "" {
-			buf.WriteString(example.Description + ":\n\n")
+			buf.WriteString(escapeMdx(example.Description) + ":\n\n")
 		}
 		buf.WriteString("```bash\n")
 		buf.WriteString(formatExampleCommands(example))

--- a/tools/gendocs/mdx_escape.go
+++ b/tools/gendocs/mdx_escape.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package main
+
+import "strings"
+
+// escapeMdx escapes '<' and '{'/'}' in prose so MDX doesn't parse them as
+// JSX, leaving fenced code blocks and inline code spans untouched.
+func escapeMdx(text string) string {
+	lines := strings.Split(text, "\n")
+	fence := ""
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if fence != "" {
+			if closesFence(trimmed, fence) {
+				fence = ""
+			}
+			continue
+		}
+		if f := opensFence(trimmed); f != "" {
+			fence = f
+			continue
+		}
+		lines[i] = escapeMdxLine(line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+// opensFence returns the fence delimiter if trimmed opens a code block.
+func opensFence(trimmed string) string {
+	for _, ch := range []byte{'`', '~'} {
+		n := 0
+		for n < len(trimmed) && trimmed[n] == ch {
+			n++
+		}
+		if n >= 3 {
+			return trimmed[:n]
+		}
+	}
+	return ""
+}
+
+// closesFence reports whether trimmed closes the given fence.
+func closesFence(trimmed, fence string) bool {
+	ch := fence[0]
+	n := 0
+	for n < len(trimmed) && trimmed[n] == ch {
+		n++
+	}
+	return n == len(trimmed) && n >= len(fence)
+}
+
+// escapeMdxLine escapes a single line, skipping over inline code spans.
+func escapeMdxLine(line string) string {
+	var out strings.Builder
+	for i := 0; i < len(line); {
+		c := line[i]
+		if c == '`' {
+			j := i
+			for j < len(line) && line[j] == '`' {
+				j++
+			}
+			delim := line[i:j]
+			if end := strings.Index(line[j:], delim); end != -1 {
+				out.WriteString(line[i : j+end+len(delim)])
+				i = j + end + len(delim)
+				continue
+			}
+		}
+		if c == '<' || c == '{' || c == '}' {
+			out.WriteByte('\\')
+		}
+		out.WriteByte(c)
+		i++
+	}
+	return out.String()
+}

--- a/tools/gendocs/mdx_escape_test.go
+++ b/tools/gendocs/mdx_escape_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEscapeMdx(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "plain text is untouched",
+			in:   "no special characters here",
+			want: "no special characters here",
+		},
+		{
+			name: "angle brackets are escaped",
+			in:   "Forward local port to <INSTANCE>:DEST_PORT.",
+			want: `Forward local port to \<INSTANCE>:DEST_PORT.`,
+		},
+		{
+			name: "curly braces are escaped",
+			in:   `Produces: {"user":{"name":"Alice"}}`,
+			want: `Produces: \{"user":\{"name":"Alice"\}\}`,
+		},
+		{
+			name: "inline code spans are left verbatim",
+			in:   "Use `<endpoint>` or `{key: value}` on the command line.",
+			want: "Use `<endpoint>` or `{key: value}` on the command line.",
+		},
+		{
+			name: "mixed prose and inline code on one line",
+			in:   "A <bad> tag next to `<ok>` code.",
+			want: `A \<bad> tag next to ` + "`<ok>`" + " code.",
+		},
+		{
+			name: "fenced code blocks are left verbatim",
+			in:   "before\n```\n<raw> {raw}\n```\nafter <bad> {bad}",
+			want: "before\n```\n<raw> {raw}\n```\nafter \\<bad> \\{bad\\}",
+		},
+		{
+			name: "tilde fences are also respected",
+			in:   "~~~\n<raw>\n~~~\n<bad>",
+			want: "~~~\n<raw>\n~~~\n\\<bad>",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, escapeMdx(tc.in))
+		})
+	}
+}


### PR DESCRIPTION
See the thread here: https://github.com/unikraft-cloud/docs/pull/252#discussion_r3766794234.

We should fix the CLI not to generate invalid mdx.