### PR TITLE
chore: Update README to include link for Unikraft CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Unikraft CLI
+# [Unikraft CLI](https://unikraft.com/docs/cli)
 
 > [!NOTE]
 >
-> This is the new **Unikraft CLI**. It is actively worked upon to deliver the latest **Unikraft Cloud** features to your CLI. [Feedback appreciated](https://unikraft.link/devsurvey)!
+> This is the new **[Unikraft CLI](https://unikraft.com/docs/cli)**. It is actively worked upon to deliver the latest **Unikraft Cloud** features to your CLI. [Feedback appreciated](https://unikraft.link/devsurvey)!
 
 The official command-line interface for [Unikraft Cloud](https://unikraft.cloud) — deploy and manage unikernels globally in milliseconds.
 


### PR DESCRIPTION
Doing some SEO work on the Unikraft CLI docs page, as it does not rank in Google and has competition with `kraft` docs.

Needing this back link from the Github repo which would improve the authoritativeness of our docs.