### PR TITLE
feat: Add build context support

### DIFF
--- a/cmd/unikraft/testdata/TestHelp/build
+++ b/cmd/unikraft/testdata/TestHelp/build
@@ -43,6 +43,8 @@ Flags:
           Secret to expose to the build (format: "id=mysecret[,src=/local/secret]").
       --ssh
           SSH agent socket or keys to expose to the build (format: "default|<id>[=<socket>|<key>[,<key>]]").
+      --build-context
+          Additional build contexts (e.g., name=path).
       --insecure
           Allow insecure (HTTP/unverified TLS) connections to registries. Specify hostnames to restrict, or omit to apply to all.
 

--- a/cmd/unikraft/testdata/TestHelp/build
+++ b/cmd/unikraft/testdata/TestHelp/build
@@ -29,6 +29,9 @@ Examples:
   # Build and save to a local OCI archive
   unikraft build . --output ./dist/my-app.oci.tar
 
+  # Build with an additional build context
+  unikraft build . --build-context shared=./shared
+
 Flags:
   -o, --output
           Output destination.

--- a/cmd/unikraft/testdata/TestHelp/images
+++ b/cmd/unikraft/testdata/TestHelp/images
@@ -87,6 +87,8 @@ Flags:
           Secret to expose to the build (format: "id=mysecret[,src=/local/secret]").
       --ssh
           SSH agent socket or keys to expose to the build (format: "default|<id>[=<socket>|<key>[,<key>]]").
+      --build-context
+          Additional build contexts (e.g., name=path).
       --insecure
           Allow insecure (HTTP/unverified TLS) connections to registries. Specify hostnames to restrict, or omit to apply to all.
 

--- a/cmd/unikraft/testdata/TestHelp/images
+++ b/cmd/unikraft/testdata/TestHelp/images
@@ -73,6 +73,9 @@ Examples:
   # Build and save to a local OCI archive
   unikraft image build . --output ./dist/my-app.oci.tar
 
+  # Build with an additional build context
+  unikraft image build . --build-context shared=./shared
+
 Flags:
   -o, --output
           Output destination.

--- a/go.mod
+++ b/go.mod
@@ -140,7 +140,7 @@ require (
 	github.com/muesli/mango-pflag v0.1.0 // indirect
 	github.com/muesli/roff v0.1.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
+	github.com/pkg/errors v0.9.1
 	github.com/posener/complete v1.2.3
 	github.com/posthog/posthog-go v1.12.4
 	github.com/rs/zerolog v1.35.1
@@ -140,7 +141,6 @@ require (
 	github.com/muesli/mango-pflag v0.1.0 // indirect
 	github.com/muesli/roff v0.1.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect

--- a/internal/builder/build.go
+++ b/internal/builder/build.go
@@ -34,10 +34,11 @@ type BuildOpts struct {
 	Labels map[string]string
 
 	// Buildkit params
-	BuildArg []string
-	Target   string
-	Secrets  []*buildflags.Secret
-	SSH      []*buildflags.SSH
+	BuildArg      []string
+	Target        string
+	BuildContexts map[string]string
+	Secrets       []*buildflags.Secret
+	SSH           []*buildflags.SSH
 
 	NoCache bool
 }

--- a/internal/builder/context.go
+++ b/internal/builder/context.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package builder
+
+import (
+	"strings"
+
+	"github.com/distribution/reference"
+	"github.com/pkg/errors"
+)
+
+// ParseContextNames parses --build-context values in the form name=value.
+func ParseContextNames(values []string) (map[string]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+
+	result := make(map[string]string, len(values))
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+
+		kv := strings.SplitN(value, "=", 2)
+		if len(kv) != 2 {
+			return nil, errors.Errorf(
+				"invalid context value: %s, expected key=value",
+				value,
+			)
+		}
+
+		named, err := reference.ParseNormalizedNamed(kv[0])
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid context name %s", kv[0])
+		}
+
+		name := strings.TrimSuffix(
+			reference.FamiliarString(named),
+			":latest",
+		)
+
+		result[name] = kv[1]
+	}
+
+	return result, nil
+}

--- a/internal/builder/context.go
+++ b/internal/builder/context.go
@@ -6,9 +6,9 @@
 package builder
 
 import (
+	"os"
 	"strings"
 
-	"github.com/distribution/reference"
 	"github.com/pkg/errors"
 )
 
@@ -25,25 +25,29 @@ func ParseContextNames(values []string) (map[string]string, error) {
 		}
 
 		kv := strings.SplitN(value, "=", 2)
-		if len(kv) != 2 {
+		if len(kv) != 2 || kv[0] == "" {
 			return nil, errors.Errorf(
 				"invalid context value: %s, expected key=value",
 				value,
 			)
 		}
-
-		named, err := reference.ParseNormalizedNamed(kv[0])
-		if err != nil {
-			return nil, errors.Wrapf(err, "invalid context name %s", kv[0])
-		}
-
-		name := strings.TrimSuffix(
-			reference.FamiliarString(named),
-			":latest",
-		)
-
-		result[name] = kv[1]
+		result[kv[0]] = kv[1]
 	}
 
 	return result, nil
+}
+
+func isLocalBuildContext(value string) bool {
+	switch {
+	case strings.HasPrefix(value, "docker-image://"),
+		strings.HasPrefix(value, "target:"),
+		strings.Contains(value, "://"):
+		return false
+	}
+	if _, err := os.Stat(value); err == nil {
+		return true
+	}
+	return strings.HasPrefix(value, "./") ||
+		strings.HasPrefix(value, "../") ||
+		strings.HasPrefix(value, "/")
 }

--- a/internal/builder/context_test.go
+++ b/internal/builder/context_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package builder
+
+import (
+	"testing"
+)
+
+func TestParseContextNames(t *testing.T) {
+	tests := []struct {
+		name    string
+		values  []string
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name:   "single context",
+			values: []string{"foo=./foo"},
+			want: map[string]string{
+				"foo": "./foo",
+			},
+		},
+		{
+			name: "multiple contexts",
+			values: []string{
+				"foo=./foo",
+				"bar=../bar",
+			},
+			want: map[string]string{
+				"foo": "./foo",
+				"bar": "../bar",
+			},
+		},
+		{
+			name:    "missing value",
+			values:  []string{"foo"},
+			wantErr: true,
+		},
+		{
+			name:   "empty",
+			values: []string{""},
+			want:   map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseContextNames(tt.values)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseContextNames() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if !tt.wantErr {
+				if len(got) != len(tt.want) {
+					t.Fatalf("got %v, want %v", got, tt.want)
+				}
+
+				for name, wantPath := range tt.want {
+					if got[name] != wantPath {
+						t.Errorf("context %q = %q, want %q", name, got[name], wantPath)
+					}
+				}
+			}
+		})
+	}
+}

--- a/internal/builder/context_test.go
+++ b/internal/builder/context_test.go
@@ -7,6 +7,8 @@ package builder
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseContextNames(t *testing.T) {
@@ -40,31 +42,100 @@ func TestParseContextNames(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "empty name",
+			values:  []string{"=./foo"},
+			wantErr: true,
+		},
+		{
 			name:   "empty",
 			values: []string{""},
 			want:   map[string]string{},
 		},
+		{
+			name:   "git context",
+			values: []string{"scripts=https://github.com/user/repo.git"},
+			want: map[string]string{
+				"scripts": "https://github.com/user/repo.git",
+			},
+		},
+		{
+			name:   "image override context",
+			values: []string{"alpine:3.23=docker-image://alpine:edge"},
+			want: map[string]string{
+				"alpine:3.23": "docker-image://alpine:edge",
+			},
+		},
+		{
+			name:   "target context",
+			values: []string{"base=target:base"},
+			want: map[string]string{
+				"base": "target:base",
+			},
+		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := ParseContextNames(tt.values)
-
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("ParseContextNames() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
 			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
 
-			if !tt.wantErr {
-				if len(got) != len(tt.want) {
-					t.Fatalf("got %v, want %v", got, tt.want)
-				}
-
-				for name, wantPath := range tt.want {
-					if got[name] != wantPath {
-						t.Errorf("context %q = %q, want %q", name, got[name], wantPath)
-					}
-				}
-			}
+func TestIsLocalBuildContext(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{
+			name:  "relative path",
+			value: "./foo",
+			want:  true,
+		},
+		{
+			name:  "parent relative path",
+			value: "../foo",
+			want:  true,
+		},
+		{
+			name:  "absolute path",
+			value: "/tmp/foo",
+			want:  true,
+		},
+		{
+			name:  "existing directory",
+			value: t.TempDir(),
+			want:  true,
+		},
+		{
+			name:  "git url",
+			value: "https://github.com/user/repo.git",
+			want:  false,
+		},
+		{
+			name:  "docker image reference",
+			value: "docker-image://alpine:edge",
+			want:  false,
+		},
+		{
+			name:  "bake target reference",
+			value: "target:base",
+			want:  false,
+		},
+		{
+			name:  "tarball url",
+			value: "https://example.com/context.tar.gz",
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isLocalBuildContext(tt.value))
 		})
 	}
 }

--- a/internal/builder/rootfs.go
+++ b/internal/builder/rootfs.go
@@ -562,6 +562,11 @@ func applyBuildOpts(attrs map[string]string, localDirs map[string]string, sessio
 		attrs["no-cache"] = ""
 	}
 
+	for name, path := range opts.BuildContexts {
+		localDirs[name] = path
+		attrs["context:"+name] = "local:" + name
+	}
+
 	for _, buildArg := range opts.BuildArg {
 		if buildArg == "" {
 			continue

--- a/internal/builder/rootfs.go
+++ b/internal/builder/rootfs.go
@@ -562,9 +562,13 @@ func applyBuildOpts(attrs map[string]string, localDirs map[string]string, sessio
 		attrs["no-cache"] = ""
 	}
 
-	for name, path := range opts.BuildContexts {
-		localDirs[name] = path
-		attrs["context:"+name] = "local:" + name
+	for name, value := range opts.BuildContexts {
+		if isLocalBuildContext(value) {
+			localDirs[name] = value
+			attrs["context:"+name] = "local:" + name
+		} else {
+			attrs["context:"+name] = value
+		}
 	}
 
 	for _, buildArg := range opts.BuildArg {

--- a/internal/builder/rootfs_test.go
+++ b/internal/builder/rootfs_test.go
@@ -837,3 +837,39 @@ func runBuildRootfs(t *testing.T, opts BuildOpts) []*imagespec.Image {
 	})
 	return imgs
 }
+
+func TestRootfsDockerfileBuildContextIntegration(t *testing.T) {
+	ctx := rootfsIntegrationContext(t)
+
+	contextDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(contextDir, "hello.txt"),
+		[]byte("hello from context\n"),
+		0o644,
+	))
+
+	dockerfile := `
+FROM scratch
+COPY --from=shared hello.txt /hello.txt
+`
+
+	rootfsPath := writeDockerfile(t, dockerfile)
+
+	imgs := runBuildRootfsIntegration(t, ctx, BuildOpts{
+		Rootfs: FSOpts{
+			Format: kraftfile.FsTypeCpio,
+			Path:   rootfsPath,
+			Type:   kraftfile.SourceTypeDockerfile,
+		},
+		BuildContexts: map[string]string{
+			"shared": contextDir,
+		},
+		Platform: []ocispec.Platform{{OS: "fc", Architecture: "x86_64"}},
+	})
+
+	require.Len(t, imgs, 1)
+
+	files := readCpioInitrd(t, imgs[0])
+	require.Contains(t, files, "./hello.txt")
+	require.Equal(t, "hello from context\n", files["./hello.txt"])
+}

--- a/internal/cmd/build.go
+++ b/internal/cmd/build.go
@@ -28,10 +28,11 @@ type ImageBuildCmd struct {
 	Arch   []string `help:"Only build the Kraftfile targets of these architectures. Defaults to every declared target; required when none are declared." example:"x86_64,arm64"`
 
 	// similar to docker compose build
-	BuildArg []string `sep:"none" help:"Set build-time variables."`
-	NoCache  bool     `help:"Do not use cache when building the image."`
-	Secret   []string `sep:"none" help:"Secret to expose to the build (format: \"id=mysecret[,src=/local/secret]\")."`
-	SSH      []string `sep:"none" help:"SSH agent socket or keys to expose to the build (format: \"default|<id>[=<socket>|<key>[,<key>]]\")."`
+	BuildArg     []string `sep:"none" help:"Set build-time variables."`
+	NoCache      bool     `help:"Do not use cache when building the image."`
+	Secret       []string `sep:"none" help:"Secret to expose to the build (format: \"id=mysecret[,src=/local/secret]\")."`
+	SSH          []string `sep:"none" help:"SSH agent socket or keys to expose to the build (format: \"default|<id>[=<socket>|<key>[,<key>]]\")."`
+	BuildContext []string `sep:"none" help:"Additional build contexts (e.g., name=path)."`
 
 	Insecure []string `help:"Allow insecure (HTTP/unverified TLS) connections to registries. Specify hostnames to restrict, or omit to apply to all." type:"optional"`
 }
@@ -114,6 +115,13 @@ func (c *ImageBuildCmd) Run(ctx context.Context, cfg *config.Config, partition *
 	buildOpts.NoCache = c.NoCache
 	if len(c.BuildArg) > 0 {
 		buildOpts.BuildArg = append(buildOpts.BuildArg, c.BuildArg...)
+	}
+	if len(c.BuildContext) > 0 {
+		contexts, err := builder.ParseContextNames(c.BuildContext)
+		if err != nil {
+			return err
+		}
+		buildOpts.BuildContexts = contexts
 	}
 	if len(c.Secret) > 0 {
 		secrets, err := buildflags.ParseSecretSpecs(c.Secret)

--- a/internal/cmd/build.go
+++ b/internal/cmd/build.go
@@ -75,6 +75,12 @@ func (ImageBuildCmd) Examples() []kingkong.Example {
 				"unikraft image build . --output ./dist/my-app.oci.tar",
 			},
 		},
+		{
+			Description: "Build with an additional build context",
+			Commands: []string{
+				"unikraft image build . --build-context shared=./shared",
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

Add support for `--build-context` to `unikraft images build`.

This allows named build contexts to be passed to BuildKit and used with
`COPY --from=<context>` in Dockerfiles.

Closes #371