### PR TITLE
fix(integration): Remove leaked test binary dir

### DIFF
--- a/cmd/unikraft/integration/helpers_test.go
+++ b/cmd/unikraft/integration/helpers_test.go
@@ -28,8 +28,7 @@ import (
 
 func TestMain(m *testing.M) {
 	code := m.Run()
-	integ.CleanupSharedImages()
-	integ.CleanupUnikraftBinary()
+	integ.Cleanup()
 	os.Exit(code)
 }
 

--- a/cmd/unikraft/integration/helpers_test.go
+++ b/cmd/unikraft/integration/helpers_test.go
@@ -29,6 +29,7 @@ import (
 func TestMain(m *testing.M) {
 	code := m.Run()
 	integ.CleanupSharedImages()
+	integ.CleanupUnikraftBinary()
 	os.Exit(code)
 }
 

--- a/cmd/unikraft/main_test.go
+++ b/cmd/unikraft/main_test.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	integ "unikraft.com/cli/internal/integration"
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	integ.CleanupUnikraftBinary()
+	os.Exit(code)
+}

--- a/internal/integration/build.go
+++ b/internal/integration/build.go
@@ -62,8 +62,8 @@ func BuildUnikraft(t *testing.T) string {
 	return buildBinaryPath
 }
 
-// CleanupUnikraftBinary deletes the temporary directory of the built binary.
-func CleanupUnikraftBinary() {
+// cleanupUnikraftBinary deletes the temporary directory of the built binary.
+func cleanupUnikraftBinary() {
 	if buildBinaryDir == "" {
 		return
 	}

--- a/internal/integration/build.go
+++ b/internal/integration/build.go
@@ -21,6 +21,7 @@ import (
 
 var (
 	buildOnce       sync.Once
+	buildBinaryDir  string
 	buildBinaryPath string
 	buildBinaryErr  error
 )
@@ -35,6 +36,7 @@ func BuildUnikraft(t *testing.T) string {
 			buildBinaryErr = fmt.Errorf("create temp dir: %w", err)
 			return
 		}
+		buildBinaryDir = binaryDir
 		binaryName := "unikraft"
 		if runtime.GOOS == "windows" {
 			binaryName += ".exe"
@@ -58,4 +60,15 @@ func BuildUnikraft(t *testing.T) string {
 	})
 	require.NoError(t, buildBinaryErr)
 	return buildBinaryPath
+}
+
+// CleanupUnikraftBinary deletes the temporary directory of the built binary.
+func CleanupUnikraftBinary() {
+	if buildBinaryDir == "" {
+		return
+	}
+	if err := os.RemoveAll(buildBinaryDir); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to cleanup unikraft binary: %v\n", err)
+	}
+	buildBinaryDir = ""
 }

--- a/internal/integration/cleanup.go
+++ b/internal/integration/cleanup.go
@@ -3,17 +3,10 @@
 // Licensed under the BSD-3-Clause License (the "License").
 // You may not use this file except in compliance with the License.
 
-package main
+package integration
 
-import (
-	"os"
-	"testing"
-
-	integ "unikraft.com/cli/internal/integration"
-)
-
-func TestMain(m *testing.M) {
-	code := m.Run()
-	integ.Cleanup()
-	os.Exit(code)
+// Cleanup releases every resource that the test helpers make.
+func Cleanup() {
+	cleanupSharedImages()
+	cleanupUnikraftBinary()
 }

--- a/internal/integration/image.go
+++ b/internal/integration/image.go
@@ -84,7 +84,7 @@ func (i *Image) Build(t *testing.T, env *TestEnv, ref string, opts ...CmdOption)
 }
 
 // SharedImage is an image that tests use. Build makes the image one time,
-// and CleanupSharedImages deletes it when the test binary ends.
+// and Cleanup deletes it when the test binary ends.
 type SharedImage struct {
 	Image
 
@@ -143,8 +143,8 @@ func registerSharedImage(env *TestEnv, ref string) {
 	sharedImageRefs = append(sharedImageRefs, ref)
 }
 
-// CleanupSharedImages deletes every shared image from the registry.
-func CleanupSharedImages() {
+// cleanupSharedImages deletes every shared image from the registry.
+func cleanupSharedImages() {
 	sharedImageMu.Lock()
 	cfg := sharedImageConfig
 	refs := slices.Clone(sharedImageRefs)


### PR DESCRIPTION
BuildUnikraft put the 51 MB test binary in a temporary directory that nothing removed. Two test packages call it, so every run left two directories behind in /tmp, which is a tmpfs and holds them in RAM.

CleanupUnikraftBinary deletes the directory, in the manner of CleanupSharedImages. TestMain of each package that builds the binary calls it. The package cmd/unikraft has a new TestMain.