### PR TITLE
fix: Format longer terminal help text as mdx for the docs

### DIFF
--- a/cmd/unikraft/testdata/TestHelp/api
+++ b/cmd/unikraft/testdata/TestHelp/api
@@ -15,8 +15,8 @@ one of:
   {...}        Inline JSON object (merges with other arguments).
   [...]        Inline JSON array (replaces the entire body).
   key=value    Set a key to a literal string value.
-  key:=raw     Set a key to a raw JSON value (number, boolean, null, object,
-               or array constructed from raw JSON).
+  key:=raw     Set a key to a raw JSON value (number, boolean, null,
+               object, or array constructed from raw JSON).
 
 NESTED JSON SYNTAX
 
@@ -54,10 +54,8 @@ object.
 
   [N][key]=value
       Creates an array of objects and assigns at index N.
-      Example: [0][type]=platform [0][name]=desktop [1][type]=platform
-[1][name]=web
-      Produces:
-[{"type":"platform","name":"desktop"},{"type":"platform","name":"web"}]
+      Example: [0][name]=web [0][port]:=80 [1][name]=api [1][port]:=90
+      Produces: [{"name":"web","port":80},{"name":"api","port":90}]
 
   []=value
       Appends raw values to the root array.
@@ -99,10 +97,6 @@ WHITESPACE IN VALUES
 
 If a value contains spaces, quote the entire argument:
   unikraft api /v1/volumes "name=my test volume" stars:=54000
-
-EXAMPLES
-
-The examples below demonstrate many of the syntax forms described above.
 
 Usage:
   unikraft api <endpoint> [<data> ...] [flags]

--- a/internal/cmd/api.go
+++ b/internal/cmd/api.go
@@ -260,8 +260,8 @@ one of:
   {...}        Inline JSON object (merges with other arguments).
   [...]        Inline JSON array (replaces the entire body).
   key=value    Set a key to a literal string value.
-  key:=raw     Set a key to a raw JSON value (number, boolean, null, object,
-               or array constructed from raw JSON).
+  key:=raw     Set a key to a raw JSON value (number, boolean, null,
+               object, or array constructed from raw JSON).
 
 NESTED JSON SYNTAX
 
@@ -299,8 +299,8 @@ object.
 
   [N][key]=value
       Creates an array of objects and assigns at index N.
-      Example: [0][type]=platform [0][name]=desktop [1][type]=platform [1][name]=web
-      Produces: [{"type":"platform","name":"desktop"},{"type":"platform","name":"web"}]
+      Example: [0][name]=web [0][port]:=80 [1][name]=api [1][port]:=90
+      Produces: [{"name":"web","port":80},{"name":"api","port":90}]
 
   []=value
       Appends raw values to the root array.
@@ -341,11 +341,7 @@ the same path.
 WHITESPACE IN VALUES
 
 If a value contains spaces, quote the entire argument:
-  unikraft api /v1/volumes "name=my test volume" stars:=54000
-
-EXAMPLES
-
-The examples below demonstrate many of the syntax forms described above.`
+  unikraft api /v1/volumes "name=my test volume" stars:=54000`
 }
 
 func (APICmd) Examples() []kingkong.Example {

--- a/tools/gendocs/detail.go
+++ b/tools/gendocs/detail.go
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package main
+
+import (
+	"regexp"
+	"strings"
+)
+
+// headingPattern matches an ALL-CAPS section heading, e.g. "REQUEST BODY
+// SYNTAX" or "TOP-LEVEL ARRAY SYNTAX".
+var headingPattern = regexp.MustCompile(`^[A-Z][A-Z0-9]*(?:[ -][A-Z0-9]+)*$`)
+
+// acronyms keep their capitalisation when an ALL-CAPS heading is lowered to
+// sentence case.
+var acronyms = map[string]bool{
+	"API":   true,
+	"CLI":   true,
+	"HTTP":  true,
+	"HTTPS": true,
+	"ID":    true,
+	"JSON":  true,
+	"OCI":   true,
+	"TLS":   true,
+	"TUI":   true,
+	"URL":   true,
+	"UUID":  true,
+	"YAML":  true,
+}
+
+// formatDetail turns a long command description into Markdown, promoting its
+// section headings to the given heading level.
+//
+// Long descriptions are written for the terminal, in the style of a man page:
+// ALL-CAPS section headings and preformatted blocks indented by two or more
+// spaces. A Markdown renderer reflows all of that as prose, which collapses
+// the aligned columns onto one line and swallows the backslashes that document
+// escaping. Headings become sections and indented runs become fenced code
+// blocks, so both the generated MDX and the man pages keep the layout the text
+// was written with.
+//
+// The heading level matters for the man pages: md2man renders both "#" and
+// "##" as .SH, which would make each section a sibling of DESCRIPTION rather
+// than a part of it, so man generation asks for "###" and gets .SS instead.
+func formatDetail(text string, level int) string {
+	heading := strings.Repeat("#", level) + " "
+	lines := strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n")
+
+	var out []string
+	appendBlank := func() {
+		if len(out) > 0 && out[len(out)-1] != "" {
+			out = append(out, "")
+		}
+	}
+
+	for i := 0; i < len(lines); {
+		line := lines[i]
+		switch {
+		case strings.TrimSpace(line) == "":
+			appendBlank()
+			i++
+
+		case isIndented(line):
+			block, next := indentedBlock(lines, i)
+			appendBlank()
+			out = append(out, fence(block)...)
+			out = append(out, "")
+			i = next
+
+		case isHeading(lines, i):
+			appendBlank()
+			out = append(out, heading+sentenceCase(strings.TrimSpace(line)))
+			out = append(out, "")
+			i++
+
+		default:
+			out = append(out, line)
+			i++
+		}
+	}
+
+	return strings.TrimRight(strings.Join(out, "\n"), "\n")
+}
+
+// isIndented reports whether line begins a preformatted block, i.e. it carries
+// at least two leading spaces.
+func isIndented(line string) bool {
+	return strings.HasPrefix(line, "  ")
+}
+
+// isHeading reports whether the line at index i is a section heading: an
+// ALL-CAPS line standing alone in its own paragraph.
+func isHeading(lines []string, i int) bool {
+	if !headingPattern.MatchString(strings.TrimRight(lines[i], " ")) {
+		return false
+	}
+	if i > 0 && strings.TrimSpace(lines[i-1]) != "" {
+		return false
+	}
+	return i == len(lines)-1 || strings.TrimSpace(lines[i+1]) == ""
+}
+
+// indentedBlock collects the run of indented lines starting at index i,
+// including any blank lines it straddles, and returns it dedented along with
+// the index of the first line after the run.
+func indentedBlock(lines []string, i int) ([]string, int) {
+	end := i
+	for j := i; j < len(lines); j++ {
+		if strings.TrimSpace(lines[j]) == "" {
+			continue
+		}
+		if !isIndented(lines[j]) {
+			break
+		}
+		end = j
+	}
+
+	block := lines[i : end+1]
+	indent := -1
+	for _, line := range block {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		width := len(line) - len(strings.TrimLeft(line, " "))
+		if indent == -1 || width < indent {
+			indent = width
+		}
+	}
+
+	dedented := make([]string, 0, len(block))
+	for _, line := range block {
+		if len(line) < indent {
+			dedented = append(dedented, "")
+			continue
+		}
+		dedented = append(dedented, strings.TrimRight(line[indent:], " "))
+	}
+	return dedented, end + 1
+}
+
+// fence wraps block in a code fence long enough to survive any backticks the
+// block itself contains.
+func fence(block []string) []string {
+	longest := 0
+	for _, line := range block {
+		run := 0
+		for _, r := range line {
+			if r == '`' {
+				run++
+				longest = max(longest, run)
+			} else {
+				run = 0
+			}
+		}
+	}
+
+	delim := strings.Repeat("`", max(3, longest+1))
+	fenced := make([]string, 0, len(block)+2)
+	fenced = append(fenced, delim)
+	fenced = append(fenced, block...)
+	return append(fenced, delim)
+}
+
+// sentenceCase lowers an ALL-CAPS heading to sentence case, leaving acronyms
+// alone: "NESTED JSON SYNTAX" becomes "Nested JSON syntax".
+func sentenceCase(heading string) string {
+	words := strings.Split(heading, " ")
+	for i, word := range words {
+		parts := strings.Split(word, "-")
+		for j, part := range parts {
+			if !acronyms[part] {
+				parts[j] = strings.ToLower(part)
+			}
+		}
+		words[i] = strings.Join(parts, "-")
+	}
+
+	out := strings.Join(words, " ")
+	return strings.ToUpper(out[:1]) + out[1:]
+}

--- a/tools/gendocs/detail_test.go
+++ b/tools/gendocs/detail_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, Unikraft GmbH and The Unikraft CLI Authors.
+// Licensed under the BSD-3-Clause License (the "License").
+// You may not use this file except in compliance with the License.
+
+package main
+
+import "testing"
+
+func TestFormatDetail(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "prose is left alone",
+			in:   "The API command makes direct HTTP requests.\nIt is useful for scripting.",
+			want: "The API command makes direct HTTP requests.\nIt is useful for scripting.",
+		},
+		{
+			name: "all-caps heading becomes a section",
+			in:   "Intro.\n\nREQUEST BODY SYNTAX\n\nMore prose.",
+			want: "Intro.\n\n## Request body syntax\n\nMore prose.",
+		},
+		{
+			name: "acronyms keep their case",
+			in:   "NESTED JSON SYNTAX\n\nBody.",
+			want: "## Nested JSON syntax\n\nBody.",
+		},
+		{
+			name: "hyphenated heading",
+			in:   "TOP-LEVEL ARRAY SYNTAX\n\nBody.",
+			want: "## Top-level array syntax\n\nBody.",
+		},
+		{
+			name: "all-caps line inside a paragraph is not a heading",
+			in:   "Set the value to\nALWAYS or NEVER.",
+			want: "Set the value to\nALWAYS or NEVER.",
+		},
+		{
+			name: "indented block becomes a fence and is dedented",
+			in:   "Args:\n\n  @file        Read from disk.\n  @-           Read from stdin.",
+			want: "Args:\n\n```\n@file        Read from disk.\n@-           Read from stdin.\n```",
+		},
+		{
+			name: "blank lines inside an indented run stay in one fence",
+			in:   "  key[]=value\n      Appends a value.\n\n  key[N]=value\n      Assigns at an index.",
+			want: "```\nkey[]=value\n    Appends a value.\n\nkey[N]=value\n    Assigns at an index.\n```",
+		},
+		{
+			name: "backslashes survive fencing",
+			in:   "  key\\[sub\\]=value    Literal bracket.\n  key[\\\\]=value       Literal backslash.",
+			want: "```\nkey\\[sub\\]=value    Literal bracket.\nkey[\\\\]=value       Literal backslash.\n```",
+		},
+		{
+			name: "fence grows past embedded backticks",
+			in:   "  use ``` to fence",
+			want: "````\nuse ``` to fence\n````",
+		},
+		{
+			name: "trailing whitespace is trimmed",
+			in:   "  padded   \n",
+			want: "```\npadded\n```",
+		},
+		{
+			name: "crlf input",
+			in:   "HEADING\r\n\r\n  block\r\n",
+			want: "## Heading\n\n```\nblock\n```",
+		},
+		{
+			name: "prose resumes after an indented block",
+			in:   "Before.\n\n  block\n\nAfter.",
+			want: "Before.\n\n```\nblock\n```\n\nAfter.",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := formatDetail(test.in, 2); got != test.want {
+				t.Errorf("formatDetail()\n got: %q\nwant: %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestSentenceCase(t *testing.T) {
+	for in, want := range map[string]string{
+		"ESCAPING":            "Escaping",
+		"REQUEST BODY SYNTAX": "Request body syntax",
+		"RAW JSON VALUES":     "Raw JSON values",
+		"TOP-LEVEL ARRAY":     "Top-level array",
+		"HTTP API":            "HTTP API",
+	} {
+		if got := sentenceCase(in); got != want {
+			t.Errorf("sentenceCase(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFormatDetailHeadingLevel(t *testing.T) {
+	// md2man renders both "#" and "##" as .SH, so man generation asks for
+	// "###" to get a .SS subsection of DESCRIPTION.
+	if got, want := formatDetail("ESCAPING\n\nBody.", 3), "### Escaping\n\nBody."; got != want {
+		t.Errorf("formatDetail(level 3) = %q, want %q", got, want)
+	}
+}

--- a/tools/gendocs/man.go
+++ b/tools/gendocs/man.go
@@ -209,7 +209,7 @@ func genManContent(node *kong.Node, header *ManHeader) ([]byte, error) {
 	buf.WriteString("# SYNOPSIS\n")
 	fmt.Fprintf(buf, "`%s`\n\n", ansi.Strip(kingkong.Summary(node)))
 	buf.WriteString("# DESCRIPTION\n")
-	buf.WriteString(description + "\n\n")
+	buf.WriteString(formatDetail(description, 3) + "\n\n")
 
 	manPrintExamples(buf, node)
 

--- a/tools/gendocs/mdx.go
+++ b/tools/gendocs/mdx.go
@@ -83,18 +83,16 @@ func generateMarkdown(ctx context.Context, node *kong.Node, dir string) error {
 	buf.Write(frontmatterBytes)
 	buf.WriteString("---\n\n")
 
-	if node.Parent == nil {
-		if help != "" {
-			buf.WriteString(escapeMdx(help) + "\n\n")
-		}
-	} else if node.Detail != "" {
-		buf.WriteString(escapeMdx(node.Detail) + "\n\n")
-	} else if help != "" {
-		buf.WriteString(escapeMdx(help) + "\n\n")
+	description := help
+	if node.Parent != nil && node.Detail != "" {
+		description = node.Detail
+	}
+	if description != "" {
+		buf.WriteString(escapeMdx(formatDetail(description, 2)) + "\n\n")
 	}
 
 	if IsRunnable(node) {
-		fmt.Fprintf(buf, "```\n%s\n```\n\n", ansi.Strip(kingkong.Summary(node)))
+		fmt.Fprintf(buf, "## Usage\n\n```\n%s\n```\n\n", ansi.Strip(kingkong.Summary(node)))
 	}
 
 	printDocsExamples(buf, node)


### PR DESCRIPTION
This adds some semantics to the terminal help text (such as standalone all-caps lines becoming headers, and indented text becoming code blocks)

Then this transformation will be applied when creating the mdx for the autogenerated CLI docs

Link to badly formatted page: https://unikraft.com/docs/cli/unikraft/api

Newly formatted page: https://com-docs-pr-303.ukp-stable.apw.unikraft.internal/docs/cli/unikraft/api