### PR TITLE
fix(cmd): Use the stdlib for the command timeout

### DIFF
--- a/cmd/unikraft/main.go
+++ b/cmd/unikraft/main.go
@@ -48,11 +48,6 @@ func main() {
 	)
 
 	ctx, err = run(ctx, args, stdio)
-	if err == nil {
-		// catch context cancellation errors, and make sure we show them, even if
-		// the command succeeded
-		err = ctx.Err()
-	}
 
 	// a command that ran on an instance and failed isn't an error of ours, so
 	// exit with the status it exited with and print nothing over its output
@@ -210,6 +205,16 @@ func run(ctx context.Context, args []string, stdio config.Stdio) (context.Contex
 	}
 
 	err = cli.RunNode(node, &opts.ConfigPath)
+
+	// Report why the context ended, rather than whatever the cancellation
+	// surfaced as: golang.org/x/net/http2 discards the cause. Must precede
+	// cleanup, which cancels the context.
+	if cause := context.Cause(ctx); cause != nil && (err == nil ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded)) {
+		err = cause
+	}
+
 	if cleanup != nil {
 		err = errors.Join(err, cleanup())
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -15,7 +15,6 @@ import (
 	"runtime"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/alecthomas/kong"
@@ -385,73 +384,18 @@ var PartitionedResources = []resource.Resource{
 	Certificate{},
 }
 
-type timedOutContext struct {
-	context.Context // parent
-	done            chan struct{}
-	mu              sync.Mutex
-	ctxErr          error
-	deadline        time.Time
+// timedOutError is the cancellation cause set when --timeout elapses. It
+// unwraps to context.DeadlineExceeded so callers can still test for a deadline.
+type timedOutError struct {
+	timeout time.Duration
 }
 
-func (c *timedOutContext) Done() <-chan struct{} { return c.done }
+func (e timedOutError) Error() string { return "timed out after " + e.timeout.String() }
 
-func (c *timedOutContext) Err() error {
-	select {
-	case <-c.done:
-	default:
-		return nil
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.ctxErr
-}
+func (timedOutError) Unwrap() error { return context.DeadlineExceeded }
 
-func (c *timedOutContext) Deadline() (time.Time, bool) {
-	return c.deadline, true
-}
-
-func newTimedOutContext(parent context.Context, timeout time.Duration) (context.Context, func()) {
-	c := &timedOutContext{
-		Context:  parent,
-		done:     make(chan struct{}),
-		deadline: time.Now().Add(timeout),
-	}
-
-	stopCh := make(chan struct{}, 1)
-
-	var (
-		once     sync.Once
-		stopOnce sync.Once
-	)
-
-	closeWithErr := func(err error) {
-		once.Do(func() {
-			c.mu.Lock()
-			c.ctxErr = err
-			c.mu.Unlock()
-			close(c.done)
-		})
-	}
-
-	timer := time.NewTimer(timeout)
-	go func() {
-		defer timer.Stop()
-		select {
-		case <-timer.C:
-			closeWithErr(fmt.Errorf("timed out"))
-		case <-parent.Done():
-			closeWithErr(parent.Err())
-		case <-stopCh:
-			// cleanup canceled
-		}
-	}()
-
-	stopFn := func() {
-		once.Do(func() {})
-		stopOnce.Do(func() { stopCh <- struct{}{} }) // signal goroutine to exit
-	}
-
-	return c, stopFn
+func newTimedOutContext(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeoutCause(parent, timeout, timedOutError{timeout: timeout})
 }
 
 type staticKey string


### PR DESCRIPTION
Drops the hand-rolled timeout context in favour of `context.WithTimeoutCause`. Behaviour is unchanged apart from the message, which now names the deadline that fired — `timed out after 30s` rather than `Get "https://…": timed out` — since a global `--timeout` bounds the whole command, not one request.

This came out of looking at TOOL-1426, which I could not reproduce: `--timeout` *is* enforced on a hung plugin route, over HTTP/1 and HTTP/2, on a connection held open and on a body that stalls mid-response. What I found instead was that `Err()` returned a bare `timed out`, so `errors.Is(err, context.DeadlineExceeded)` was false everywhere, and the returned cancel never cancelled anything — which was quietly load-bearing, since making it real turns `ctx.Err()` into a non-nil error on every successful run that set `--timeout`.

Relates to https://linear.app/unikraft/issue/TOOL-1426/unikraft-api-timeout-not-enforced-on-hung-plugin-route-requests.