### PR TITLE
fix(integration): Increase OOM test memory

### DIFF
--- a/cmd/unikraft/integration/instance_test.go
+++ b/cmd/unikraft/integration/instance_test.go
@@ -245,7 +245,7 @@ cmd: ["cat", "/sys/class/uio/uio0/device/startdata"]
 			"--set", "metro=" + r.Config.MetroName,
 			"--set", "image=nginx:latest",
 			"--set", "autostart=true",
-			"--set", "resources.memory=16Mib",
+			"--set", "resources.memory=24Mib",
 			"--set", "resources.vcpus=1",
 		})
 


### PR DESCRIPTION
After recent platform and kernel updates, the oom test started failing with an 'unknown error'.

This is because probably some components started using up more memory, making the kernel not boot up at all to report the page fault.

Fix is to slightly increase memory to allow for the crash to happen, but not to much or it will start passing.