### PR TITLE
fix(volume-templates): Create a template per volume

### DIFF
--- a/cmd/unikraft/integration/volume_template_test.go
+++ b/cmd/unikraft/integration/volume_template_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVolumeTemplates(t *testing.T) {
@@ -44,6 +45,33 @@ func TestVolumeTemplates(t *testing.T) {
 		assert.Regexp(t, `state:\s+template`, out)
 
 		r.Run(t, []string{"unikraft", "volume", "template", "delete", templateName})
+	})
+
+	t.Run("multiple-volumes", func(t *testing.T) {
+		r := runner(t, true, []string{staging, stable})
+		volName := uniq()
+
+		for _, suffix := range []string{"a", "b"} {
+			r.Run(t, []string{
+				"unikraft", "volume", "create",
+				"--output", "quiet",
+				"--set", "name=test-" + suffix + "-" + volName,
+				"--set", "metro=" + r.Config.MetroName,
+				"--set", "size=10",
+			})
+		}
+
+		out := r.Run(t, []string{
+			"unikraft", "volume", "template", "create",
+			"test-a-" + volName, "test-b-" + volName,
+			"--output", "template={{ .name }}",
+		})
+		templateNames := strings.Fields(out)
+		require.Len(t, templateNames, 2)
+
+		for _, templateName := range templateNames {
+			r.Run(t, []string{"unikraft", "volume", "template", "delete", templateName})
+		}
 	})
 
 	t.Run("create-from-template", func(t *testing.T) {

--- a/internal/cmd/volume_templates.go
+++ b/internal/cmd/volume_templates.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/alecthomas/kong"
 
@@ -50,8 +49,8 @@ func (c *VolumeTemplateCreateCmd) Run(ctx context.Context, stdio config.Stdio, s
 	if err := cmd.ApplyShortcutFlags(&c.SetArgs, kctx.Flags()); err != nil {
 		return err
 	}
-	if len(c.Targets) > 0 {
-		c.Set = append(c.Set, map[string]string{"volumes": strings.Join(c.Targets, ",")})
+	for _, target := range c.Targets {
+		c.Set = append(c.Set, map[string]string{"volumes": target})
 	}
 	return c.ResourceCreateCmd.Run(ctx, stdio, sandbox)
 }


### PR DESCRIPTION
Fallout from https://github.com/unikraft-cloud/cli/pull/395 — `unikraft volume template create a b` comma-joined its positional volumes into one `--set volumes` value and relied on the parser splitting it back apart, so it now goes looking for a volume named `a,b`.