### PR TITLE
fix(build)!: Remove default target

### DIFF
--- a/cmd/unikraft/integration/build_test.go
+++ b/cmd/unikraft/integration/build_test.go
@@ -71,7 +71,7 @@ roms:
 			).Apply(dir))
 
 			r.Run(t, []string{"unikraft", "build", "base", "--output", baseImage}, integ.WithWorkDir(dir))
-			r.Run(t, []string{"unikraft", "build", "rom", "--output", romImage}, integ.WithWorkDir(dir))
+			r.Run(t, []string{"unikraft", "build", "rom", "--arch", "x86_64", "--output", romImage}, integ.WithWorkDir(dir))
 			r.Run(t, []string{"unikraft", "run", "--name", "test-" + instName, "--metro", r.Config.MetroName, "--output", "quiet", "--image", baseImage, "--rom", romFlag})
 			r.Run(t, []string{"unikraft", "--timeout", "10s", "instance", "wait", "--until", "state==stopped", "test-" + instName})
 

--- a/cmd/unikraft/testdata/TestHelp/build
+++ b/cmd/unikraft/testdata/TestHelp/build
@@ -33,7 +33,8 @@ Flags:
   -o, --output
           Output destination.
       --arch
-          Only build the Kraftfile targets of these architectures (x86_64, arm64). Defaults to every target, or x86_64 when none are declared.
+          Only build the Kraftfile targets of these architectures. Defaults to every declared target; required when none are declared.
+          [examples: x86_64, arm64]
       --build-arg
           Set build-time variables.
       --no-cache

--- a/cmd/unikraft/testdata/TestHelp/images
+++ b/cmd/unikraft/testdata/TestHelp/images
@@ -77,7 +77,8 @@ Flags:
   -o, --output
           Output destination.
       --arch
-          Only build the Kraftfile targets of these architectures (x86_64, arm64). Defaults to every target, or x86_64 when none are declared.
+          Only build the Kraftfile targets of these architectures. Defaults to every declared target; required when none are declared.
+          [examples: x86_64, arm64]
       --build-arg
           Set build-time variables.
       --no-cache

--- a/internal/builder/build.go
+++ b/internal/builder/build.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/containerd/platforms"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"unikraft.com/x/image-spec"
+	imagespec "unikraft.com/x/image-spec"
 	"unikraft.com/x/kraftfile"
 	"unikraft.com/x/log"
 
@@ -52,10 +52,6 @@ type FSOpts struct {
 	Pad        int64 // pad file to specified size
 	Compress   bool
 	KeepOwners bool
-}
-
-var DefaultPlatform = ocispec.Platform{
-	Architecture: imagespec.ArchitectureIntel, OS: imagespec.PlatformKraftcloud,
 }
 
 func (o *BuildOpts) FilterArch(arches ...string) error {
@@ -155,12 +151,8 @@ func Build(ctx context.Context, opts BuildOpts) ([]*imagespec.Image, error) {
 		}
 	}
 
-	// Without a kernel, use a default platform if none specified.
 	if len(opts.Platform) == 0 {
-		log.G(ctx).Info().
-			Str("platform", platforms.Format(DefaultPlatform)).
-			Msg("no target specified, using default platform")
-		opts.Platform = []ocispec.Platform{DefaultPlatform}
+		return nil, fmt.Errorf("no platform targets specified")
 	}
 
 	// Build ROMs if any are specified.

--- a/internal/builder/rootfs.go
+++ b/internal/builder/rootfs.go
@@ -107,16 +107,6 @@ func DetectSourceType(path string) (kraftfile.SourceType, error) {
 }
 
 func BuildRoms(ctx context.Context, opts BuildOpts) (_ [][]imagespec.File, rerr error) {
-	plats := opts.Platform
-	if len(plats) == 0 {
-		log.G(ctx).
-			Debug().
-			Str("platform", platforms.Format(DefaultPlatform)).
-			Msg("no platform specified for roms, using default")
-
-		plats = []ocispec.Platform{DefaultPlatform}
-	}
-
 	var romFiles [][]imagespec.File
 
 	// Release anything already built if a later ROM fails.
@@ -141,8 +131,8 @@ func BuildRoms(ctx context.Context, opts BuildOpts) (_ [][]imagespec.File, rerr 
 				Format: cmp.Or(rom.Format, kraftfile.FsTypeErofs),
 				Pad:    rom.Pad,
 			},
-			Platform: plats,
 			// propagate BuildKit options from the parent build
+			Platform: opts.Platform,
 			BuildArg: opts.BuildArg,
 			Target:   opts.Target,
 			Secrets:  opts.Secrets,
@@ -154,16 +144,16 @@ func BuildRoms(ctx context.Context, opts BuildOpts) (_ [][]imagespec.File, rerr 
 		if err != nil {
 			return nil, fmt.Errorf("building rom from %q: %w", rom.Path, err)
 		}
-		if len(imgs) != len(plats) {
+		if len(imgs) != len(opts.Platform) {
 			return nil, fmt.Errorf("rom build from %q produced %d images for %d platforms",
-				rom.Path, len(imgs), len(plats))
+				rom.Path, len(imgs), len(opts.Platform))
 		}
 
 		perPlat := make([]imagespec.File, len(imgs))
 		for i, img := range imgs {
 			if img.Initrd == nil {
 				return nil, fmt.Errorf("rom build from %q produced no output for platform %s",
-					rom.Path, platforms.Format(plats[i]))
+					rom.Path, platforms.Format(opts.Platform[i]))
 			}
 			perPlat[i] = img.Initrd
 			img.Initrd = nil // detach so Close doesn't close it

--- a/internal/builder/rootfs_test.go
+++ b/internal/builder/rootfs_test.go
@@ -484,6 +484,7 @@ func TestRomDefaultFormat(t *testing.T) {
 				// Format intentionally omitted; should default to erofs.
 			},
 		},
+		Platform: []ocispec.Platform{{OS: "fc", Architecture: "x86_64"}},
 	})
 	require.NoError(t, err)
 	require.Len(t, romFiles, 1)

--- a/internal/cmd/build.go
+++ b/internal/cmd/build.go
@@ -25,7 +25,7 @@ import (
 type ImageBuildCmd struct {
 	Input  string   `arg:"" default:"." help:"Path to the input directory."`
 	Output string   `short:"o" help:"Output destination"`
-	Arch   []string `help:"Only build the Kraftfile targets of these architectures (x86_64, arm64). Defaults to every target, or x86_64 when none are declared."`
+	Arch   []string `help:"Only build the Kraftfile targets of these architectures. Defaults to every declared target; required when none are declared." example:"x86_64,arm64"`
 
 	// similar to docker compose build
 	BuildArg []string `sep:"none" help:"Set build-time variables."`

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -18,11 +18,13 @@ import (
 	"time"
 
 	"github.com/alecthomas/kong"
+	"github.com/containerd/platforms"
 	"github.com/docker/go-units"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/cloud/sdk/platform/group"
+	imagespec "unikraft.com/x/image-spec"
 	"unikraft.com/x/kingkong"
 	"unikraft.com/x/kraftfile"
 	"unikraft.com/x/log"
@@ -748,6 +750,8 @@ func (c *VolumeImportCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *
 	if err != nil {
 		return fmt.Errorf("detecting source type for %q: %w", c.Source, err)
 	}
+	plat := platforms.DefaultSpec()
+	plat.OS = imagespec.PlatformKraftcloud
 	importOpts := &builder.BuildOpts{
 		Rootfs: builder.FSOpts{
 			Path: c.Source,
@@ -755,8 +759,7 @@ func (c *VolumeImportCmd) Run(ctx context.Context, stdio config.Stdio, sandbox *
 			// Set format to CPIO as volimport expects a CPIO archive
 			Format: kraftfile.FsTypeCpio,
 		},
-		// Set platform as volimport makes sense only on UnikraftCloud
-		Platform: []ocispec.Platform{builder.DefaultPlatform},
+		Platform: []ocispec.Platform{plat},
 	}
 
 	// Build an import archive from the data source.


### PR DESCRIPTION
We're now a multi-platform shop: we support amd64 and also aarch64.

So, to support them equally - no more build defaults. We now *require* that when building an image the user has specified an architecture:
- For building an image, very little changes if users have a `runtime`, we still default to using all of them. Users can still override it using the `targets:` key (or the new `--arch` flag).
- For building a rom, users will now need to set the `targets:` key (or `--arch`) *explicitly*.

This is a breaking change, but this was originally done under my previous (wrong) assumption that ROMs would be platform-independent. They really aren't, so I think the breaking change is justified, and creates a simpler-to-understand config.

Before:

```
spec: v0.7
roms:
  - ./Dockerfile
```

After:

```
spec: v0.7
roms:
  - ./Dockerfile
targets:
  - kraftcloud/x86_64
```