### PR TITLE
feat: Support building the CLI for js/wasm

### DIFF
--- a/.github/workflows/check-static.yaml
+++ b/.github/workflows/check-static.yaml
@@ -57,3 +57,11 @@ jobs:
       shell: bash
       run: |
           task go:ci/check
+
+    # The web console runs this CLI as a WebAssembly module.  Build it here so
+    # a new dependency on a local daemon, a terminal or a filesystem is caught
+    # in review rather than at release time.
+    - name: Build for js/wasm
+      shell: bash
+      run: |
+          GOOS=js GOARCH=wasm go build -o /dev/null ./cmd/unikraft

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -43,6 +43,45 @@ tasks:
         docs: https://unikraft.com/docs/cli
         issues: https://github.com/unikraft-cloud/cli/issues
 
+  wasm:
+    desc: The `unikraft` CLI compiled to WebAssembly for the browser.
+    silent: true
+    vars:
+      outdir: '{{.distdir}}/wasm'
+      git_tag:
+        sh: git update-index -q --refresh && git describe --abbrev=0 --tags --dirty || printf "0.0.0"
+      git_sha:
+        sh: git update-index -q --refresh && git rev-parse HEAD || printf "dev"
+      goroot:
+        sh: '{{.go_bin}} env GOROOT'
+      go_version:
+        sh: '{{.go_bin}} env GOVERSION'
+      go_ldflags: >-
+        -s -w
+        -X "unikraft.com/x/version.Name=unikraft-cli"
+        -X "unikraft.com/x/version.Docs=https://unikraft.com/docs/cli"
+        -X "unikraft.com/x/version.Issues=https://github.com/unikraft-cloud/cli/issues"
+        -X "unikraft.com/x/version.Version={{.git_tag}}"
+        -X "unikraft.com/x/version.Commit={{.git_sha}}"
+        -X "unikraft.com/x/version.BuildTime={{now}}"
+    cmds:
+    - mkdir -p '{{.outdir}}'
+    # The browser host needs the loader from the same toolchain that built the
+    # module: the import names change between Go releases.
+    - cp '{{.goroot}}/lib/wasm/wasm_exec.js' '{{.outdir}}/wasm_exec.js'
+    - >-
+      GOOS=js GOARCH=wasm {{.go_bin}} build -v {{.CLI_ARGS}}
+      -trimpath
+      -ldflags='{{.go_ldflags}}'
+      -o '{{.outdir}}/unikraft.wasm'
+      ./cmd/unikraft
+    - gzip -9 -n -k -f '{{.outdir}}/unikraft.wasm'
+    - >-
+      printf '{"version":"%s","commit":"%s","goVersion":"%s"}\n'
+      '{{.git_tag}}' '{{.git_sha}}' '{{.go_version}}'
+      > '{{.outdir}}/unikraft.wasm.json'
+    - ls -la '{{.outdir}}'
+
   lint:
     desc: Lint the project.
     silent: true

--- a/cmd/unikraft/cancel_js.go
+++ b/cmd/unikraft/cancel_js.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build js && wasm
+
+package main
+
+import (
+	"context"
+	"syscall/js"
+)
+
+// installCancelHook publishes a global "unikraftCancel" function so the host
+// page can interrupt the running command.  Signals never arrive in wasm, so
+// this takes the place of Ctrl-C.  The returned function removes the hook.
+func installCancelHook(cancel context.CancelFunc) func() {
+	fn := js.FuncOf(func(js.Value, []js.Value) any {
+		cancel()
+		return nil
+	})
+	js.Global().Set("unikraftCancel", fn)
+
+	return func() {
+		js.Global().Delete("unikraftCancel")
+		fn.Release()
+	}
+}

--- a/cmd/unikraft/cancel_other.go
+++ b/cmd/unikraft/cancel_other.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build !(js && wasm)
+
+package main
+
+import "context"
+
+// installCancelHook does nothing outside wasm, where signals already deliver
+// interrupts.  The returned function is a no-op.
+func installCancelHook(cancel context.CancelFunc) func() {
+	return func() {}
+}

--- a/cmd/unikraft/main.go
+++ b/cmd/unikraft/main.go
@@ -35,6 +35,7 @@ func main() {
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
+	defer installCancelHook(cancel)()
 
 	var (
 		err error

--- a/internal/cmd/build.go
+++ b/internal/cmd/build.go
@@ -6,20 +6,9 @@
 package cmd
 
 import (
-	"context"
-	"fmt"
 	"strings"
 
-	"golang.org/x/mod/semver"
-	"unikraft.com/cli/internal/builder"
-	"unikraft.com/cli/internal/builder/buildflags"
-	"unikraft.com/cli/internal/config"
-	"unikraft.com/cli/internal/images"
-	"unikraft.com/cli/internal/resource"
-	imagespec "unikraft.com/x/image-spec"
 	"unikraft.com/x/kingkong"
-	"unikraft.com/x/kraftfile"
-	"unikraft.com/x/log"
 )
 
 type ImageBuildCmd struct {
@@ -77,104 +66,6 @@ func (ImageBuildCmd) Examples() []kingkong.Example {
 	}
 }
 
-func (c *ImageBuildCmd) Run(ctx context.Context, cfg *config.Config, partition *resource.Partition) error {
-	kf, err := kraftfile.ParseDirectory(c.Input, kraftfile.WithSkippedVersionCheck())
-	if err != nil {
-		return err
-	}
-	if semver.Compare(kf.Spec, kraftfile.SpecVersionMin) < 0 {
-		log.G(ctx).Warn().
-			Str("spec", kf.Spec).
-			Str("min", kraftfile.SpecVersionMin).
-			Msg("Kraftfile spec version is older than minimum; parsing is best-effort")
-	} else if semver.Compare(kf.Spec, kraftfile.SpecVersionMax) > 0 {
-		log.G(ctx).Warn().
-			Str("spec", kf.Spec).
-			Str("max", kraftfile.SpecVersionMax).
-			Msg("Kraftfile spec version is newer than maximum; parsing is best-effort")
-	}
-
-	buildOpts, err := builder.KraftfileToBuildOpts(c.Input, kf)
-	if err != nil {
-		return err
-	}
-
-	arches := make([]string, 0, len(c.Arch))
-	for _, a := range c.Arch {
-		arch, err := imagespec.NormalizeArch(a)
-		if err != nil {
-			return fmt.Errorf("%w: expected %s or %s", err, imagespec.ArchitectureIntel, imagespec.ArchitectureArm)
-		}
-		arches = append(arches, arch)
-	}
-	if err := buildOpts.FilterArch(arches...); err != nil {
-		return err
-	}
-
-	buildOpts.NoCache = c.NoCache
-	if len(c.BuildArg) > 0 {
-		buildOpts.BuildArg = append(buildOpts.BuildArg, c.BuildArg...)
-	}
-	if len(c.Secret) > 0 {
-		secrets, err := buildflags.ParseSecretSpecs(c.Secret)
-		if err != nil {
-			return err
-		}
-		buildOpts.Secrets = secrets
-	}
-	if len(c.SSH) > 0 {
-		ssh, err := buildflags.ParseSSHSpecs(c.SSH)
-		if err != nil {
-			return err
-		}
-		buildOpts.SSH = ssh
-	}
-
-	imgs, err := builder.Build(ctx, buildOpts)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		for _, img := range imgs {
-			img.Close()
-		}
-	}()
-
-	if c.Output == "" {
-		return nil
-	}
-	output, err := imagespec.GuessURI(c.Output)
-	if err != nil {
-		return err
-	}
-
-	var opts []images.AccessorOpt
-	if c.Insecure != nil {
-		if len(c.Insecure) > 0 {
-			opts = append(opts, images.WithInsecureRegistry(c.Insecure...))
-		} else {
-			opts = append(opts, images.WithInsecureRegistries())
-		}
-	}
-
-	access, err := images.Accessor(ctx, opts...)
-	if err != nil {
-		return err
-	}
-	err = access.Save(ctx, output, imgs...)
-	if err != nil {
-		return err
-	}
-
-	if partition != nil && output.Scheme == imagespec.URISchemeOCI {
-		if err := addImageToPartition(ctx, partition, output.Path); err != nil {
-			return fmt.Errorf("adding built image to partition: %w", err)
-		}
-	}
-
-	return nil
-}
-
 type BuildCmd struct {
 	ImageBuildCmd `embed:""`
 }
@@ -193,8 +84,4 @@ func (BuildCmd) Examples() []kingkong.Example {
 	}
 
 	return imageExamples
-}
-
-func (c *BuildCmd) Run(ctx context.Context, cfg *config.Config, partition *resource.Partition) error {
-	return c.ImageBuildCmd.Run(ctx, cfg, partition)
 }

--- a/internal/cmd/build_js.go
+++ b/internal/cmd/build_js.go
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build js
+
+package cmd
+
+import (
+	"context"
+
+	"unikraft.com/cli/internal/config"
+	"unikraft.com/cli/internal/resource"
+)
+
+// Run reports that image builds need a local container builder.
+func (c *ImageBuildCmd) Run(ctx context.Context, cfg *config.Config, partition *resource.Partition) error {
+	return notAvailable("image build")
+}
+
+// Run reports that image builds need a local container builder.
+func (c *BuildCmd) Run(ctx context.Context, cfg *config.Config, partition *resource.Partition) error {
+	return notAvailable("build")
+}

--- a/internal/cmd/build_native.go
+++ b/internal/cmd/build_native.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build !js
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/mod/semver"
+	"unikraft.com/cli/internal/builder"
+	"unikraft.com/cli/internal/builder/buildflags"
+	"unikraft.com/cli/internal/config"
+	"unikraft.com/cli/internal/images"
+	"unikraft.com/cli/internal/resource"
+	imagespec "unikraft.com/x/image-spec"
+	"unikraft.com/x/kraftfile"
+	"unikraft.com/x/log"
+)
+
+func (c *ImageBuildCmd) Run(ctx context.Context, cfg *config.Config, partition *resource.Partition) error {
+	kf, err := kraftfile.ParseDirectory(c.Input, kraftfile.WithSkippedVersionCheck())
+	if err != nil {
+		return err
+	}
+	if semver.Compare(kf.Spec, kraftfile.SpecVersionMin) < 0 {
+		log.G(ctx).Warn().
+			Str("spec", kf.Spec).
+			Str("min", kraftfile.SpecVersionMin).
+			Msg("Kraftfile spec version is older than minimum; parsing is best-effort")
+	} else if semver.Compare(kf.Spec, kraftfile.SpecVersionMax) > 0 {
+		log.G(ctx).Warn().
+			Str("spec", kf.Spec).
+			Str("max", kraftfile.SpecVersionMax).
+			Msg("Kraftfile spec version is newer than maximum; parsing is best-effort")
+	}
+
+	buildOpts, err := builder.KraftfileToBuildOpts(c.Input, kf)
+	if err != nil {
+		return err
+	}
+
+	arches := make([]string, 0, len(c.Arch))
+	for _, a := range c.Arch {
+		arch, err := imagespec.NormalizeArch(a)
+		if err != nil {
+			return fmt.Errorf("%w: expected %s or %s", err, imagespec.ArchitectureIntel, imagespec.ArchitectureArm)
+		}
+		arches = append(arches, arch)
+	}
+	if err := buildOpts.FilterArch(arches...); err != nil {
+		return err
+	}
+
+	buildOpts.NoCache = c.NoCache
+	if len(c.BuildArg) > 0 {
+		buildOpts.BuildArg = append(buildOpts.BuildArg, c.BuildArg...)
+	}
+	if len(c.Secret) > 0 {
+		secrets, err := buildflags.ParseSecretSpecs(c.Secret)
+		if err != nil {
+			return err
+		}
+		buildOpts.Secrets = secrets
+	}
+	if len(c.SSH) > 0 {
+		ssh, err := buildflags.ParseSSHSpecs(c.SSH)
+		if err != nil {
+			return err
+		}
+		buildOpts.SSH = ssh
+	}
+
+	imgs, err := builder.Build(ctx, buildOpts)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		for _, img := range imgs {
+			img.Close()
+		}
+	}()
+
+	if c.Output == "" {
+		return nil
+	}
+	output, err := imagespec.GuessURI(c.Output)
+	if err != nil {
+		return err
+	}
+
+	var opts []images.AccessorOpt
+	if c.Insecure != nil {
+		if len(c.Insecure) > 0 {
+			opts = append(opts, images.WithInsecureRegistry(c.Insecure...))
+		} else {
+			opts = append(opts, images.WithInsecureRegistries())
+		}
+	}
+
+	access, err := images.Accessor(ctx, opts...)
+	if err != nil {
+		return err
+	}
+	err = access.Save(ctx, output, imgs...)
+	if err != nil {
+		return err
+	}
+
+	if partition != nil && output.Scheme == imagespec.URISchemeOCI {
+		if err := addImageToPartition(ctx, partition, output.Path); err != nil {
+			return fmt.Errorf("adding built image to partition: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (c *BuildCmd) Run(ctx context.Context, cfg *config.Config, partition *resource.Partition) error {
+	return c.ImageBuildCmd.Run(ctx, cfg, partition)
+}

--- a/internal/cmd/images.go
+++ b/internal/cmd/images.go
@@ -13,8 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containerd/errdefs"
-	"github.com/containerd/platforms"
 	"github.com/distribution/reference"
 	"github.com/opencontainers/go-digest"
 	"unikraft.com/cloud/sdk/controlplane"
@@ -23,8 +21,6 @@ import (
 	"unikraft.com/x/joinerrgroup"
 	"unikraft.com/x/kingkong"
 	"unikraft.com/x/log"
-
-	imagespec "unikraft.com/x/image-spec"
 
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/images"
@@ -43,21 +39,6 @@ type ImagesCmd struct {
 	Delete ImagesDeleteCmd `cmd:"" help:"Remove an image." aliases:"rm,remove"`
 	Copy   ImagesCopyCmd   `cmd:"" help:"Copy images."`
 	List   ImagesListCmd   `cmd:"" help:"List images." aliases:"ls"`
-}
-
-type Image struct {
-	Ref    types.ImageRef[reference.Named] `field:",short"`
-	Digest digest.Digest                   `field:",long"`
-
-	Config   ImageConfig   `field:",embed"`
-	Metadata ImageMetadata `field:",long,embed"`
-
-	Kernel      *ImageFile  `field:",long,embed"`
-	KernelDebug *ImageFile  `field:"kernel.dbg,long,embed"`
-	Initrd      *ImageFile  `field:",long,embed"`
-	Roms        []ImageFile `field:",long,embed"`
-
-	Image imagespec.Image `field:"-" json:"image"`
 }
 
 type ImageConfig struct {
@@ -79,175 +60,6 @@ type ImageFile struct {
 	MediaType   string            `field:",long"`
 	Annotations map[string]string `field:",long"`
 	Size        types.SizeBytes   `field:",long"`
-}
-
-func (Image) Type() resource.Type {
-	return resource.Type{
-		Name:  "image",
-		Names: "images",
-	}
-}
-
-func (i Image) Key() resource.Key {
-	return staticKey(i.Ref.Reference.String())
-}
-
-func (i Image) Raw() any {
-	return i.Image.Descriptor
-}
-
-func (i Image) Fields(ctx context.Context) ([]resource.Field, error) {
-	return resource.FieldsFromStruct(i)
-}
-
-func imageFileFrom(file imagespec.File) *ImageFile {
-	if file == nil {
-		return nil
-	}
-	desc, _ := file.Source()
-	return &ImageFile{
-		Digest:      desc.Digest,
-		MediaType:   desc.MediaType,
-		Annotations: desc.Annotations,
-		Size:        types.SizeBytes(desc.Size),
-	}
-}
-
-func imageRomsFrom(files []imagespec.File) []ImageFile {
-	if len(files) == 0 {
-		return nil
-	}
-	roms := make([]ImageFile, 0, len(files))
-	for _, file := range files {
-		rom := imageFileFrom(file)
-		if rom == nil {
-			continue
-		}
-		roms = append(roms, *rom)
-	}
-	if len(roms) == 0 {
-		return nil
-	}
-	return roms
-}
-
-func (Image) Get(ctx context.Context, keys []string) ([]resource.Resource, error) {
-	access, err := images.Accessor(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	perKey := make([][]resource.Resource, len(keys))
-	eg := joinerrgroup.Group{}
-	for i, key := range keys {
-		eg.Go(func() error {
-			src, err := imagespec.GuessURI(key)
-			if err != nil {
-				return fmt.Errorf("parsing image reference %q: %w", key, err)
-			}
-			imgs, err := access.LoadAll(ctx, src, platforms.All)
-			if err != nil {
-				if errdefs.IsNotFound(err) {
-					return group.ErrRefNotFound{Refs: group.Refs{{Name: key}}}
-				}
-				return fmt.Errorf("failed to resolve image %q: %w", key, err)
-			}
-			defer func() {
-				for _, img := range imgs {
-					img.Close()
-				}
-			}()
-
-			for _, img := range imgs {
-				config := img.Image
-				envs := make(map[string]string, len(config.Config.Env))
-				for _, entry := range config.Config.Env {
-					if key, val, ok := strings.Cut(entry, "="); ok {
-						envs[key] = val
-					}
-				}
-
-				meta := img.Metadata()
-				resource := Image{
-					Ref: types.ImageRef[reference.Named]{
-						Reference: img.Name,
-					},
-					Digest: img.Descriptor.Digest,
-					Config: ImageConfig{
-						Cmd:      config.Config.Cmd,
-						Env:      envs,
-						Platform: types.Platform(config.Platform),
-					},
-					Metadata: ImageMetadata{
-						Author:  meta.Author,
-						Created: meta.Created,
-					},
-					Kernel:      imageFileFrom(img.Kernel),
-					KernelDebug: imageFileFrom(img.KernelDebug),
-					Initrd:      imageFileFrom(img.Initrd),
-					Roms:        imageRomsFrom(img.Roms),
-					Image:       *img,
-				}
-				perKey[i] = append(perKey[i], &resource)
-			}
-			return nil
-		})
-	}
-	err = eg.Wait()
-	return slices.Concat(perKey...), err
-}
-
-func (Image) Delete(ctx context.Context, keys []string) error {
-	access, err := images.Accessor(ctx)
-	if err != nil {
-		return err
-	}
-
-	eg := joinerrgroup.Group{}
-	for _, key := range keys {
-		eg.Go(func() error {
-			uri, err := imagespec.GuessURI(key)
-			if err != nil {
-				return fmt.Errorf("parsing image reference %q: %w", key, err)
-			}
-			if err := access.Delete(ctx, uri); err != nil {
-				if errdefs.IsNotFound(err) {
-					return group.ErrRefNotFound{Refs: group.Refs{{Name: key}}}
-				}
-				return fmt.Errorf("deleting image %q: %w", key, err)
-			}
-
-			return nil
-		})
-	}
-	return eg.Wait()
-}
-
-func (Image) Examples() map[cmd.CmdType][]kingkong.Example {
-	return map[cmd.CmdType][]kingkong.Example{
-		cmd.CmdTypeGet: {
-			{
-				Description: "Inspect an image by tag",
-				Commands:    []string{"unikraft image get nginx:latest"},
-			},
-		},
-		cmd.CmdTypeList: {
-			{
-				Description: "List all images",
-				Commands:    []string{"unikraft image list"},
-			},
-			{
-				Description: "Filter images by reference",
-				Commands:    []string{`unikraft image list --filter 'ref~="/nginx"'`},
-			},
-		},
-		cmd.CmdTypeDelete: {
-			{
-				Description: "Delete a remote image",
-				Commands:    []string{"unikraft image delete unikraft.io/official/nginx:latest"},
-			},
-		},
-	}
 }
 
 type ImageEntry struct {
@@ -726,54 +538,6 @@ func (cmd ImagesCopyCmd) Examples() []kingkong.Example {
 			},
 		},
 	}
-}
-
-func (cmd ImagesCopyCmd) Run(ctx context.Context, partition *resource.Partition) error {
-	var opts []images.AccessorOpt
-	if cmd.Insecure != nil {
-		if len(cmd.Insecure) > 0 {
-			opts = append(opts, images.WithInsecureRegistry(cmd.Insecure...))
-		} else {
-			opts = append(opts, images.WithInsecureRegistries())
-		}
-	}
-
-	access, err := images.Accessor(ctx, opts...)
-	if err != nil {
-		return err
-	}
-
-	src, err := imagespec.GuessURI(cmd.Source)
-	if err != nil {
-		return fmt.Errorf("parsing source image reference: %w", err)
-	}
-	dest, err := imagespec.GuessURI(cmd.Dest)
-	if err != nil {
-		return fmt.Errorf("parsing destination image reference: %w", err)
-	}
-
-	imgs, err := access.LoadAll(ctx, src, platforms.All)
-	if err != nil {
-		return fmt.Errorf("loading image from source: %w", err)
-	}
-	defer func() {
-		for _, img := range imgs {
-			img.Close()
-		}
-	}()
-
-	err = access.Save(ctx, dest, imgs...)
-	if err != nil {
-		return fmt.Errorf("saving image to destination: %w", err)
-	}
-
-	if partition != nil && dest.Scheme == imagespec.URISchemeOCI {
-		if err := addImageToPartition(ctx, partition, dest.Path); err != nil {
-			return fmt.Errorf("adding copied image to partition: %w", err)
-		}
-	}
-
-	return nil
 }
 
 type ImagesListCmd struct {

--- a/internal/cmd/images_registry_js.go
+++ b/internal/cmd/images_registry_js.go
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build js
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/distribution/reference"
+	"github.com/opencontainers/go-digest"
+	"unikraft.com/x/kingkong"
+
+	"unikraft.com/cli/internal/resource"
+	"unikraft.com/cli/internal/resource/cmd"
+	"unikraft.com/cli/internal/types"
+)
+
+// Image identifies a registry image.  The web console has no local image
+// store, so only the fields which name an image are kept.
+type Image struct {
+	Ref    types.ImageRef[reference.Named] `field:",short"`
+	Digest digest.Digest                   `field:",long"`
+}
+
+func (Image) Type() resource.Type {
+	return resource.Type{
+		Name:  "image",
+		Names: "images",
+	}
+}
+
+func (i Image) Key() resource.Key {
+	return staticKey(i.Ref.Reference.String())
+}
+
+func (i Image) Raw() any {
+	return i.Ref.Reference.String()
+}
+
+func (i Image) Fields(ctx context.Context) ([]resource.Field, error) {
+	return resource.FieldsFromStruct(i)
+}
+
+// Get reports that inspecting an image needs a registry client.
+func (Image) Get(ctx context.Context, keys []string) ([]resource.Resource, error) {
+	return nil, notAvailable("image inspect")
+}
+
+// Delete reports that deleting an image needs a registry client.
+func (Image) Delete(ctx context.Context, keys []string) error {
+	return notAvailable("image delete")
+}
+
+func (Image) Examples() map[cmd.CmdType][]kingkong.Example {
+	return nil
+}
+
+// Run reports that copying images needs a registry client.
+func (cmd ImagesCopyCmd) Run(ctx context.Context, partition *resource.Partition) error {
+	return notAvailable("image copy")
+}

--- a/internal/cmd/images_registry_native.go
+++ b/internal/cmd/images_registry_native.go
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build !js
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
+	"github.com/distribution/reference"
+	"github.com/opencontainers/go-digest"
+	"unikraft.com/cloud/sdk/platform/group"
+	"unikraft.com/x/joinerrgroup"
+	"unikraft.com/x/kingkong"
+
+	imagespec "unikraft.com/x/image-spec"
+
+	"unikraft.com/cli/internal/images"
+	"unikraft.com/cli/internal/resource"
+	"unikraft.com/cli/internal/resource/cmd"
+	"unikraft.com/cli/internal/types"
+)
+
+type Image struct {
+	Ref    types.ImageRef[reference.Named] `field:",short"`
+	Digest digest.Digest                   `field:",long"`
+
+	Config   ImageConfig   `field:",embed"`
+	Metadata ImageMetadata `field:",long,embed"`
+
+	Kernel      *ImageFile  `field:",long,embed"`
+	KernelDebug *ImageFile  `field:"kernel.dbg,long,embed"`
+	Initrd      *ImageFile  `field:",long,embed"`
+	Roms        []ImageFile `field:",long,embed"`
+
+	Image imagespec.Image `field:"-" json:"image"`
+}
+
+func (Image) Type() resource.Type {
+	return resource.Type{
+		Name:  "image",
+		Names: "images",
+	}
+}
+
+func (i Image) Key() resource.Key {
+	return staticKey(i.Ref.Reference.String())
+}
+
+func (i Image) Raw() any {
+	return i.Image.Descriptor
+}
+
+func (i Image) Fields(ctx context.Context) ([]resource.Field, error) {
+	return resource.FieldsFromStruct(i)
+}
+
+func imageFileFrom(file imagespec.File) *ImageFile {
+	if file == nil {
+		return nil
+	}
+	desc, _ := file.Source()
+	return &ImageFile{
+		Digest:      desc.Digest,
+		MediaType:   desc.MediaType,
+		Annotations: desc.Annotations,
+		Size:        types.SizeBytes(desc.Size),
+	}
+}
+
+func imageRomsFrom(files []imagespec.File) []ImageFile {
+	if len(files) == 0 {
+		return nil
+	}
+	roms := make([]ImageFile, 0, len(files))
+	for _, file := range files {
+		rom := imageFileFrom(file)
+		if rom == nil {
+			continue
+		}
+		roms = append(roms, *rom)
+	}
+	if len(roms) == 0 {
+		return nil
+	}
+	return roms
+}
+
+func (Image) Get(ctx context.Context, keys []string) ([]resource.Resource, error) {
+	access, err := images.Accessor(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	perKey := make([][]resource.Resource, len(keys))
+	eg := joinerrgroup.Group{}
+	for i, key := range keys {
+		eg.Go(func() error {
+			src, err := imagespec.GuessURI(key)
+			if err != nil {
+				return fmt.Errorf("parsing image reference %q: %w", key, err)
+			}
+			imgs, err := access.LoadAll(ctx, src, platforms.All)
+			if err != nil {
+				if errdefs.IsNotFound(err) {
+					return group.ErrRefNotFound{Refs: group.Refs{{Name: key}}}
+				}
+				return fmt.Errorf("failed to resolve image %q: %w", key, err)
+			}
+			defer func() {
+				for _, img := range imgs {
+					img.Close()
+				}
+			}()
+
+			for _, img := range imgs {
+				config := img.Image
+				envs := make(map[string]string, len(config.Config.Env))
+				for _, entry := range config.Config.Env {
+					if key, val, ok := strings.Cut(entry, "="); ok {
+						envs[key] = val
+					}
+				}
+
+				meta := img.Metadata()
+				resource := Image{
+					Ref: types.ImageRef[reference.Named]{
+						Reference: img.Name,
+					},
+					Digest: img.Descriptor.Digest,
+					Config: ImageConfig{
+						Cmd:      config.Config.Cmd,
+						Env:      envs,
+						Platform: types.Platform(config.Platform),
+					},
+					Metadata: ImageMetadata{
+						Author:  meta.Author,
+						Created: meta.Created,
+					},
+					Kernel:      imageFileFrom(img.Kernel),
+					KernelDebug: imageFileFrom(img.KernelDebug),
+					Initrd:      imageFileFrom(img.Initrd),
+					Roms:        imageRomsFrom(img.Roms),
+					Image:       *img,
+				}
+				perKey[i] = append(perKey[i], &resource)
+			}
+			return nil
+		})
+	}
+	err = eg.Wait()
+	return slices.Concat(perKey...), err
+}
+
+func (Image) Delete(ctx context.Context, keys []string) error {
+	access, err := images.Accessor(ctx)
+	if err != nil {
+		return err
+	}
+
+	eg := joinerrgroup.Group{}
+	for _, key := range keys {
+		eg.Go(func() error {
+			uri, err := imagespec.GuessURI(key)
+			if err != nil {
+				return fmt.Errorf("parsing image reference %q: %w", key, err)
+			}
+			if err := access.Delete(ctx, uri); err != nil {
+				if errdefs.IsNotFound(err) {
+					return group.ErrRefNotFound{Refs: group.Refs{{Name: key}}}
+				}
+				return fmt.Errorf("deleting image %q: %w", key, err)
+			}
+
+			return nil
+		})
+	}
+	return eg.Wait()
+}
+
+func (Image) Examples() map[cmd.CmdType][]kingkong.Example {
+	return map[cmd.CmdType][]kingkong.Example{
+		cmd.CmdTypeGet: {
+			{
+				Description: "Inspect an image by tag",
+				Commands:    []string{"unikraft image get nginx:latest"},
+			},
+		},
+		cmd.CmdTypeList: {
+			{
+				Description: "List all images",
+				Commands:    []string{"unikraft image list"},
+			},
+			{
+				Description: "Filter images by reference",
+				Commands:    []string{`unikraft image list --filter 'ref~="/nginx"'`},
+			},
+		},
+		cmd.CmdTypeDelete: {
+			{
+				Description: "Delete a remote image",
+				Commands:    []string{"unikraft image delete unikraft.io/official/nginx:latest"},
+			},
+		},
+	}
+}
+
+func (cmd ImagesCopyCmd) Run(ctx context.Context, partition *resource.Partition) error {
+	var opts []images.AccessorOpt
+	if cmd.Insecure != nil {
+		if len(cmd.Insecure) > 0 {
+			opts = append(opts, images.WithInsecureRegistry(cmd.Insecure...))
+		} else {
+			opts = append(opts, images.WithInsecureRegistries())
+		}
+	}
+
+	access, err := images.Accessor(ctx, opts...)
+	if err != nil {
+		return err
+	}
+
+	src, err := imagespec.GuessURI(cmd.Source)
+	if err != nil {
+		return fmt.Errorf("parsing source image reference: %w", err)
+	}
+	dest, err := imagespec.GuessURI(cmd.Dest)
+	if err != nil {
+		return fmt.Errorf("parsing destination image reference: %w", err)
+	}
+
+	imgs, err := access.LoadAll(ctx, src, platforms.All)
+	if err != nil {
+		return fmt.Errorf("loading image from source: %w", err)
+	}
+	defer func() {
+		for _, img := range imgs {
+			img.Close()
+		}
+	}()
+
+	err = access.Save(ctx, dest, imgs...)
+	if err != nil {
+		return fmt.Errorf("saving image to destination: %w", err)
+	}
+
+	if partition != nil && dest.Scheme == imagespec.URISchemeOCI {
+		if err := addImageToPartition(ctx, partition, dest.Path); err != nil {
+			return fmt.Errorf("adding copied image to partition: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/internal/cmd/instances.go
+++ b/internal/cmd/instances.go
@@ -19,7 +19,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/distribution/reference"
@@ -42,7 +41,6 @@ import (
 	"unikraft.com/cli/internal/resource/cmd"
 	"unikraft.com/cli/internal/resource/value"
 	"unikraft.com/cli/internal/timeouts"
-	"unikraft.com/cli/internal/tunnel"
 	"unikraft.com/cli/internal/types"
 )
 
@@ -2265,34 +2263,4 @@ func (cmd InstancesTunnelCmd) Examples() []kingkong.Example {
 			Commands:    []string{"unikraft instance tunnel -p 5500 my-instance:8080"},
 		},
 	}
-}
-
-func (cmd *InstancesTunnelCmd) Run(ctx context.Context, stdio config.Stdio) error {
-	targets, err := tunnel.ParseTargets(cmd.Targets, cmd.TunnelProxyPorts)
-	if err != nil {
-		return fmt.Errorf("could not parse targets: %w", err)
-	}
-
-	tun, err := tunnel.New(ctx, targets)
-	if err != nil {
-		return fmt.Errorf("could not create tunnel: %w", err)
-	}
-
-	g, err := multimetro.NewClient(ctx)
-	if err != nil {
-		return err
-	}
-
-	defer func() {
-		// Detach from ctx so cleanup survives the same Ctrl-C that triggered
-		// it, but bound it so a stuck API call can't leave a still-billed
-		// proxy instance orphaned.
-		closeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
-		defer cancel()
-		if err := tun.Close(closeCtx, g); err != nil {
-			log.G(ctx).Error().Err(err).Msg("could not terminate tunnel proxy")
-		}
-	}()
-
-	return tun.Run(ctx, g, cmd.ProxyControlPort, cmd.TunnelServiceImage)
 }

--- a/internal/cmd/instances_tui.go
+++ b/internal/cmd/instances_tui.go
@@ -3,6 +3,8 @@
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
 
+//go:build !js
+
 package cmd
 
 import (

--- a/internal/cmd/instances_tunnel_js.go
+++ b/internal/cmd/instances_tunnel_js.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build js
+
+package cmd
+
+import (
+	"context"
+
+	"unikraft.com/cli/internal/config"
+)
+
+// Run reports that tunnels need a local listening socket.
+func (cmd *InstancesTunnelCmd) Run(ctx context.Context, stdio config.Stdio) error {
+	return notAvailable("instance tunnel")
+}

--- a/internal/cmd/instances_tunnel_native.go
+++ b/internal/cmd/instances_tunnel_native.go
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build !js
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"unikraft.com/x/log"
+
+	"unikraft.com/cli/internal/config"
+	"unikraft.com/cli/internal/multimetro"
+	"unikraft.com/cli/internal/tunnel"
+)
+
+func (cmd *InstancesTunnelCmd) Run(ctx context.Context, stdio config.Stdio) error {
+	targets, err := tunnel.ParseTargets(cmd.Targets, cmd.TunnelProxyPorts)
+	if err != nil {
+		return fmt.Errorf("could not parse targets: %w", err)
+	}
+
+	tun, err := tunnel.New(ctx, targets)
+	if err != nil {
+		return fmt.Errorf("could not create tunnel: %w", err)
+	}
+
+	g, err := multimetro.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		// Detach from ctx so cleanup survives the same Ctrl-C that triggered
+		// it, but bound it so a stuck API call can't leave a still-billed
+		// proxy instance orphaned.
+		closeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		if err := tun.Close(closeCtx, g); err != nil {
+			log.G(ctx).Error().Err(err).Msg("could not terminate tunnel proxy")
+		}
+	}()
+
+	return tun.Run(ctx, g, cmd.ProxyControlPort, cmd.TunnelServiceImage)
+}

--- a/internal/cmd/login/fingerprint.go
+++ b/internal/cmd/login/fingerprint.go
@@ -3,6 +3,8 @@
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
 
+//go:build !js
+
 package login
 
 import (

--- a/internal/cmd/login/fingerprint_js.go
+++ b/internal/cmd/login/fingerprint_js.go
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build js
+
+package login
+
+import (
+	"runtime"
+
+	"unikraft.com/cloud/sdk/controlplane"
+	"unikraft.com/x/ptr"
+	"unikraft.com/x/version"
+)
+
+// getFingerprint reports a fixed identity.  The browser exposes no machine
+// characteristics, so every web console session looks the same.
+func getFingerprint() (controlplane.RequestSigninRequest, error) {
+	return controlplane.RequestSigninRequest{
+		Hostname:   "web-console",
+		Os:         ptr.Ptr("browser"),
+		Container:  ptr.Ptr(false),
+		CliVersion: &version.Version,
+		Goarch:     ptr.Ptr(runtime.GOARCH),
+		Goos:       ptr.Ptr(runtime.GOOS),
+		GoVersion:  ptr.Ptr(runtime.Version()),
+	}, nil
+}

--- a/internal/cmd/metro_quotas.go
+++ b/internal/cmd/metro_quotas.go
@@ -11,11 +11,9 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"slices"
 	"strings"
 	"time"
 
-	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"charm.land/lipgloss/v2/compat"
 	"github.com/docker/go-units"
@@ -24,7 +22,6 @@ import (
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/kvwriter"
 	"unikraft.com/cli/internal/multimetro"
-	uitui "unikraft.com/cli/internal/tui/uitui"
 	xio "unikraft.com/cli/internal/x/io"
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/cloud/sdk/platform/group"
@@ -34,6 +31,9 @@ import (
 
 // MetroQuotasCmd displays quota usage for metros in an interactive TUI.
 // Tabs allow switching between individual metros.
+// quotaErrorStyle renders per-metro fetch errors.
+var quotaErrorStyle = lipgloss.NewStyle().Foreground(colors.Error)
+
 type MetroQuotasCmd struct {
 	Metro []string       `short:"m" help:"Show quotas for specific metros only." placeholder:"metro"`
 	Watch *time.Duration `short:"w" help:"Watch for changes and refresh output. Defaults to 2s." type:"optional" placeholder:"duration"`
@@ -56,10 +56,7 @@ func (cmd *MetroQuotasCmd) Run(ctx context.Context, stdio config.Stdio) error {
 	}
 
 	if xio.IsTTY(stdio.Stdout) {
-		m := newQuotasModel(ctx, cmd.Metro, watch)
-		p := tea.NewProgram(m, tea.WithInput(stdio.Stdin), tea.WithOutput(xio.Unwrap(stdio.Stdout)))
-		_, err := p.Run()
-		return err
+		return runQuotasTUI(ctx, stdio, cmd, watch)
 	}
 	if cmd.Watch != nil {
 		return cmd.watchRenderLoop(ctx, stdio.Stdout, *watch)
@@ -108,7 +105,7 @@ func renderQuotaSections(data map[string]*platform.Quotas, errors map[string]err
 		if q != nil {
 			b.WriteString(renderQuotaView(q, userName, defaultQuotaBarWidth))
 		} else if err := errors[tab]; err != nil {
-			b.WriteString(uitui.ErrorStyle.Render(err.Error()))
+			b.WriteString(quotaErrorStyle.Render(err.Error()))
 			b.WriteString("\n")
 		} else {
 			b.WriteString("no quota data available\n")
@@ -129,241 +126,10 @@ type multiMetroResult struct {
 	err      error
 }
 
-type quotasModel struct {
-	ctx           context.Context
-	metros        []string
-	watchInterval *time.Duration
-	lastRefresh   time.Time
-	tabs          []string
-	activeTab     int
-	termWidth     int
-	termHgt       int
-	data          map[string]*platform.Quotas
-	errors        map[string]error
-	userName      string
-	loading       bool
-	err           error
-}
-
-type (
-	quotasLoadedMsg = multiMetroResult
-	quotasTickMsg   struct{}
-	quotasStatusMsg struct{}
-)
-
 const (
 	defaultQuotaBarWidth = 36
 	minQuotaBarWidth     = 10
 )
-
-func computeQuotaBarWidth(termWidth int) int {
-	if termWidth <= 0 {
-		return defaultQuotaBarWidth
-	}
-	const reserved = 42
-	w := termWidth - reserved
-	return max(minQuotaBarWidth, min(w, defaultQuotaBarWidth))
-}
-
-func newQuotasModel(ctx context.Context, metros []string, watchInterval *time.Duration) quotasModel {
-	var tabs []string
-	if len(metros) == 1 {
-		tabs = []string{metros[0]}
-	}
-	return quotasModel{
-		ctx:           ctx,
-		metros:        metros,
-		watchInterval: watchInterval,
-		tabs:          tabs,
-		data:          make(map[string]*platform.Quotas),
-		errors:        make(map[string]error),
-		loading:       true,
-	}
-}
-
-func (m quotasModel) Init() tea.Cmd {
-	if m.watchInterval != nil {
-		return tea.Batch(m.fetchCmd(), m.watchTickCmd(), m.watchStatusTickCmd())
-	}
-	return m.fetchCmd()
-}
-
-func (m quotasModel) fetchCmd() tea.Cmd {
-	ctx := m.ctx
-	metros := slices.Clone(m.metros)
-	return func() tea.Msg {
-		return fetchAllMetros(ctx, metros)
-	}
-}
-
-func (m quotasModel) watchTickCmd() tea.Cmd {
-	if m.watchInterval == nil {
-		return nil
-	}
-	return tea.Tick(*m.watchInterval, func(time.Time) tea.Msg {
-		return quotasTickMsg{}
-	})
-}
-
-func (m quotasModel) watchStatusTickCmd() tea.Cmd {
-	if m.watchInterval == nil {
-		return nil
-	}
-	return tea.Tick(50*time.Millisecond, func(time.Time) tea.Msg {
-		return quotasStatusMsg{}
-	})
-}
-
-func (m quotasModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg := msg.(type) {
-	case quotasLoadedMsg:
-		m.loading = false
-		if msg.err != nil {
-			m.err = msg.err
-			return m, nil
-		}
-		m.lastRefresh = time.Now()
-		m.userName = msg.userName
-		m.data = msg.data
-		m.errors = msg.errors
-		m.tabs = msg.tabs
-
-		if len(m.tabs) == 0 && len(m.metros) == 1 {
-			m.tabs = []string{m.metros[0]}
-		}
-		if m.activeTab >= len(m.tabs) {
-			m.activeTab = 0
-		}
-		return m, nil
-
-	case quotasTickMsg:
-		m.loading = true
-		return m, tea.Batch(m.fetchCmd(), m.watchTickCmd())
-
-	case quotasStatusMsg:
-		return m, m.watchStatusTickCmd()
-
-	case tea.KeyPressMsg:
-		switch msg.Keystroke() {
-		case "ctrl+c", "q", "escape":
-			return m, tea.Quit
-		case "tab", "right", "l":
-			if len(m.tabs) > 1 {
-				m.activeTab = (m.activeTab + 1) % len(m.tabs)
-			}
-		case "shift+tab", "left", "h":
-			if len(m.tabs) > 1 {
-				m.activeTab = (m.activeTab - 1 + len(m.tabs)) % len(m.tabs)
-			}
-		}
-
-	case tea.WindowSizeMsg:
-		m.termWidth = msg.Width
-		m.termHgt = msg.Height
-	}
-	return m, nil
-}
-
-func (m quotasModel) View() tea.View {
-	var view strings.Builder
-	if m.err != nil {
-		return tea.NewView(fmt.Sprintf("  Error: %v\n", m.err))
-	}
-
-	// Render tabs
-	view.WriteString("  ")
-	for i, tab := range m.tabs {
-		label := tab
-		if _, ok := m.errors[tab]; ok {
-			label = tab + "!"
-		}
-		if i == m.activeTab {
-			style := lipgloss.NewStyle().Foreground(colors.Slate50).Background(colors.Primary).Padding(0, 1)
-			if _, ok := m.errors[tab]; ok {
-				style = style.Foreground(colors.Warning)
-			}
-			view.WriteString(style.Render(label))
-		} else {
-			style := lipgloss.NewStyle().Faint(true).Padding(0, 1)
-			if _, ok := m.errors[tab]; ok {
-				style = style.Foreground(colors.Warning)
-			}
-			view.WriteString(style.Render(label))
-		}
-		if i < len(m.tabs)-1 {
-			view.WriteString(" ")
-		}
-	}
-	view.WriteString("\n\n")
-
-	// Render quota view
-	if m.loading && len(m.data) == 0 {
-		view.WriteString("  Loading quotas...\n")
-		return tea.NewView(view.String())
-	}
-
-	var q *platform.Quotas
-	if m.activeTab < len(m.tabs) {
-		tab := m.tabs[m.activeTab]
-		q = m.data[tab]
-	}
-
-	if q == nil {
-		if err := m.errors[m.tabs[m.activeTab]]; err != nil {
-			view.WriteString("  ")
-			view.WriteString(uitui.ErrorStyle.Render(err.Error()))
-			view.WriteString("\n")
-		} else {
-			view.WriteString("  No quota data available.\n")
-		}
-	} else {
-		view.WriteString(renderQuotaView(q, m.userName, computeQuotaBarWidth(m.termWidth)))
-	}
-
-	view.WriteString("\n")
-	view.WriteString(lipgloss.NewStyle().Italic(true).Faint(true).Render("  Tab/←→: switch metro  q: quit"))
-
-	if m.watchInterval != nil && !m.lastRefresh.IsZero() {
-		elapsed := time.Since(m.lastRefresh).Seconds()
-		status := fmt.Sprintf("  last refreshed %.1fs ago", elapsed)
-		status = lipgloss.NewStyle().Italic(true).Faint(true).Render(status)
-		view.WriteString(status)
-	}
-
-	quotaView := view.String()
-
-	viewW := max(computeQuotaBarWidth(m.termWidth), maxLineWidth(quotaView))
-	viewH := lineCount(quotaView)
-	if m.termWidth > 0 && m.termHgt > 0 && (m.termWidth < viewW || m.termHgt < viewH) {
-		var b strings.Builder
-		b.WriteString("  Terminal too small for quota view.\n")
-		b.WriteString("  Increase terminal size.\n\n")
-		fmt.Fprintf(&b, "  Current: width=%d height=%d\n", m.termWidth, m.termHgt)
-		fmt.Fprintf(&b, "  Needed:  width=%d height=%d\n", viewW, viewH)
-		return tea.NewView(b.String())
-	}
-
-	return tea.NewView(quotaView)
-}
-
-func lineCount(s string) int {
-	s = strings.TrimSuffix(s, "\n")
-	if s == "" {
-		return 0
-	}
-	return strings.Count(s, "\n") + 1
-}
-
-func maxLineWidth(s string) int {
-	maxWidth := 0
-	for line := range strings.SplitSeq(strings.TrimSuffix(s, "\n"), "\n") {
-		w := lipgloss.Width(line)
-		if w > maxWidth {
-			maxWidth = w
-		}
-	}
-	return maxWidth
-}
 
 func renderQuotaView(q *platform.Quotas, userName string, barWidth int) string {
 	var b strings.Builder

--- a/internal/cmd/metro_quotas_tui_js.go
+++ b/internal/cmd/metro_quotas_tui_js.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build js
+
+package cmd
+
+import (
+	"context"
+	"time"
+
+	"unikraft.com/cli/internal/config"
+)
+
+// runQuotasTUI falls back to plain rendering.  The browser terminal owns the
+// screen, so the full-screen view is not used there.
+func runQuotasTUI(ctx context.Context, stdio config.Stdio, cmd *MetroQuotasCmd, watch *time.Duration) error {
+	if watch != nil {
+		return cmd.watchRenderLoop(ctx, stdio.Stdout, *watch)
+	}
+	return cmd.renderOnce(ctx, stdio.Stdout)
+}

--- a/internal/cmd/metro_quotas_tui_native.go
+++ b/internal/cmd/metro_quotas_tui_native.go
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build !js
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"unikraft.com/cli/internal/config"
+	uitui "unikraft.com/cli/internal/tui/uitui"
+	xio "unikraft.com/cli/internal/x/io"
+	"unikraft.com/cloud/sdk/platform"
+	"unikraft.com/x/colors"
+)
+
+// runQuotasTUI shows quota usage in an interactive full-screen view.
+func runQuotasTUI(ctx context.Context, stdio config.Stdio, cmd *MetroQuotasCmd, watch *time.Duration) error {
+	m := newQuotasModel(ctx, cmd.Metro, watch)
+	p := tea.NewProgram(m, tea.WithInput(stdio.Stdin), tea.WithOutput(xio.Unwrap(stdio.Stdout)))
+	_, err := p.Run()
+	return err
+}
+
+type quotasModel struct {
+	ctx           context.Context
+	metros        []string
+	watchInterval *time.Duration
+	lastRefresh   time.Time
+	tabs          []string
+	activeTab     int
+	termWidth     int
+	termHgt       int
+	data          map[string]*platform.Quotas
+	errors        map[string]error
+	userName      string
+	loading       bool
+	err           error
+}
+
+type (
+	quotasLoadedMsg = multiMetroResult
+	quotasTickMsg   struct{}
+	quotasStatusMsg struct{}
+)
+
+func computeQuotaBarWidth(termWidth int) int {
+	if termWidth <= 0 {
+		return defaultQuotaBarWidth
+	}
+	const reserved = 42
+	w := termWidth - reserved
+	return max(minQuotaBarWidth, min(w, defaultQuotaBarWidth))
+}
+
+func newQuotasModel(ctx context.Context, metros []string, watchInterval *time.Duration) quotasModel {
+	var tabs []string
+	if len(metros) == 1 {
+		tabs = []string{metros[0]}
+	}
+	return quotasModel{
+		ctx:           ctx,
+		metros:        metros,
+		watchInterval: watchInterval,
+		tabs:          tabs,
+		data:          make(map[string]*platform.Quotas),
+		errors:        make(map[string]error),
+		loading:       true,
+	}
+}
+
+func (m quotasModel) Init() tea.Cmd {
+	if m.watchInterval != nil {
+		return tea.Batch(m.fetchCmd(), m.watchTickCmd(), m.watchStatusTickCmd())
+	}
+	return m.fetchCmd()
+}
+
+func (m quotasModel) fetchCmd() tea.Cmd {
+	ctx := m.ctx
+	metros := slices.Clone(m.metros)
+	return func() tea.Msg {
+		return fetchAllMetros(ctx, metros)
+	}
+}
+
+func (m quotasModel) watchTickCmd() tea.Cmd {
+	if m.watchInterval == nil {
+		return nil
+	}
+	return tea.Tick(*m.watchInterval, func(time.Time) tea.Msg {
+		return quotasTickMsg{}
+	})
+}
+
+func (m quotasModel) watchStatusTickCmd() tea.Cmd {
+	if m.watchInterval == nil {
+		return nil
+	}
+	return tea.Tick(50*time.Millisecond, func(time.Time) tea.Msg {
+		return quotasStatusMsg{}
+	})
+}
+
+func (m quotasModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case quotasLoadedMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.err = msg.err
+			return m, nil
+		}
+		m.lastRefresh = time.Now()
+		m.userName = msg.userName
+		m.data = msg.data
+		m.errors = msg.errors
+		m.tabs = msg.tabs
+
+		if len(m.tabs) == 0 && len(m.metros) == 1 {
+			m.tabs = []string{m.metros[0]}
+		}
+		if m.activeTab >= len(m.tabs) {
+			m.activeTab = 0
+		}
+		return m, nil
+
+	case quotasTickMsg:
+		m.loading = true
+		return m, tea.Batch(m.fetchCmd(), m.watchTickCmd())
+
+	case quotasStatusMsg:
+		return m, m.watchStatusTickCmd()
+
+	case tea.KeyPressMsg:
+		switch msg.Keystroke() {
+		case "ctrl+c", "q", "escape":
+			return m, tea.Quit
+		case "tab", "right", "l":
+			if len(m.tabs) > 1 {
+				m.activeTab = (m.activeTab + 1) % len(m.tabs)
+			}
+		case "shift+tab", "left", "h":
+			if len(m.tabs) > 1 {
+				m.activeTab = (m.activeTab - 1 + len(m.tabs)) % len(m.tabs)
+			}
+		}
+
+	case tea.WindowSizeMsg:
+		m.termWidth = msg.Width
+		m.termHgt = msg.Height
+	}
+	return m, nil
+}
+
+func (m quotasModel) View() tea.View {
+	var view strings.Builder
+	if m.err != nil {
+		return tea.NewView(fmt.Sprintf("  Error: %v\n", m.err))
+	}
+
+	// Render tabs
+	view.WriteString("  ")
+	for i, tab := range m.tabs {
+		label := tab
+		if _, ok := m.errors[tab]; ok {
+			label = tab + "!"
+		}
+		if i == m.activeTab {
+			style := lipgloss.NewStyle().Foreground(colors.Slate50).Background(colors.Primary).Padding(0, 1)
+			if _, ok := m.errors[tab]; ok {
+				style = style.Foreground(colors.Warning)
+			}
+			view.WriteString(style.Render(label))
+		} else {
+			style := lipgloss.NewStyle().Faint(true).Padding(0, 1)
+			if _, ok := m.errors[tab]; ok {
+				style = style.Foreground(colors.Warning)
+			}
+			view.WriteString(style.Render(label))
+		}
+		if i < len(m.tabs)-1 {
+			view.WriteString(" ")
+		}
+	}
+	view.WriteString("\n\n")
+
+	// Render quota view
+	if m.loading && len(m.data) == 0 {
+		view.WriteString("  Loading quotas...\n")
+		return tea.NewView(view.String())
+	}
+
+	var q *platform.Quotas
+	if m.activeTab < len(m.tabs) {
+		tab := m.tabs[m.activeTab]
+		q = m.data[tab]
+	}
+
+	if q == nil {
+		if err := m.errors[m.tabs[m.activeTab]]; err != nil {
+			view.WriteString("  ")
+			view.WriteString(uitui.ErrorStyle.Render(err.Error()))
+			view.WriteString("\n")
+		} else {
+			view.WriteString("  No quota data available.\n")
+		}
+	} else {
+		view.WriteString(renderQuotaView(q, m.userName, computeQuotaBarWidth(m.termWidth)))
+	}
+
+	view.WriteString("\n")
+	view.WriteString(lipgloss.NewStyle().Italic(true).Faint(true).Render("  Tab/←→: switch metro  q: quit"))
+
+	if m.watchInterval != nil && !m.lastRefresh.IsZero() {
+		elapsed := time.Since(m.lastRefresh).Seconds()
+		status := fmt.Sprintf("  last refreshed %.1fs ago", elapsed)
+		status = lipgloss.NewStyle().Italic(true).Faint(true).Render(status)
+		view.WriteString(status)
+	}
+
+	quotaView := view.String()
+
+	viewW := max(computeQuotaBarWidth(m.termWidth), maxLineWidth(quotaView))
+	viewH := lineCount(quotaView)
+	if m.termWidth > 0 && m.termHgt > 0 && (m.termWidth < viewW || m.termHgt < viewH) {
+		var b strings.Builder
+		b.WriteString("  Terminal too small for quota view.\n")
+		b.WriteString("  Increase terminal size.\n\n")
+		fmt.Fprintf(&b, "  Current: width=%d height=%d\n", m.termWidth, m.termHgt)
+		fmt.Fprintf(&b, "  Needed:  width=%d height=%d\n", viewW, viewH)
+		return tea.NewView(b.String())
+	}
+
+	return tea.NewView(quotaView)
+}
+
+func lineCount(s string) int {
+	s = strings.TrimSuffix(s, "\n")
+	if s == "" {
+		return 0
+	}
+	return strings.Count(s, "\n") + 1
+}
+
+func maxLineWidth(s string) int {
+	maxWidth := 0
+	for line := range strings.SplitSeq(strings.TrimSuffix(s, "\n"), "\n") {
+		w := lipgloss.Width(line)
+		if w > maxWidth {
+			maxWidth = w
+		}
+	}
+	return maxWidth
+}

--- a/internal/cmd/tui.go
+++ b/internal/cmd/tui.go
@@ -3,6 +3,8 @@
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
 
+//go:build !js
+
 package cmd
 
 import (

--- a/internal/cmd/tui_js.go
+++ b/internal/cmd/tui_js.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build js
+
+package cmd
+
+import (
+	"context"
+
+	"unikraft.com/cli/internal/config"
+)
+
+type TUICmd struct {
+	Resource string `arg:"" optional:"" help:"Resource type to browse."`
+	Name     string `arg:"" optional:"" help:"Resource key to open."`
+}
+
+// Run reports that the full-screen TUI needs a real terminal.
+func (cmd *TUICmd) Run(ctx context.Context, stdio config.Stdio) error {
+	return notAvailable("the TUI")
+}

--- a/internal/cmd/unavailable_js.go
+++ b/internal/cmd/unavailable_js.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build js
+
+package cmd
+
+import "fmt"
+
+// notAvailable reports that a command needs a local environment which the
+// browser build does not provide.  It names the native CLI as the alternative.
+func notAvailable(what string) error {
+	return fmt.Errorf(
+		"%s is not available in the web console; use the native unikraft CLI: https://unikraft.com/docs/cli",
+		what,
+	)
+}

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -3,6 +3,8 @@
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
 
+//go:build !js
+
 package cmd
 
 import (

--- a/internal/cmd/upgrade_js.go
+++ b/internal/cmd/upgrade_js.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build js
+
+package cmd
+
+import (
+	"context"
+
+	"unikraft.com/cli/internal/config"
+)
+
+type UpgradeCmd struct {
+	Channel string `help:"Release channel to upgrade from." default:"stable" enum:"stable,staging"`
+	Force   bool   `short:"f" help:"Force upgrade even if already at latest version."`
+	Version string `short:"v" help:"Upgrade to a specific version."`
+	BinDir  string `help:"Directory where to install the binary. If empty, uses the current binary location."`
+	BaseUrl string `help:"Base URL for fetching releases." env:"UNIKRAFT_CLI_INSTALL_URL" default:"https://pkg.unikraft.com" hidden:"true"`
+}
+
+// Run reports that self-upgrade needs a writable binary on disk.
+func (cmd *UpgradeCmd) Run(ctx context.Context, stdio config.Stdio) error {
+	return notAvailable("upgrade")
+}

--- a/internal/cmd/volumes.go
+++ b/internal/cmd/volumes.go
@@ -8,28 +8,16 @@ package cmd
 import (
 	"cmp"
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
-	"math"
-	"path/filepath"
 	"slices"
-	"strconv"
-	"time"
-
-	"github.com/containerd/platforms"
-	"github.com/docker/go-units"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/cloud/sdk/platform/group"
-	imagespec "unikraft.com/x/image-spec"
 	"unikraft.com/x/kingkong"
-	"unikraft.com/x/kraftfile"
 	"unikraft.com/x/log"
 	"unikraft.com/x/ptr"
 
-	"unikraft.com/cli/internal/builder"
 	"unikraft.com/cli/internal/config"
 	"unikraft.com/cli/internal/mirror"
 	"unikraft.com/cli/internal/multimetro"
@@ -38,7 +26,6 @@ import (
 	"unikraft.com/cli/internal/resource/patch"
 	"unikraft.com/cli/internal/resource/value"
 	"unikraft.com/cli/internal/types"
-	"unikraft.com/cli/internal/volimport"
 )
 
 type VolumesCmd struct {
@@ -665,156 +652,4 @@ func (VolumeImportCmd) Examples() []kingkong.Example {
 			Commands:    []string{"unikraft volume import my-volume --source ./Dockerfile"},
 		},
 	}
-}
-
-func (c *VolumeImportCmd) Run(ctx context.Context, stdio config.Stdio, partition *resource.Partition) error {
-	if c.Source == "" {
-		return fmt.Errorf("source path is required")
-	}
-
-	// Resolve source to an absolute path.
-	abs, err := filepath.Abs(c.Source)
-	if err != nil {
-		return fmt.Errorf("resolving source path: %w", err)
-	}
-	c.Source = abs
-
-	if c.Port < 1024 || c.Port > 65535 {
-		return fmt.Errorf("port must be between 1024 and 65535")
-	}
-
-	// Resolve the target volume.
-	gettable := partition.WrapGettable(Volume{})
-	resources, err := gettable.Get(ctx, []string{c.Volume})
-	if err != nil {
-		return err
-	}
-	if len(resources) == 0 {
-		return fmt.Errorf("volume not found: %s", c.Volume)
-	}
-	if len(resources) > 1 {
-		keys := make([]string, 0, len(resources))
-		for _, res := range resources {
-			keys = append(keys, res.Key().String())
-		}
-		return fmt.Errorf("ambiguous volume: %s (found %v)", c.Volume, keys)
-	}
-	vol, ok := resources[0].(Volume)
-	if !ok {
-		return fmt.Errorf("unexpected resource type %T", resources[0])
-	}
-
-	sourceType, err := builder.DetectSourceType(c.Source)
-	if err != nil {
-		return fmt.Errorf("detecting source type for %q: %w", c.Source, err)
-	}
-	plat := platforms.DefaultSpec()
-	plat.OS = imagespec.PlatformKraftcloud
-	importOpts := &builder.BuildOpts{
-		Rootfs: builder.FSOpts{
-			Path: c.Source,
-			Type: sourceType,
-			// Set format to CPIO as volimport expects a CPIO archive
-			Format: kraftfile.FsTypeCpio,
-		},
-		Platform: []ocispec.Platform{plat},
-	}
-
-	// Build an import archive from the data source.
-	log.G(ctx).Trace().Str("source", c.Source).Msg("packaging source as import archive")
-	images, err := builder.BuildRootfs(ctx, *importOpts)
-	if err != nil {
-		return fmt.Errorf("packaging source as import archive: %w", err)
-	}
-	if len(images) == 0 {
-		return fmt.Errorf("no images were built from the provided source")
-	}
-	if len(images) > 1 {
-		return fmt.Errorf("multiple images were built from the provided source; expected exactly one")
-	}
-	initrd := images[0].Initrd
-	if initrd == nil {
-		return fmt.Errorf("built image has no initrd")
-	}
-	defer func() {
-		if err := initrd.Cleanup(); err != nil {
-			log.G(ctx).Error().Err(err).Msg("cleaning up initrd")
-		}
-	}()
-
-	cpioReader, cpioSize, err := initrd.Open(ctx)
-	if err != nil {
-		return fmt.Errorf("opening import archive: %w", err)
-	}
-	defer cpioReader.Close()
-
-	authStr, err := volimport.GenRandAuth()
-	if err != nil {
-		return fmt.Errorf("generating authentication token: %w", err)
-	}
-
-	// Spawn a temporary volimport instance in the volume's metro.
-	g, err := multimetro.NewClient(ctx)
-	if err != nil {
-		return err
-	}
-	var instUUID, instFQDN string
-	var metroInsecure bool
-	if err := group.DoMetro(ctx, g, string(vol.Metro), func(ctx context.Context, mc multimetro.MetroClient) error {
-		metroInsecure = ptr.ZeroIfNil(mc.Metro.Insecure)
-		var merr error
-		volimportTimeout := uint64(10)
-		if deadline, ok := ctx.Deadline(); ok {
-			t := max(
-				// don't run past deadline (+2s for tolerance)
-				time.Until(deadline)+2*time.Second,
-				// set reasonable max timeout
-				10*time.Second,
-			)
-			volimportTimeout = uint64(math.Ceil(t.Seconds()))
-		}
-		instUUID, instFQDN, merr = volimport.Start(ctx, mc, c.Image, vol.UUID, authStr, volimportTimeout, c.Port)
-		return merr
-	}); err != nil {
-		return fmt.Errorf("spawning volume data import instance: %w", err)
-	}
-
-	defer func() {
-		if err := group.DoMetro(ctx, g, string(vol.Metro), func(ctx context.Context, mc multimetro.MetroClient) error {
-			return volimport.Terminate(ctx, mc, instUUID)
-		}); err != nil {
-			log.G(ctx).Error().Err(err).Msg("terminating volume data import instance")
-		}
-	}()
-
-	// Open a TLS connection to the instance and stream the CPIO archive.
-	instAddr := instFQDN + ":" + strconv.Itoa(c.Port)
-	log.G(ctx).Info().
-		Str("size", units.BytesSize(float64(cpioSize))).
-		Str("volume", c.Volume).
-		Msg("importing data into volume")
-
-	conn, err := tls.Dial("tcp", instAddr, &tls.Config{
-		InsecureSkipVerify: metroInsecure,
-	})
-	if err != nil {
-		return fmt.Errorf("connecting to volume import service at %s: %w", instAddr, err)
-	}
-	defer conn.Close()
-
-	freeSpace, totalSpace, err := volimport.Copy(ctx, conn, authStr, cpioReader, c.Force, uint64(cpioSize))
-	if err != nil {
-		return fmt.Errorf("importing data: %w", err)
-	}
-
-	log.G(ctx).Info().
-		Str("volume", c.Volume).
-		Str("free", units.BytesSize(float64(freeSpace))).
-		Str("total", units.BytesSize(float64(totalSpace))).
-		Msg("import complete")
-
-	// Wait for the import instance to stop; it auto-deletes via delete-on-stop.
-	return group.DoMetro(ctx, g, string(vol.Metro), func(ctx context.Context, mc multimetro.MetroClient) error {
-		return volimport.Wait(ctx, mc, instUUID)
-	})
 }

--- a/internal/cmd/volumes_import_js.go
+++ b/internal/cmd/volumes_import_js.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build js
+
+package cmd
+
+import (
+	"context"
+
+	"unikraft.com/cli/internal/config"
+	"unikraft.com/cli/internal/resource"
+)
+
+// Run reports that volume imports need local files and a raw TCP connection.
+func (c *VolumeImportCmd) Run(ctx context.Context, stdio config.Stdio, partition *resource.Partition) error {
+	return notAvailable("volume import")
+}

--- a/internal/cmd/volumes_import_native.go
+++ b/internal/cmd/volumes_import_native.go
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build !js
+
+package cmd
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"math"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/containerd/platforms"
+	"github.com/docker/go-units"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"unikraft.com/cloud/sdk/platform/group"
+	imagespec "unikraft.com/x/image-spec"
+	"unikraft.com/x/kraftfile"
+	"unikraft.com/x/log"
+	"unikraft.com/x/ptr"
+
+	"unikraft.com/cli/internal/builder"
+	"unikraft.com/cli/internal/config"
+	"unikraft.com/cli/internal/multimetro"
+	"unikraft.com/cli/internal/resource"
+	"unikraft.com/cli/internal/volimport"
+)
+
+func (c *VolumeImportCmd) Run(ctx context.Context, stdio config.Stdio, partition *resource.Partition) error {
+	if c.Source == "" {
+		return fmt.Errorf("source path is required")
+	}
+
+	// Resolve source to an absolute path.
+	abs, err := filepath.Abs(c.Source)
+	if err != nil {
+		return fmt.Errorf("resolving source path: %w", err)
+	}
+	c.Source = abs
+
+	if c.Port < 1024 || c.Port > 65535 {
+		return fmt.Errorf("port must be between 1024 and 65535")
+	}
+
+	// Resolve the target volume.
+	gettable := partition.WrapGettable(Volume{})
+	resources, err := gettable.Get(ctx, []string{c.Volume})
+	if err != nil {
+		return err
+	}
+	if len(resources) == 0 {
+		return fmt.Errorf("volume not found: %s", c.Volume)
+	}
+	if len(resources) > 1 {
+		keys := make([]string, 0, len(resources))
+		for _, res := range resources {
+			keys = append(keys, res.Key().String())
+		}
+		return fmt.Errorf("ambiguous volume: %s (found %v)", c.Volume, keys)
+	}
+	vol, ok := resources[0].(Volume)
+	if !ok {
+		return fmt.Errorf("unexpected resource type %T", resources[0])
+	}
+
+	sourceType, err := builder.DetectSourceType(c.Source)
+	if err != nil {
+		return fmt.Errorf("detecting source type for %q: %w", c.Source, err)
+	}
+	plat := platforms.DefaultSpec()
+	plat.OS = imagespec.PlatformKraftcloud
+	importOpts := &builder.BuildOpts{
+		Rootfs: builder.FSOpts{
+			Path: c.Source,
+			Type: sourceType,
+			// Set format to CPIO as volimport expects a CPIO archive
+			Format: kraftfile.FsTypeCpio,
+		},
+		Platform: []ocispec.Platform{plat},
+	}
+
+	// Build an import archive from the data source.
+	log.G(ctx).Trace().Str("source", c.Source).Msg("packaging source as import archive")
+	images, err := builder.BuildRootfs(ctx, *importOpts)
+	if err != nil {
+		return fmt.Errorf("packaging source as import archive: %w", err)
+	}
+	if len(images) == 0 {
+		return fmt.Errorf("no images were built from the provided source")
+	}
+	if len(images) > 1 {
+		return fmt.Errorf("multiple images were built from the provided source; expected exactly one")
+	}
+	initrd := images[0].Initrd
+	if initrd == nil {
+		return fmt.Errorf("built image has no initrd")
+	}
+	defer func() {
+		if err := initrd.Cleanup(); err != nil {
+			log.G(ctx).Error().Err(err).Msg("cleaning up initrd")
+		}
+	}()
+
+	cpioReader, cpioSize, err := initrd.Open(ctx)
+	if err != nil {
+		return fmt.Errorf("opening import archive: %w", err)
+	}
+	defer cpioReader.Close()
+
+	authStr, err := volimport.GenRandAuth()
+	if err != nil {
+		return fmt.Errorf("generating authentication token: %w", err)
+	}
+
+	// Spawn a temporary volimport instance in the volume's metro.
+	g, err := multimetro.NewClient(ctx)
+	if err != nil {
+		return err
+	}
+	var instUUID, instFQDN string
+	var metroInsecure bool
+	if err := group.DoMetro(ctx, g, string(vol.Metro), func(ctx context.Context, mc multimetro.MetroClient) error {
+		metroInsecure = ptr.ZeroIfNil(mc.Metro.Insecure)
+		var merr error
+		volimportTimeout := uint64(10)
+		if deadline, ok := ctx.Deadline(); ok {
+			t := max(
+				// don't run past deadline (+2s for tolerance)
+				time.Until(deadline)+2*time.Second,
+				// set reasonable max timeout
+				10*time.Second,
+			)
+			volimportTimeout = uint64(math.Ceil(t.Seconds()))
+		}
+		instUUID, instFQDN, merr = volimport.Start(ctx, mc, c.Image, vol.UUID, authStr, volimportTimeout, c.Port)
+		return merr
+	}); err != nil {
+		return fmt.Errorf("spawning volume data import instance: %w", err)
+	}
+
+	defer func() {
+		if err := group.DoMetro(ctx, g, string(vol.Metro), func(ctx context.Context, mc multimetro.MetroClient) error {
+			return volimport.Terminate(ctx, mc, instUUID)
+		}); err != nil {
+			log.G(ctx).Error().Err(err).Msg("terminating volume data import instance")
+		}
+	}()
+
+	// Open a TLS connection to the instance and stream the CPIO archive.
+	instAddr := instFQDN + ":" + strconv.Itoa(c.Port)
+	log.G(ctx).Info().
+		Str("size", units.BytesSize(float64(cpioSize))).
+		Str("volume", c.Volume).
+		Msg("importing data into volume")
+
+	conn, err := tls.Dial("tcp", instAddr, &tls.Config{
+		InsecureSkipVerify: metroInsecure,
+	})
+	if err != nil {
+		return fmt.Errorf("connecting to volume import service at %s: %w", instAddr, err)
+	}
+	defer conn.Close()
+
+	freeSpace, totalSpace, err := volimport.Copy(ctx, conn, authStr, cpioReader, c.Force, uint64(cpioSize))
+	if err != nil {
+		return fmt.Errorf("importing data: %w", err)
+	}
+
+	log.G(ctx).Info().
+		Str("volume", c.Volume).
+		Str("free", units.BytesSize(float64(freeSpace))).
+		Str("total", units.BytesSize(float64(totalSpace))).
+		Msg("import complete")
+
+	// Wait for the import instance to stop; it auto-deletes via delete-on-stop.
+	return group.DoMetro(ctx, g, string(vol.Metro), func(ctx context.Context, mc multimetro.MetroClient) error {
+		return volimport.Wait(ctx, mc, instUUID)
+	})
+}

--- a/internal/images/authprovider.go
+++ b/internal/images/authprovider.go
@@ -3,6 +3,8 @@
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
 
+//go:build !js
+
 package images
 
 import (

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -3,35 +3,25 @@
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
 
+//go:build !js
+
 package images
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/containerd/containerd/v2/core/remotes/docker"
-	"github.com/distribution/reference"
 	imagespec "unikraft.com/x/image-spec"
 
 	"unikraft.com/cli/internal/config"
-	xreference "unikraft.com/cli/internal/x/reference"
 )
-
-const DefaultRegistry = "unikraft.io"
 
 var defaultRegistries = []string{
 	"unikraft.io",
 	"index.unikraft.io",
 }
 
-type insecureContextKey struct{}
-
-// WithInsecureContext returns a context that carries insecure registry options,
-// which are picked up by Accessor.
-func WithInsecureContext(ctx context.Context, opts ...AccessorOpt) context.Context {
-	return context.WithValue(ctx, insecureContextKey{}, opts)
-}
-
+// Accessor builds a registry accessor for the current profile.
 func Accessor(ctx context.Context, opts ...AccessorOpt) (*imagespec.Accessor, error) {
 	if len(opts) == 0 {
 		if ctxOpts, ok := ctx.Value(insecureContextKey{}).([]AccessorOpt); ok {
@@ -58,55 +48,4 @@ func Accessor(ctx context.Context, opts ...AccessorOpt) (*imagespec.Accessor, er
 		imagespec.WithRegistryHeaders(options.Headers),
 		imagespec.WithReferenceParser(ParseNormalizedNamed),
 	), nil
-}
-
-// AccessorOpt is a functional option for configuring an Accessor.
-type AccessorOpt func(*accessorOpts)
-
-type accessorOpts struct {
-	insecureRegistries []string
-	allInsecure        bool
-}
-
-func WithInsecureRegistry(hosts ...string) AccessorOpt {
-	return func(o *accessorOpts) {
-		o.insecureRegistries = hosts
-	}
-}
-
-func WithInsecureRegistries() AccessorOpt {
-	return func(o *accessorOpts) {
-		o.allInsecure = true
-	}
-}
-
-func ParseNormalizedNamed(key string) (reference.Named, error) {
-	return ParseNormalizedNamedMetro(nil, key)
-}
-
-func ParseNormalizedNamedMetro(metro *config.Metro, key string) (reference.Named, error) {
-	if uri, err := imagespec.ParseURI(key); err == nil {
-		if uri.Scheme != imagespec.URISchemeOCI {
-			return nil, fmt.Errorf("%w: invalid scheme %q", reference.ErrReferenceInvalidFormat, uri.Scheme)
-		}
-		key = uri.Path
-	}
-
-	index := DefaultRegistry
-	if metro != nil {
-		index = metro.Index().Host
-	}
-	return xreference.ParseNormalizedNamed(
-		key,
-		xreference.WithDefaultDomain(index),
-		xreference.WithDefaultPrefix("official/"),
-	)
-}
-
-func FamiliarString(ref reference.Reference) string {
-	return xreference.FamiliarString(
-		ref,
-		xreference.WithDefaultDomain(DefaultRegistry),
-		xreference.WithDefaultPrefix("official/"),
-	)
 }

--- a/internal/images/options.go
+++ b/internal/images/options.go
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package images
+
+import "context"
+
+type insecureContextKey struct{}
+
+// WithInsecureContext returns a context that carries insecure registry options,
+// which are picked up by Accessor.
+func WithInsecureContext(ctx context.Context, opts ...AccessorOpt) context.Context {
+	return context.WithValue(ctx, insecureContextKey{}, opts)
+}
+
+// AccessorOpt is a functional option for configuring an Accessor.
+type AccessorOpt func(*accessorOpts)
+
+type accessorOpts struct {
+	insecureRegistries []string
+	allInsecure        bool
+}
+
+// WithInsecureRegistry allows insecure connections to the named hosts.
+func WithInsecureRegistry(hosts ...string) AccessorOpt {
+	return func(o *accessorOpts) {
+		o.insecureRegistries = hosts
+	}
+}
+
+// WithInsecureRegistries allows insecure connections to every host.
+func WithInsecureRegistries() AccessorOpt {
+	return func(o *accessorOpts) {
+		o.allInsecure = true
+	}
+}

--- a/internal/images/reference.go
+++ b/internal/images/reference.go
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package images
+
+import (
+	"github.com/distribution/reference"
+
+	"unikraft.com/cli/internal/config"
+	xreference "unikraft.com/cli/internal/x/reference"
+)
+
+const DefaultRegistry = "unikraft.io"
+
+// ParseNormalizedNamed parses an image reference against the default registry.
+func ParseNormalizedNamed(key string) (reference.Named, error) {
+	return ParseNormalizedNamedMetro(nil, key)
+}
+
+// ParseNormalizedNamedMetro parses an image reference against the metro's
+// registry, or the default registry when metro is nil.
+func ParseNormalizedNamedMetro(metro *config.Metro, key string) (reference.Named, error) {
+	key, err := stripImageURI(key)
+	if err != nil {
+		return nil, err
+	}
+
+	index := DefaultRegistry
+	if metro != nil {
+		index = metro.Index().Host
+	}
+	return xreference.ParseNormalizedNamed(
+		key,
+		xreference.WithDefaultDomain(index),
+		xreference.WithDefaultPrefix("official/"),
+	)
+}
+
+// FamiliarString renders a reference without the default registry and prefix.
+func FamiliarString(ref reference.Reference) string {
+	return xreference.FamiliarString(
+		ref,
+		xreference.WithDefaultDomain(DefaultRegistry),
+		xreference.WithDefaultPrefix("official/"),
+	)
+}

--- a/internal/images/resolver.go
+++ b/internal/images/resolver.go
@@ -3,6 +3,8 @@
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
 
+//go:build !js
+
 package images
 
 import (

--- a/internal/images/uri_js.go
+++ b/internal/images/uri_js.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build js
+
+package images
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/distribution/reference"
+)
+
+// stripImageURI rejects image URIs.  The web console has no local image store,
+// so only plain registry references are accepted.
+func stripImageURI(key string) (string, error) {
+	if scheme, rest, ok := strings.Cut(key, "://"); ok {
+		if scheme != "oci" {
+			return "", fmt.Errorf("%w: invalid scheme %q", reference.ErrReferenceInvalidFormat, scheme)
+		}
+		key = rest
+	}
+	return key, nil
+}

--- a/internal/images/uri_native.go
+++ b/internal/images/uri_native.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build !js
+
+package images
+
+import (
+	"fmt"
+
+	"github.com/distribution/reference"
+	imagespec "unikraft.com/x/image-spec"
+)
+
+// stripImageURI removes an "oci://" prefix from key and rejects every other
+// scheme.  Keys without a scheme pass through unchanged.
+func stripImageURI(key string) (string, error) {
+	if uri, err := imagespec.ParseURI(key); err == nil {
+		if uri.Scheme != imagespec.URISchemeOCI {
+			return "", fmt.Errorf("%w: invalid scheme %q", reference.ErrReferenceInvalidFormat, uri.Scheme)
+		}
+		key = uri.Path
+	}
+	return key, nil
+}

--- a/internal/multimetro/client.go
+++ b/internal/multimetro/client.go
@@ -11,7 +11,6 @@ import (
 
 	"unikraft.com/cloud/sdk/platform"
 	"unikraft.com/cloud/sdk/platform/group"
-	"unikraft.com/x/iata"
 	"unikraft.com/x/log"
 	"unikraft.com/x/ptr"
 
@@ -88,11 +87,7 @@ func GetMetros(ctx context.Context, profile *config.Profile) ([]config.Metro, er
 
 	var metros []config.Metro
 	for _, metro := range metroResp.Data.Metros {
-		// Normalize the metro's IATA code via the iata package.
-		location := metro.IataCode
-		if matched := iata.ToIata(location); matched != iata.IataUnknown {
-			location = matched.Code
-		}
+		location := normalizeIataCode(metro.IataCode)
 		metros = append(metros, config.Metro{
 			Name:     metro.Name,
 			Endpoint: metro.Endpoint,

--- a/internal/multimetro/iata_js.go
+++ b/internal/multimetro/iata_js.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build js
+
+package multimetro
+
+// normalizeIataCode returns the code as the control plane reported it.  The
+// lookup table behind the canonical form is too large for the wasm backend, and
+// the web console reads its metro list from the console itself.
+func normalizeIataCode(code string) string {
+	return code
+}

--- a/internal/multimetro/iata_native.go
+++ b/internal/multimetro/iata_native.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build !js
+
+package multimetro
+
+import "unikraft.com/x/iata"
+
+// normalizeIataCode returns the canonical form of an IATA code, or the code
+// unchanged when it is not recognised.
+func normalizeIataCode(code string) string {
+	if matched := iata.ToIata(code); matched != iata.IataUnknown {
+		return matched.Code
+	}
+	return code
+}

--- a/internal/resource/patch/editor_exec_js.go
+++ b/internal/resource/patch/editor_exec_js.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build js
+
+package patch
+
+import (
+	"context"
+	"errors"
+)
+
+// errNoEditor reports that the web console cannot launch an editor.
+var errNoEditor = errors.New("editing with --visual or --cmd is not available in the web console; use --set, --load or --save -")
+
+// CommandEditorFunc reports that running an editor needs a local shell.
+func CommandEditorFunc(command string) EditorFunc {
+	return func(ctx context.Context, input []byte) ([]byte, error) {
+		return nil, errNoEditor
+	}
+}
+
+// VisualCommandEditorFunc reports that running an editor needs a local shell.
+func VisualCommandEditorFunc() (EditorFunc, error) {
+	return nil, errNoEditor
+}

--- a/internal/resource/patch/editor_exec_native.go
+++ b/internal/resource/patch/editor_exec_native.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build !js
+
+package patch
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// CommandEditorFunc creates an EditorFunc that runs a shell command with YAML on stdin
+// and reads the edited YAML from stdout.
+func CommandEditorFunc(command string) EditorFunc {
+	return func(ctx context.Context, input []byte) ([]byte, error) {
+		cmd := exec.CommandContext(ctx, "sh", "-c", command)
+		cmd.Stdin = bytes.NewReader(input)
+		cmd.Stderr = os.Stderr
+
+		output, err := cmd.Output()
+		if err != nil {
+			return nil, fmt.Errorf("command exited with error: %w", err)
+		}
+		return output, nil
+	}
+}
+
+// VisualCommandEditorFunc creates an EditorFunc that uses a temp file and system editor.
+func VisualCommandEditorFunc() (EditorFunc, error) {
+	editorCmd, err := getEditor()
+	if err != nil {
+		return nil, err
+	}
+	return func(ctx context.Context, input []byte) ([]byte, error) {
+		tmpfile, err := os.CreateTemp("", "unikraft-edit-*.yaml")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create temp file: %w", err)
+		}
+		defer os.Remove(tmpfile.Name())
+
+		if _, err := tmpfile.Write(input); err != nil {
+			tmpfile.Close()
+			return nil, fmt.Errorf("failed to write temp file: %w", err)
+		}
+		if err := tmpfile.Close(); err != nil {
+			return nil, fmt.Errorf("failed to close temp file: %w", err)
+		}
+
+		cmd := exec.CommandContext(ctx, editorCmd, tmpfile.Name())
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return nil, fmt.Errorf("editor exited with error: %w", err)
+		}
+
+		output, err := os.ReadFile(tmpfile.Name())
+		if err != nil {
+			return nil, fmt.Errorf("failed to read edited file: %w", err)
+		}
+		return output, nil
+	}, nil
+}
+
+func getEditor() (string, error) {
+	if editor := os.Getenv("VISUAL"); editor != "" {
+		return editor, nil
+	}
+	if editor := os.Getenv("EDITOR"); editor != "" {
+		return editor, nil
+	}
+	return "", fmt.Errorf("no editor set: please set $VISUAL or $EDITOR")
+}

--- a/internal/resource/patch/visual.go
+++ b/internal/resource/patch/visual.go
@@ -12,8 +12,6 @@ import (
 	"encoding"
 	"fmt"
 	"io"
-	"os"
-	"os/exec"
 	"reflect"
 	"slices"
 
@@ -49,59 +47,6 @@ func SaveYAML(res resource.Resource, fields []resource.Field, patches []resource
 		return fmt.Errorf("failed to write YAML: %w", err)
 	}
 	return nil
-}
-
-// CommandEditorFunc creates an EditorFunc that runs a shell command with YAML on stdin
-// and reads the edited YAML from stdout.
-func CommandEditorFunc(command string) EditorFunc {
-	return func(ctx context.Context, input []byte) ([]byte, error) {
-		cmd := exec.CommandContext(ctx, "sh", "-c", command)
-		cmd.Stdin = bytes.NewReader(input)
-		cmd.Stderr = os.Stderr
-
-		output, err := cmd.Output()
-		if err != nil {
-			return nil, fmt.Errorf("command exited with error: %w", err)
-		}
-		return output, nil
-	}
-}
-
-// VisualCommandEditorFunc creates an EditorFunc that uses a temp file and system editor.
-func VisualCommandEditorFunc() (EditorFunc, error) {
-	editorCmd, err := getEditor()
-	if err != nil {
-		return nil, err
-	}
-	return func(ctx context.Context, input []byte) ([]byte, error) {
-		tmpfile, err := os.CreateTemp("", "unikraft-edit-*.yaml")
-		if err != nil {
-			return nil, fmt.Errorf("failed to create temp file: %w", err)
-		}
-		defer os.Remove(tmpfile.Name())
-
-		if _, err := tmpfile.Write(input); err != nil {
-			tmpfile.Close()
-			return nil, fmt.Errorf("failed to write temp file: %w", err)
-		}
-		if err := tmpfile.Close(); err != nil {
-			return nil, fmt.Errorf("failed to close temp file: %w", err)
-		}
-
-		cmd := exec.CommandContext(ctx, editorCmd, tmpfile.Name())
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			return nil, fmt.Errorf("editor exited with error: %w", err)
-		}
-
-		output, err := os.ReadFile(tmpfile.Name())
-		if err != nil {
-			return nil, fmt.Errorf("failed to read edited file: %w", err)
-		}
-		return output, nil
-	}, nil
 }
 
 // ContentEditorFunc creates an EditorFunc that ignores input and returns the provided content.
@@ -461,14 +406,4 @@ func normalizeValue(v any) any {
 		}
 	}
 	return v
-}
-
-func getEditor() (string, error) {
-	if editor := os.Getenv("VISUAL"); editor != "" {
-		return editor, nil
-	}
-	if editor := os.Getenv("EDITOR"); editor != "" {
-		return editor, nil
-	}
-	return "", fmt.Errorf("no editor set: please set $VISUAL or $EDITOR")
 }

--- a/internal/telemetry/distinctid_js.go
+++ b/internal/telemetry/distinctid_js.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build js
+
+package telemetry
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// generateDistinctID returns a fixed anonymous ID.  The browser exposes no
+// machine characteristics to fingerprint.
+func generateDistinctID() string {
+	hash := sha256.Sum256([]byte("web-console-unikraft-cli"))
+	return hex.EncodeToString(hash[:16])
+}

--- a/internal/telemetry/distinctid_native.go
+++ b/internal/telemetry/distinctid_native.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build !js
+
+package telemetry
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+
+	"unikraft.com/x/fingerprint"
+)
+
+// generateDistinctID creates an anonymous distinct ID based on machine fingerprint.
+// The ID is a SHA-256 hash to ensure privacy while maintaining consistency.
+func generateDistinctID() string {
+	fp, err := fingerprint.New()
+	if err != nil {
+		// Fallback to hostname-based ID
+		hostname, _ := os.Hostname()
+		hash := sha256.Sum256([]byte(hostname + "-unikraft-cli"))
+		return hex.EncodeToString(hash[:16])
+	}
+
+	// Create a stable fingerprint string from machine characteristics
+	fpStr := fmt.Sprintf("%s-%s-%s-%s-%t",
+		fp.Hostname,
+		fp.Os,
+		fp.Goarch,
+		fp.Goos,
+		fp.Container,
+	)
+	hash := sha256.Sum256([]byte(fpStr))
+	return hex.EncodeToString(hash[:16])
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/posthog/posthog-go"
 
-	"unikraft.com/x/fingerprint"
 	"unikraft.com/x/version"
 )
 
@@ -81,29 +80,6 @@ func Init() error {
 	sessionID = generateSessionID()
 
 	return nil
-}
-
-// generateDistinctID creates an anonymous distinct ID based on machine fingerprint.
-// The ID is a SHA-256 hash to ensure privacy while maintaining consistency.
-func generateDistinctID() string {
-	fp, err := fingerprint.New()
-	if err != nil {
-		// Fallback to hostname-based ID
-		hostname, _ := os.Hostname()
-		hash := sha256.Sum256([]byte(hostname + "-unikraft-cli"))
-		return hex.EncodeToString(hash[:16])
-	}
-
-	// Create a stable fingerprint string from machine characteristics
-	fpStr := fmt.Sprintf("%s-%s-%s-%s-%t",
-		fp.Hostname,
-		fp.Os,
-		fp.Goarch,
-		fp.Goos,
-		fp.Container,
-	)
-	hash := sha256.Sum256([]byte(fpStr))
-	return hex.EncodeToString(hash[:16])
 }
 
 // generateDistinctID creates a unique session ID for this CLI invocation, which

--- a/internal/tui/selector/colors.go
+++ b/internal/tui/selector/colors.go
@@ -3,6 +3,8 @@
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
 
+//go:build !js
+
 package selector
 
 import (

--- a/internal/tui/selector/selector_js.go
+++ b/internal/tui/selector/selector_js.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build js
+
+package selector
+
+import jujuerrors "github.com/juju/errors"
+
+var ErrNoOptionSelected = jujuerrors.New("no option selected")
+
+// ErrNotInteractive reports that the caller must name its choice up front.
+var ErrNotInteractive = jujuerrors.New("interactive selection is not available in the web console; pass the value as an argument")
+
+// Single reports that interactive prompts need a real terminal.
+func Single[T ~string](question string, options ...T) (T, error) {
+	var zero T
+	return zero, ErrNotInteractive
+}
+
+// SingleWithDefault reports that interactive prompts need a real terminal.
+func SingleWithDefault[T ~string](question string, defaultValue string, options ...T) (T, error) {
+	var zero T
+	return zero, ErrNotInteractive
+}

--- a/internal/tui/selector/single.go
+++ b/internal/tui/selector/single.go
@@ -3,6 +3,8 @@
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
 
+//go:build !js
+
 package selector
 
 import (

--- a/internal/tui/watcher/model.go
+++ b/internal/tui/watcher/model.go
@@ -3,6 +3,8 @@
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
 
+//go:build !js
+
 package watcher
 
 import (

--- a/internal/tui/watcher/watcher.go
+++ b/internal/tui/watcher/watcher.go
@@ -12,8 +12,6 @@ import (
 	"io"
 	"time"
 
-	tea "charm.land/bubbletea/v2"
-
 	xio "unikraft.com/cli/internal/x/io"
 )
 
@@ -22,33 +20,6 @@ func WatchOutput(ctx context.Context, interval time.Duration, out io.Writer, ren
 		return watchOutputPretty(ctx, interval, xio.Unwrap(out), render)
 	}
 	return watchOutputPlain(ctx, interval, out, render)
-}
-
-func watchOutputPretty(ctx context.Context, interval time.Duration, out io.Writer, render func(io.Writer) error) error {
-	program := tea.NewProgram(
-		watchModel{underlying: out, render: render, interval: interval},
-		tea.WithOutput(out),
-		tea.WithContext(ctx),
-	)
-
-	finalModel, err := program.Run()
-	if errors.Is(err, tea.ErrInterrupted) || errors.Is(err, tea.ErrProgramKilled) {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	if err := ctx.Err(); err != nil {
-		if errors.Is(err, context.Canceled) {
-			return nil
-		}
-		return err
-	}
-
-	if model, ok := finalModel.(watchModel); ok && model.err != nil {
-		return model.err
-	}
-	return nil
 }
 
 func watchOutputPlain(ctx context.Context, interval time.Duration, out io.Writer, render func(io.Writer) error) error {

--- a/internal/tui/watcher/watcher_js.go
+++ b/internal/tui/watcher/watcher_js.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build js
+
+package watcher
+
+import (
+	"context"
+	"io"
+	"time"
+)
+
+// watchOutputPretty falls back to plain re-rendering.  The browser terminal
+// owns the screen, so the alternate-screen view is not used there.
+func watchOutputPretty(ctx context.Context, interval time.Duration, out io.Writer, render func(io.Writer) error) error {
+	return watchOutputPlain(ctx, interval, out, render)
+}

--- a/internal/tui/watcher/watcher_native.go
+++ b/internal/tui/watcher/watcher_native.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2025, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build !js
+
+package watcher
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func watchOutputPretty(ctx context.Context, interval time.Duration, out io.Writer, render func(io.Writer) error) error {
+	program := tea.NewProgram(
+		watchModel{underlying: out, render: render, interval: interval},
+		tea.WithOutput(out),
+		tea.WithContext(ctx),
+	)
+
+	finalModel, err := program.Run()
+	if errors.Is(err, tea.ErrInterrupted) || errors.Is(err, tea.ErrProgramKilled) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		if errors.Is(err, context.Canceled) {
+			return nil
+		}
+		return err
+	}
+
+	if model, ok := finalModel.(watchModel); ok && model.err != nil {
+		return model.err
+	}
+	return nil
+}

--- a/internal/x/io/tty_js.go
+++ b/internal/x/io/tty_js.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build js
+
+package io
+
+import (
+	"io"
+	"os"
+	"strconv"
+)
+
+// forceTTYEnv makes the host declare that stdout is a terminal.  The browser
+// terminal renders ANSI output but has no file descriptor to probe.
+const forceTTYEnv = "UNIKRAFT_FORCE_TTY"
+
+// defaultTermWidth is used when the host does not report a width.
+const defaultTermWidth = 80
+
+// IsTTY reports whether the host declared its output to be a terminal.
+func IsTTY(w io.Writer) bool {
+	return os.Getenv(forceTTYEnv) == "1"
+}
+
+// IsTTYReader always reports false.  Standard input is a pipe fed by the host,
+// so callers must read it rather than skip it.
+func IsTTYReader(r io.Reader) bool {
+	return false
+}
+
+// TermWidth returns the width the host reported in COLUMNS.
+func TermWidth(w io.Writer) int {
+	if cols, err := strconv.Atoi(os.Getenv("COLUMNS")); err == nil && cols > 0 {
+		return cols
+	}
+	return defaultTermWidth
+}

--- a/internal/x/io/tty_native.go
+++ b/internal/x/io/tty_native.go
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+//go:build !js
+
+package io
+
+import (
+	"io"
+
+	"github.com/charmbracelet/x/term"
+	"unikraft.com/x/guesstermwidth"
+)
+
+func isTerminal(v any) bool {
+	fd, ok := v.(interface{ Fd() uintptr })
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(fd.Fd())
+}
+
+// IsTTY reports whether the writer ultimately targets a terminal, transparently
+// peeling off known wrappers via Unwrap.
+func IsTTY(w io.Writer) bool {
+	return isTerminal(Unwrap(w))
+}
+
+// IsTTYReader reports whether the reader ultimately draws from a terminal.
+func IsTTYReader(r io.Reader) bool {
+	return isTerminal(r)
+}
+
+// TermWidth returns the terminal width for the writer, transparently peeling
+// off known wrappers via Unwrap.
+func TermWidth(w io.Writer) int {
+	return guesstermwidth.GuessTermWidth(Unwrap(w))
+}

--- a/internal/x/io/unwrap.go
+++ b/internal/x/io/unwrap.go
@@ -9,8 +9,6 @@ import (
 	"io"
 
 	"github.com/charmbracelet/colorprofile"
-	"github.com/charmbracelet/x/term"
-	"unikraft.com/x/guesstermwidth"
 )
 
 // Unwrap peels off known io.Writer wrappers to expose the underlying writer.
@@ -23,29 +21,4 @@ func Unwrap(w io.Writer) io.Writer {
 			return w
 		}
 	}
-}
-
-func isTerminal(v any) bool {
-	fd, ok := v.(interface{ Fd() uintptr })
-	if !ok {
-		return false
-	}
-	return term.IsTerminal(fd.Fd())
-}
-
-// IsTTY reports whether the writer ultimately targets a terminal, transparently
-// peeling off known wrappers via Unwrap.
-func IsTTY(w io.Writer) bool {
-	return isTerminal(Unwrap(w))
-}
-
-// IsTTYReader reports whether the reader ultimately draws from a terminal.
-func IsTTYReader(r io.Reader) bool {
-	return isTerminal(r)
-}
-
-// TermWidth returns the terminal width for the writer, transparently peeling
-// off known wrappers via Unwrap.
-func TermWidth(w io.Writer) int {
-	return guesstermwidth.GuessTermWidth(Unwrap(w))
 }


### PR DESCRIPTION
The CLI did not compile for GOOS=js GOARCH=wasm, so the dashboard could not run it in the browser. The build graph reached BuildKit, containerd, Docker, Bubble Tea, a machine fingerprint and a large generated IATA table, none of which the wasm backend accepts.

Commands that need a local daemon, terminal or filesystem now split into `!js` and `js` files. The js side keeps the kong structs, so help output is unchanged, and reports that the command belongs to the native CLI. A `wasm` task builds and compresses the module.

Not yet ready for review